### PR TITLE
Provide a generic rake task (deploy:build) to make changes before slug compilation.

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -50,6 +50,7 @@ class LanguagePack::Ruby < LanguagePack::Base
       build_bundler
       create_database_yml
       install_binaries
+      run_deploy_build_rake_task
       run_assets_precompile_rake_task
     end
   end
@@ -429,6 +430,13 @@ params = CGI.parse(uri.query || "")
     if rake_task_defined?("assets:precompile")
       topic "Running: rake assets:precompile"
       pipe("env PATH=$PATH:bin bundle exec rake assets:precompile 2>&1")
+    end
+  end
+
+  def run_deploy_build_rake_task
+    if rake_task_defined?("deploy:build")
+      topic "Running: rake deploy:build"
+      pipe("env PATH=$PATH:bin bundle exec rake deploy:build 2>&1")
     end
   end
 end


### PR DESCRIPTION
I've had a need for hooking into the slug compilation process before the slug is actually compiled to generate data. Before the automatic running of `rake assets:precompile` was added,  there was not an easy way to do this. 

Rather than using non-asset related code in the `assets:precompile` task I think it makes sense to have a generic `deploy:build` task that people can use as a hook for doing whatever it is they need to do before compilation.

Thoughts?
