### PR TITLE
Reduce slug size

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -335,6 +335,9 @@ ERROR
         run "bundle clean"
         cache_store ".bundle"
         cache_store "vendor/bundle"
+
+        # Keep gem cache out of the slug
+        FileUtils.rm_rf("vendor/bundle/ruby/1.9.1/cache")
       else
         log "bundle", :status => "failure"
         error_message = "Failed to install gems via Bundler."


### PR DESCRIPTION
- Keep the gem cache (including Bundler's git cache) out of the slug.
- Keep Rubinius .rbc files out of the slug unless ruby_version_rbx? is true.

This may not be ready to merge, but it doesn't hurt to open a pull request so this can be looked at and discussed by people who know more about it than I do. :grin:

I've been using this for a little over a month now with no side-effects other than a dramatically reduced slug size. The cache seems to still exist on redeploys (as far as I can tell), it just doesn't get included in the compiled slug.

On my current Diaspora deploy (with a few extra git dependencies and at least one gem that, for some reason, includes .rbc files) I can't use the default buildpack because my slug size would be 102.2MB. With this patch it's 87.0MB.
