### PR TITLE
Add possibility to set connection_pool size

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -365,6 +365,7 @@ password = uri.password
 
 host = uri.host
 port = uri.port
+pool = ENV["DB_POOL"] || 5
 
 params = CGI.parse(uri.query || "")
 
@@ -377,6 +378,7 @@ params = CGI.parse(uri.query || "")
   <%= attribute "password", password, true %>
   <%= attribute "host",     host %>
   <%= attribute "port",     port %>
+  <%= attribute "pool",     pool %>
 
 <% params.each do |key, value| %>
   <%= key %>: <%= value.first %>


### PR DESCRIPTION
I added the possibility to set the connection pool size in database.yml using an environment variable "DB_POOL".
When not set, the default (5) is written to the file instead.
