### PR TITLE
Improves detection of whether a Rake task is defined or not

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -538,7 +538,13 @@ params = CGI.parse(uri.query || "")
   # @param [String] the task in question
   # @return [Boolean] true if the rake task is defined in the app
   def rake_task_defined?(task)
-    run("env PATH=$PATH bundle exec rake #{task} --dry-run") && $?.success?
+    task_check = "rake -p 'Rake.application.load_rakefile; Rake::Task.task_defined?(ARGV[0])' #{task}"
+    out = run("env PATH=$PATH bundle exec #{task_check}")
+    if $?.success?
+      out.strip == "true"
+    else
+      error(out)
+    end
   end
 
   # executes the block with GIT_DIR environment variable removed since it can mess with the current working directory git thinks it's in


### PR DESCRIPTION
We ran into this earlier today. A Rails 3 application with a `Rakefile` that isn't broken gives the following output during a push:

```
...
       Cleaning up the bundler cache.
-----> Writing config/database.yml to read from DATABASE_URL
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       Asset precompilation completed (14.48s)
-----> Rails plugin injection
       Injecting rails_log_stdout
...
```

However, a Rails 3 app with a `Rakefile` that raises an exception on load causes the asset precompilation to silently fail:

```
...
       Cleaning up the bundler cache.
-----> Writing config/database.yml to read from DATABASE_URL
-----> Rails plugin injection
       Injecting rails_log_stdout
...
```

I've patched the buildpack to check for defined Rake tasks in a different manner. If checking for a Rake task fails because of an exception, and not because the task is undefined, the push is aborted (I raised "Bad Rakefile" in this instance):

```

       Cleaning up the bundler cache.
-----> Writing config/database.yml to read from DATABASE_URL
 !
 !     rake aborted!
 !     Bad Rakefile
 !     
 !     (See full trace by running task with --trace)
 !
 !     Heroku push rejected, failed to compile Ruby/rails app
```
