### PR TITLE
Say something if the assets:precompile task is not defined

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -61,6 +61,8 @@ private
             puts "http://devcenter.heroku.com/articles/rails31_heroku_cedar#troubleshooting"
           end
         end
+      else
+        puts "No assets:precompile task, assuming that the asset pipeline is not in use"
       end
     end
   end


### PR DESCRIPTION
At the moment the buildpack just silently skips the asset pipeline if something goes wrong with `rake assets:precompile --dry-run` giving the user no indication of what happened.
