### PR TITLE
Respect the runtime asset compilation setting.

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -43,6 +43,9 @@ private
         if File.exists?("public/assets/manifest.yml")
           puts "Detected manifest.yml, assuming assets were compiled locally"
         else
+          FileUtils.mkdir_p('public')
+          cache_load "public/assets"
+
           ENV["RAILS_GROUPS"] ||= "assets"
           ENV["RAILS_ENV"]    ||= "production"
 
@@ -53,6 +56,19 @@ private
           if $?.success?
             log "assets_precompile", :status => "success"
             puts "Asset precompilation completed (#{"%.2f" % time}s)"
+
+            # If 'assets:clean_expired' task is available (provided by the turbo-sprockets-rails3 gem),
+            # then remove old assets and cache them for next time.
+            if rake_task_defined?('assets:clean_expired')
+              puts "Running: rake assets:clean_expired"
+              run("env PATH=$PATH:bin bundle exec rake assets:clean_expired 2>&1")
+
+              if $?.success?
+                cache_store "public/assets"
+              else
+                cache_clear "public/assets"
+              end
+            end
           else
             log "assets_precompile", :status => "failure"
 


### PR DESCRIPTION
If asset compilation fails, it is enabled by default without checking
the setting in the environment file. This checks the environment file
and abides by it's setting.
