### PR TITLE
Allow URI-encoded username, password, and database name in DATABASE_URL

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -468,10 +468,10 @@ environment = ENV["RAILS_ENV"] || ENV["RACK_ENV"]
 adapter = uri.scheme
 adapter = "postgresql" if adapter == "postgres"
 
-database = (uri.path || "").split("/")[1]
+database = URI.unescape((uri.path || "").split("/")[1])
 
-username = uri.user
-password = uri.password
+username = URI.unescape(uri.user)
+password = URI.unescape(uri.password)
 
 host = uri.host
 port = uri.port


### PR DESCRIPTION
Ran into a problem where my database password contained a double quote.  Changed the Ruby buildpack to allow URI encoding in the username, password, and database name portions of DATABASE_URL.
