### PR TITLE
Cache public/assets if rake assets:clean_expired is available

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -43,6 +43,9 @@ private
         if File.exists?("public/assets/manifest.yml")
           puts "Detected manifest.yml, assuming assets were compiled locally"
         else
+          FileUtils.mkdir_p('public')
+          cache_load "public/assets"
+
           ENV["RAILS_GROUPS"] ||= "assets"
           ENV["RAILS_ENV"]    ||= "production"
 
@@ -53,6 +56,23 @@ private
           if $?.success?
             log "assets_precompile", :status => "success"
             puts "Asset precompilation completed (#{"%.2f" % time}s)"
+
+            # If the 'turbo-sprockets-rails3' gem is available, run 'assets:clean_expired' and
+            # cache assets if task was successful.
+            if gem_is_bundled?('turbo-sprockets-rails3')
+              log("assets_clean_expired") do
+                run("env PATH=$PATH:bin bundle exec rake assets:clean_expired 2>&1")
+                if $?.success?
+                  log "assets_clean_expired", :status => "success"
+                  cache_store "public/assets"
+                else
+                  log "assets_clean_expired", :status => "failure"
+                  cache_clear "public/assets"
+                end
+              end
+            else
+              cache_clear "public/assets"
+            end
           else
             log "assets_precompile", :status => "failure"
             puts "Precompiling assets failed, enabling runtime asset compilation"


### PR DESCRIPTION
This pull request provides support for the [turbo-sprockets-rails3](https://github.com/ndbroadbent/turbo-sprockets-rails3) gem for Rails 3 apps. 

If a `assets:clean_expired` Rake task is available, it will remove expired assets and cache them for the next run.