### PR TITLE
Rails3.use?: use String#include? instead of =~

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -8,7 +8,7 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
   def self.use?
     super &&
       File.exists?("config/application.rb") &&
-      File.read("config/application.rb") =~ /Rails::Application/
+      File.read("config/application.rb").include?("Rails::Application")
   end
 
   def name


### PR DESCRIPTION
closes #53 

We can always rewrite `bin/detect` later.
