### PR TITLE
Print warning when rakefile appears to be broken

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -546,7 +546,13 @@ params = CGI.parse(uri.query || "")
   # @param [String] the task in question
   # @return [Boolean] true if the rake task is defined in the app
   def rake_task_defined?(task)
-    run("env PATH=$PATH bundle exec rake #{task} --dry-run") && $?.success?
+    output = run("env PATH=$PATH bundle exec rake #{task} --dry-run")
+    if output && $?.success?
+      return true
+    elsif !output.match(/Don't know how to build task '#{task}'/)
+      puts "WARNING: There appears to have been an issue loading your rake file, you might like to check it out"
+    end
+    false
   end
 
   # executes the block with GIT_DIR environment variable removed since it can mess with the current working directory git thinks it's in


### PR DESCRIPTION
Related to https://github.com/heroku/heroku-buildpack-ruby/pull/34, but a little simpler and naive.

It will print a warning if the dry-run fails, but the error doesn't incude the _Don't know how to build task '...'_ message. Otherwise the behavior is as you would expect.
