### PR TITLE
Update rails2.rb self.use? to better detect Rails 2 apps

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -8,7 +8,8 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
   # detects if this is a valid Rails 2 app
   # @return [Boolean] true if it's a Rails 2 app
   def self.use?
-    super && File.exist?("config/environment.rb")
+    super && File.exist?("config/environment.rb") && 
+      File.read("config/environment.rb") =~ /Rails::Initializer/
   end
 
   def name


### PR DESCRIPTION
I originally wanted to use `gem_is_bundled?`, however every time I pushed to my app using this custom buildpack I was getting a "no Cedar-supported app detected" message, so I stole the detection method from `rails3.rb`. Not being too familiar with Rails 2 I'm not sure if the `Rails::Initializer` is as reliable as I would like. 

Fixes heroku/heroku-buildpack-ruby#55
