### PR TITLE
Allow apps that don't use a DB

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -447,8 +447,10 @@ ERROR
 
   # writes ERB based database.yml for Rails. The database.yml uses the DATABASE_URL from the environment during runtime.
   def create_database_yml
+    return unless ENV['DATABASE_URL']
+    return unless File.directory?("config")
+
     log("create_database_yml") do
-      return unless File.directory?("config")
       topic("Writing config/database.yml to read from DATABASE_URL")
       File.open("config/database.yml", "w") do |file|
         file.puts <<-DATABASE_YML


### PR DESCRIPTION
The current build pack blows up in this case. If you are running a simple rack app without a database an error is raised. The error is raised by this code:

``` ruby
begin
  uri = URI.parse(ENV["DATABASE_URL"])
rescue URI::InvalidURIError
  raise "Invalid DATABASE_URL"
end
```

This commit introduces a simple guard.
