### PR TITLE
Finegrained detection for Rails2 apps. Close #55.

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -8,7 +8,9 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
   # detects if this is a valid Rails 2 app
   # @return [Boolean] true if it's a Rails 2 app
   def self.use?
-    super && File.exist?("config/environment.rb")
+    File.exists?("Gemfile") &&
+    File.exists?("config/environment.rb") &&
+    File.read("config/environment.rb") =~ /Rails::Initializer\.run/
   end
 
   def name

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -6,9 +6,10 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
   # detects if this is a Rails 3.x app
   # @return [Boolean] true if it's a Rails 3.x app
   def self.use?
-    super &&
-      File.exists?("config/application.rb") &&
-      File.read("config/application.rb") =~ /Rails::Application/
+    File.exists?("Gemfile") &&
+    File.exists?("config.ru") &&
+    File.exists?("config/application.rb") &&
+    File.read("config/application.rb") =~ /Rails::Application/
   end
 
   def name


### PR DESCRIPTION
This PR introduces fine grained rails2 and rails 3 detection. I found this problem by using a directory structure similar to rails for a non rails project. The problem was my app was considered rails 2 by the existence of `config/environment.rb`. This commit reads the content of the file to determine if it's actually a rails2 app. 

This introduced another problem. The Rails 3 pack inherits from Rails 2 and calls `super`. This made me duplicate logic from the superclass in the subclass to keep things in order.
