### PR TITLE
print warning when removing Gemfile.lock generated on windows

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -369,6 +369,10 @@ ERROR
       end
 
       if has_windows_gemfile_lock?
+        topic "WARNING: Removing `Gemfile.lock` because it was generated on Windows."
+        puts "Bundler will do a full resolve so native gems are handled properly."
+        puts "This may result in unexpected gem versions being used in your app."
+
         log("bundle", "has_windows_gemfile_lock")
         File.unlink("Gemfile.lock")
       else


### PR DESCRIPTION
Removing `Gemfile.lock` should print a warning. It can result in unexpected versions of gems being used in your deployed app.

I'd almost argue that this breaks the `Gemfile.lock` contract and deserves an error, but I think a warning is a good start. 

This is well documented [here](https://github.com/heroku/heroku-buildpack-ruby#bundler) but not readily apparent on deploy or looking at your logs.

Workflow case: Windows user on your team removes a gem only required in development, `Gemfile.lock` is regenerated with `PLATFORMS` as Windows. Github hides `Gemfile.lock` changes by default in the pull request and the changes get merged, thinking nothing of the change because it only involved development gems.

On deploy, Heroku removes and ignores the locked version of your gems, all of a sudden you're using [draper](https://github.com/drapergem/draper) v1.0 in production and your app is blowing up because of API changes from 0.18, which you were locked to originally.
