### PR TITLE
Explictly sets the prefix when building node

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ task "node:install", :version do |t, args|
         "rm -rf #{prefix}/bin"
       ].join(" && ")
 
-      sh "vulcan build -v -o #{name}.tgz --source node-v#{version} --command=\"#{build_command}\""
+      sh "vulcan build -v -o #{name}.tgz --source node-v#{version} --command=\"#{build_command}\" --prefix=\"#{prefix}\""
       s3_upload(tmpdir, name)
     end
   end


### PR DESCRIPTION
This prefix fix is needed to fix a problem with the node.js build. You'll get this error from vulcan if you try to build node.js with the current HEAD:

```
$ rake 'node:install[0.4.7]'

... [lots of build messages]

bin/vulcan-make:69:in `chdir': No such file or directory - /app/vendor/node-v0.4 (Errno::ENOENT)
  from bin/vulcan-make:69:in `block (2 levels) in <main>'
  from bin/vulcan-make:18:in `chdir'
  from bin/vulcan-make:18:in `block in <main>'
  from /usr/local/lib/ruby/1.9.1/tmpdir.rb:83:in `mktmpdir'
  from bin/vulcan-make:17:in `<main>'
```

I'm pretty sure this is caused by vulcan unintentionally chopping off the '.7' extension when it calls File#basename in cli.rb.
