### PR TITLE
shared-database:5mb -> heroku-postgresql:dev

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -73,8 +73,8 @@ private
 
   # most rails apps need a database
   # @return [Array] shared database addon
-  def add_shared_database_addon
-    ['shared-database:5mb']
+  def add_dev_database_addon
+    ['heroku-postgresql:dev']
   end
 
   # sets up the profile.d script for this buildpack

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -26,7 +26,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   end
 
   def default_addons
-    add_shared_database_addon
+    add_dev_database_addon
   end
 
   def default_config_vars
@@ -561,10 +561,10 @@ params = CGI.parse(uri.query || "")
     ENV["GIT_DIR"] = git_dir
   end
 
-  # decides if we need to enable the shared database addon
+  # decides if we need to enable the dev database addon
   # @return [Array] the database addon if the pg gem is detected or an empty Array if it isn't.
-  def add_shared_database_addon
-    gem_is_bundled?("pg") ? ['shared-database:5mb'] : []
+  def add_dev_database_addon
+    gem_is_bundled?("pg") ? ['heroku-postgresql:dev'] : []
   end
 
   # decides if we need to install the node.js binary


### PR DESCRIPTION
The shared databases are gone. Change to create `heroku-postgresql:dev` instead. Oddly enough the buildpack creates `heroku-postgresql:dev` databases as-is, so something must be correcting it in the background on the API side. Or maybe this just isn't used at all?
