### PR TITLE
Use SSH key from env if provided.

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -68,6 +68,7 @@ class LanguagePack::Ruby < LanguagePack::Base
 
   def compile
     Dir.chdir(build_path)
+    write_ssh_key
     remove_vendor_bundle
     install_ruby
     install_jvm
@@ -353,6 +354,21 @@ ERROR
     end
   end
 
+  def write_ssh_key
+    return unless key = ENV['SSH_KEY']
+    FileUtils.mkdir_p File.expand_path('~/.ssh')
+    File.open(File.expand_path('~/.ssh/id_rsa'), 'w') do |f|
+      f.write key
+    end
+    File.open(File.expand_path('~/.ssh/shim'), 'w') do |f|
+      f.write <<EOF
+#!/bin/sh
+exec /usr/bin/ssh -o StrictHostKeyChecking=no -i "$HOME/.ssh/id_rsa" "$@"
+EOF
+      f.chmod(0700)
+    end
+  end
+
   # remove `vendor/bundle` that comes from the git repo
   # in case there are native ext.
   # users should be using `bundle pack` instead.
@@ -372,6 +388,7 @@ ERROR
     log("bundle") do
       bundle_without = ENV["BUNDLE_WITHOUT"] || "development:test"
       bundle_command = "bundle install --without #{bundle_without} --path vendor/bundle --binstubs vendor/bundle/bin"
+      bundle_command = 'GIT_SSH="$HOME/.ssh/shim" ' + bundle_command if ENV['SSH_KEY']
 
       unless File.exist?("Gemfile.lock")
         error "Gemfile.lock is required. Please run \"bundle install\" locally\nand commit your Gemfile.lock."


### PR DESCRIPTION
I think this is a better way to handle private GitHub gem dependencies.

If a user adds an SSH_KEY env var (and assuming they're using [user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile)), this allows private gems to be cloned from GitHub, without going through hoops like [this](https://gist.github.com/masonforest/4048732).

Thoughts?

**Example**

```bash
heroku labs:enable user-env-compile -a foo-bar-1234
heroku config:set SSH_KEY="$(cat ~/.ssh/id_rsa)" -a foo-bar-1234
```

```ruby
source 'https://rubygems.org'

gem 'rake'
gem 'private-gem', git: 'git@github.com:ejholmes/private-gem.git'
```