### PR TITLE
Retry apps until we get a 200.

### DIFF
--- a/spec/rails23_spec.rb
+++ b/spec/rails23_spec.rb
@@ -5,7 +5,7 @@ describe "Rails 2.3.x" do
     Hatchet::AnvilApp.new("rails23_mri_187", :buildpack => buildpack).deploy do |app, heroku|
       add_database(app, heroku)
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body).to eq("hello")
+      expect(successful_body(app)).to eq("hello")
     end
   end
 end

--- a/spec/rails3_spec.rb
+++ b/spec/rails3_spec.rb
@@ -5,7 +5,7 @@ describe "Rails 3.x" do
     Hatchet::AnvilApp.new("rails3_mri_193", :buildpack => buildpack).deploy do |app, heroku|
       add_database(app, heroku)
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body).to eq("hello")
+      expect(successful_body(app)).to eq("hello")
     end
   end
 
@@ -15,7 +15,7 @@ describe "Rails 3.x" do
         add_database(app, heroku)
         expect(app).to be_deployed
         expect(output).to match("Ruby/Rails")
-        expect(Excon.get("http://#{app.name}.herokuapp.com").body).to eq("hello")
+        expect(successful_body(app)).to eq("hello")
       end
     end
   end

--- a/spec/rubies_spec.rb
+++ b/spec/rubies_spec.rb
@@ -4,36 +4,35 @@ describe "Ruby Versions" do
   it "should deploy ruby 1.8.7 properly" do
     Hatchet::AnvilApp.new("mri_187", :buildpack => buildpack).deploy do |app, heroku, output|
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body.chomp).to eq("ruby 1.8.7 (2012-10-12 patchlevel 371) [x86_64-linux]")
+      expect(successful_body(app).chomp).to eq("ruby 1.8.7 (2012-10-12 patchlevel 371) [x86_64-linux]")
     end
   end
 
   it "should deploy ruby 1.9.2 properly" do
     Hatchet::AnvilApp.new("mri_192", :buildpack => buildpack).deploy do |app, heroku, output|
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body.chomp).to eq("ruby 1.9.2p320 (2012-04-20 revision 35421) [x86_64-linux]")
+      expect(successful_body(app).chomp).to eq("ruby 1.9.2p320 (2012-04-20 revision 35421) [x86_64-linux]")
     end
   end
 
   it "should deploy ruby 1.9.2 properly (git)" do
     Hatchet::GitApp.new("mri_192", :buildpack => git_repo).deploy do |app, heroku, output|
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body.chomp).to eq("ruby 1.9.2p320 (2012-04-20 revision 35421) [x86_64-linux]")
+      expect(successful_body(app).chomp).to eq("ruby 1.9.2p320 (2012-04-20 revision 35421) [x86_64-linux]")
     end
   end
 
   it "should deploy ruby 1.9.3 properly" do
     Hatchet::AnvilApp.new("mri_193", :buildpack => buildpack).deploy do |app, heroku, output|
-      puts output
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body.chomp).to eq("ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-linux]")
+      expect(successful_body(app).chomp).to eq("ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-linux]")
     end
   end
 
   it "should deploy ruby 2.0.0 properly" do
     Hatchet::AnvilApp.new("mri_200", :buildpack => buildpack).deploy do |app, heroku|
       expect(app).to be_deployed
-      expect(Excon.get("http://#{app.name}.herokuapp.com").body.chomp).to eq("ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]")
+      expect(successful_body(app).chomp).to eq("ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,7 @@ def add_database(app, heroku)
   _, value = heroku.get_config_vars(app.name).body.detect {|key, value| key.match(/HEROKU_POSTGRESQL_[A-Z]+_URL/) }
   heroku.put_config_vars(app.name, 'DATABASE_URL' => value)
 end
+
+def successful_body(app)
+  Excon.get("http://#{app.name}.herokuapp.com", :idempotent => true, :expects => 200, :retry_limit => 10).body
+end


### PR DESCRIPTION
When deploying new apps there can be a slight delay between the "new app"
page going away and the actual app serving traffic.

This should make post-deploy app checks more reliable.
