### PR TITLE
Add asset precompilation caching between deploys to Rails 3 & 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ The buildpack will detect your apps as a Rails 3 app if it has an `application.r
 
 To enable static assets being served on the dyno, [rails3_serve_static_assets](http://github.com/pedro/rails3_serve_static_assets) is installed by default. If the [execjs gem](http://github.com/sstephenson/execjs) is detected then [node.js](http://github.com/joyent/node) will be vendored. The `assets:precompile` rake task will get run if no `public/manifest.yml` is detected.  See [this article](http://devcenter.heroku.com/articles/rails31_heroku_cedar) on how rails 3.1 works on cedar.
 
+#### Asset Compilation Cache
+
+To greatly speed up deploys when your assets are unchanged, the buildpack caches your precompiled assets between deploys. Usually this is a seamless process. If your cache becomes stale (for example, when a gem updates its assets), you can force the buildpack to recompile by adding a newline to any file in your app/assets directory.
+
 Hacking
 -------
 

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -162,7 +162,8 @@ private ##################################
   def cache_copy(from, to)
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
-    system("cp -a #{from}/. #{to}")
+    from = File.directory?(from) ? "#{from}/." : from
+    system("cp -a #{from} #{to}")
   end
 
   # check if the cache content exists

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -39,6 +39,9 @@ class LanguagePack::Rails4 < LanguagePack::Rails3
         topic("Preparing app for Rails asset pipeline")
         if Dir.glob('public/assets/manifest-*.json').any?
           puts "Detected manifest file, assuming assets were compiled locally"
+        elsif precompiled_assets_are_cached?
+          puts "Assets already compiled, loading from cache"
+          cache_load "public/assets"
         else
           ENV["RAILS_GROUPS"] ||= "assets"
           ENV["RAILS_ENV"]    ||= "production"
@@ -50,6 +53,7 @@ class LanguagePack::Rails4 < LanguagePack::Rails3
           if $?.success?
             log "assets_precompile", :status => "success"
             puts "Asset precompilation completed (#{"%.2f" % time}s)"
+            cache_uncompiled_assets
           else
             log "assets_precompile", :status => "failure"
             error "Precompiling assets failed."


### PR DESCRIPTION
We each know the pain of forgetting to check in one file at 3 am on a Tuesday night.  We deploy to staging so we can email the client a progress report, only to bring down the app because of one oversight. We quickly rollback, but now the fun begins: we `git push heroku master` once again, only to wait, and wait, and wait, while `rake assets:precompile` generates an identical asset manifest to the one just generated not 10 minutes ago.

What if we could reliably speed up some of our deploys by a factor of 10? If we deploy ten times a week, and save 3 minutes per deploy, we've added 2 hours a month of productivity. How would we go about this? By attacking the largest bottleneck to deploying Rails apps on Heroku: precompiling assets. 

Often our front-end code is unchanged, and we just want to tweak a rake task or fix a minor bug. This pull request side-steps the precompile task on such deploys by seamlessly loading in the precompiled assets from Heroku's cache directory.

We have been reliably using this technique on several production apps for [about 8 months now](https://github.com/nthj/heroku-buildpack-ruby/commit/889d9f98b229dd999567144a4ce9e63f09a0ae47), including at [Huckberry.com](http://huckberry.com/), with about a dozen deploys a week. I've dropped junior developers into apps with this buildpack and it has just worked, no explanation required. And it's saved me many hours, my clients a lot of money, and made my Heroku experience much more enjoyable overall.

The one caveat I have run into are bundled assets being updated without a corresponding change to Gemfile.lock, in which case the diff statement doesn't catch the changes, and continues to use the cached assets. This is easily avoided by running bundle or just changing any file in app/assets, lib/assets or vendor/assets.  

@pdsphil suggested I offer this as a pull request, and here we are.  I'm looking forward to hearing your feedback, how we can improve this, and the possibility of helping to improve the Heroku deployment process overall.

**Testing**

To test this pull request, please run this command on your Rails 3 or 4 Heroku app:

    heroku config:add BUILDPACK_URL=https://github.com/nthj/heroku-buildpack-ruby.git#precompile-optimizations