### PR TITLE
Raise error on sqlite3 gem inclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 before_script: bundle exec rake hatchet:setup_travis
 
 # Run tests in parallel
-script: bundle exec parallel_rspec -n 6 spec/
+script: bundle exec parallel_rspec -n 7 spec/
 
 after_script:
   - heroku keys:remove ~/.ssh/id_rsa

--- a/hatchet.json
+++ b/hatchet.json
@@ -1,7 +1,8 @@
 {
   "bundler": [
     "sharpstone/git_gemspec",
-    "sharpstone/no_lockfile"
+    "sharpstone/no_lockfile",
+    "sharpstone/sqlite3_gemfile"
   ],
   "ruby": [
     "sharpstone/mri_187"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -450,7 +450,7 @@ ERROR
 
 
 Detected sqlite3 gem which is not supported on Heroku.
-http://devcenter.heroku.com/articles/how-do-i-use-sqlite3-for-development
+https://devcenter.heroku.com/articles/sqlite3
 ERROR
         end
 

--- a/spec/gem_detect_errors_spec.rb
+++ b/spec/gem_detect_errors_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "Raise errors on specific gems" do
+  it "should should raise on sqlite3" do
+    Hatchet::AnvilApp.new("sqlite3_gemfile", allow_failure: true).deploy do |app|
+      expect(app).not_to be_deployed
+      expect(app.output).to include("Detected sqlite3 gem which is not supported")
+      expect(app.output).to include("devcenter.heroku.com/articles/sqlite3")
+    end
+  end
+end
+


### PR DESCRIPTION
When sqlite3 is included in the Gemfile heroku will attempt to install it which fails. This failure is due to a missing sqlite3 library on the dyno which was done intentionally. If we know the build will fail, we should take the opportunity to educate the developer exactly why they should not use sqlite3 on our platform. This is done by directing them to:

https://devcenter.heroku.com/articles/sqlite3

The full output they will see will look like this:

```
Checking for app files to sync... done, 0 files needed
Launching build process...  done
Preparing app for compilation... done
Fetching buildpack... done
Detecting buildpack... done, Ruby/Rack
Fetching cache... empty
Compiling app...
  Using Ruby version: ruby-1.9.3
 !
    ERROR: Cannot install sqlite3 gem on Heroku, remove or replace it with the 'pg' gem
    ERROR: for more information see: https://devcenter.heroku.com/articles/sqlite3
 !
```

cc @wycats

ATP: https://travis-ci.org/heroku/heroku-buildpack-ruby/builds/7479155
