### PR TITLE
Verify Rails 3 to 4 without ./bin works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ after_script:
 env:
   global:
   - HATCHET_RETRIES=3
+  - IS_RUNNING_ON_TRAVIS=true
   # sets the HEROKU_API_KEY to a dummy user for Heroku deploys
   - secure: |-
       ccqb7fKumq2+VEkSrkCqmLjALj5R/ZDgAQGZULSFYeD0O0man3hezUEbMB53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
     anvil-cli (0.16.0)
       progress (~> 2.4.0)
       rest-client (~> 1.6.7)
       thor (~> 0.15.2)
+    atomic (1.1.9)
     diff-lcs (1.1.3)
     excon (0.25.0)
     heroku-api (0.3.13)
       excon (~> 0.25.0)
-    heroku_hatchet (0.2.0)
+    heroku_hatchet (1.0.0)
       activesupport
       anvil-cli
       excon
       heroku-api
+      repl_runner
       rrrretry
       thor
-    i18n (0.6.1)
+    i18n (0.6.4)
     mime-types (1.23)
+    minitest (4.7.5)
     multi_json (1.7.7)
     parallel (0.6.5)
     parallel_tests (0.13.1)
       parallel
     progress (2.4.0)
     rake (10.0.4)
+    repl_runner (0.0.1)
+      activesupport
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rrrretry (0.0.1)
@@ -41,6 +49,9 @@ GEM
     rspec-retry (0.2.1)
       rspec
     thor (0.15.4)
+    thread_safe (0.1.0)
+      atomic
+    tzinfo (0.3.37)
 
 PLATFORMS
   ruby

--- a/hatchet.json
+++ b/hatchet.json
@@ -21,6 +21,7 @@
     "sharpstone/railties3_mri_193"
   ],
   "rails4": [
-    "sharpstone/rails4-manifest"
+    "sharpstone/rails4-manifest",
+    "sharpstone/rails3-to-4-no-bin"
   ]
 }

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -8,4 +8,13 @@ describe "Rails 4.x" do
     end
   end
 
+  it "upgraded from 3 to 4 missing ./bin still works" do
+    Hatchet::AnvilApp.new("rails3-to-4-no-bin").deploy do |app, heroku|
+      add_database(app, heroku)
+
+      app.run("rails console") do |console|
+        console.run("'hello' + 'world'") {|result| expect(result).to match('helloworld')}
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
   config.alias_example_to :fit, :focused => true
   config.full_backtrace = true
   config.verbose_retry = true # show retry status in spec process
-  config.default_retry_count = 2 # retry all tests that fail again
+  config.default_retry_count = 2 if ENV['IS_RUNNING_ON_TRAVIS'] # retry all tests that fail again
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
Looks like it is good to go. Using new major release of Hatchet that fixed all sorts of compatibility issues with running interactive consoles. Split all of that code into a separate lib: https://github.com/schneems/repl_runner

ATP, looks like code on master is good to go.
