### PR TITLE
Fix DATABASE_URL bug for jruby rails apps

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -71,7 +71,7 @@ private
     ENV["DATABASE_URL"] ||= begin
       # need to use a dummy DATABASE_URL here, so rails can load the environment
       scheme =
-        if gem_is_bundled?("pg")
+        if gem_is_bundled?("pg") || gem_is_bundled?("jdbc-postgres")
           "postgres"
         elsif gem_is_bundled?("mysql")
           "mysql"


### PR DESCRIPTION
Support dummy postgres DATABASE_URL for jruby

The "pg" gem is not included in a jruby app, so the dummy DATABASE_URL is invalid.
