### PR TITLE
[#118] make rake_task_defined? work in the face of extraneous output

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -637,7 +637,7 @@ params = CGI.parse(uri.query || "")
       task_check = "ruby -S rake -p 'Rake.application.load_rakefile; Rake::Task.task_defined?(ARGV[0])' #{task}"
       out = run("env PATH=$PATH:bin bundle exec #{task_check}")
       if $?.success?
-        out.strip == "true"
+        out.split($/).last.strip == "true"
       elsif ["No Rakefile found", "rake is not part of the bundle.", "no such file to load -- rake"].any? {|e| out.include?(e) }
         false
       else


### PR DESCRIPTION
Extraneous should only ever occur if people either have a Rakefile that produces output or are using the user-env-compile labs feature and their app produces output upon environment load.
