### PR TITLE
nokogiri should compile with system libs

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -2,7 +2,8 @@
   "bundler": [
     "sharpstone/git_gemspec",
     "sharpstone/no_lockfile",
-    "sharpstone/sqlite3_gemfile"
+    "sharpstone/sqlite3_gemfile",
+    "sharpstone/nokogiri_160"
   ],
   "ruby": [
     "sharpstone/mri_187"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -519,7 +519,7 @@ WARNING
           bundler_path   = "#{pwd}/#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}/lib"
           # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
           # codon since it uses bundler.
-          env_vars       = "env BUNDLE_GEMFILE=#{pwd}/Gemfile BUNDLE_CONFIG=#{pwd}/.bundle/config CPATH=#{yaml_include}:$CPATH CPPATH=#{yaml_include}:$CPPATH LIBRARY_PATH=#{yaml_lib}:$LIBRARY_PATH RUBYOPT=\"#{syck_hack}\""
+          env_vars       = "env BUNDLE_GEMFILE=#{pwd}/Gemfile BUNDLE_CONFIG=#{pwd}/.bundle/config CPATH=#{yaml_include}:$CPATH CPPATH=#{yaml_include}:$CPPATH LIBRARY_PATH=#{yaml_lib}:$LIBRARY_PATH RUBYOPT=\"#{syck_hack}\" NOKOGIRI_USE_SYSTEM_LIBRARIES=true"
           env_vars      += " BUNDLER_LIB_PATH=#{bundler_path}" if ruby_version && ruby_version.match(/^ruby-1\.8\.7/)
           puts "Running: #{bundle_command}"
           instrument "ruby.bundle_install" do
@@ -747,6 +747,8 @@ params = CGI.parse(uri.query || "")
         puts "Updating to rubygems #{rubygems_version}. Clearing bundler cache."
         purge_bundler_cache
       end
+
+      purge_bundler_cache if @metadata.exists?(buildpack_version_cache) && @metadata.read(buildpack_version_cache).sub('v', '').to_i <= 76
 
       FileUtils.mkdir_p(heroku_metadata)
       @metadata.write(ruby_version_cache, full_ruby_version, false)

--- a/spec/bugs_spec.rb
+++ b/spec/bugs_spec.rb
@@ -9,4 +9,11 @@ describe "Bugs" do
       end
     end
   end
+
+  it "nokogiri should use the system libxml2" do
+    Hatchet::Runner.new("nokogiri_160").deploy do |app|
+      expect(app.output).to match("Installing nokogiri")
+      expect(app.run("bundle exec nokogiri -v")).not_to include("ARNING: Nokogiri was built against LibXML version")
+    end
+  end
 end


### PR DESCRIPTION
As of nokogiri 1.6.0, they default to using the vendored libxml2 libs.
This is problematic for two reasons. First, with the way the heroku
build environment works,
https://github.com/sparklemotion/nokogiri/issues/923. This means it
won't link nokogiri.so properly since it's dependent on hardcoded paths
that don't exist during runtime. Second, compiling libxml2 and friends
is unnecessary since we have them already setup. We should skip this to
speed up deploys.
