### PR TITLE
Symlink ruby.exe to ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     atomic (1.1.10)
     diff-lcs (1.1.3)
     excon (0.25.3)
-    heroku-api (0.3.14)
+    heroku-api (0.3.15)
       excon (~> 0.25.1)
     heroku_hatchet (1.1.4)
       activesupport

--- a/hatchet.json
+++ b/hatchet.json
@@ -23,6 +23,7 @@
   ],
   "rails4": [
     "sharpstone/rails4-manifest",
-    "sharpstone/rails3-to-4-no-bin"
+    "sharpstone/rails3-to-4-no-bin",
+    "sharpstone/rails4_windows_mri193"
   ]
 }

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -306,10 +306,13 @@ ERROR_MSG
       end
       error invalid_ruby_version_message unless $?.success?
 
-      bin_dir = "bin"
-      FileUtils.mkdir_p bin_dir
-      Dir["#{slug_vendor_ruby}/bin/*"].each do |bin|
-        run("ln -s ../#{bin} #{bin_dir}")
+      app_bin_dir = "bin"
+      FileUtils.mkdir_p app_bin_dir
+
+      run("ln -s ruby #{slug_vendor_ruby}/bin/ruby.exe")
+
+      Dir["#{slug_vendor_ruby}/bin/*"].each do |vendor_bin|
+        run("ln -s ../#{vendor_bin} #{app_bin_dir}")
       end
 
       @metadata.write("buildpack_ruby_version", ruby_version)

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -18,4 +18,16 @@ describe "Rails 4.x" do
       end
     end
   end
+
+  it "works with windows" do
+      result = app.run("rails -v")
+      expect(result).to match("4.0.0")
+
+      result = app.run("rake -T")
+      expect(result).to match("assets:precompile")
+
+      result = app.run("bundle show rails")
+      expect(result).to match("rails-4.0.0")
+    end
+  end
 end


### PR DESCRIPTION
Rails 4 introduced the `bin/` directory to generated projects with executables `rails`, `bundle`, `rake`, etc. The file generated on windows has a link to an incorrect `ruby.exe` in the shebang line. See #134.

This PR adds a symlink so that `ruby.exe` can be called in addition to `ruby.
