### PR TITLE
add bundler binstubs to the .profile.d path

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -239,7 +239,7 @@ private
     instrument 'setup_profiled' do
       set_env_override "GEM_PATH", "$HOME/#{slug_vendor_base}:$GEM_PATH"
       set_env_default  "LANG",     "en_US.UTF-8"
-      set_env_override "PATH",     "$HOME/bin:$HOME/#{slug_vendor_base}/bin:$PATH"
+      set_env_override "PATH",     "$HOME/bin:$HOME/#{slug_vendor_base}/bin:$HOME/#{bundler_binstubs_path}:$PATH"
 
       if ruby_version_jruby?
         set_env_default "JAVA_OPTS", default_java_opts


### PR DESCRIPTION
We weren't adding the `--binstubs` to the runtime `.profile.d/ruby.sh`. This fixes that.
