### PR TITLE
store the rails 4 asset cache to improve asset pipeline performance

### DIFF
--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -2,6 +2,8 @@ require "pathname"
 
 # General Language Pack module
 module LanguagePack
+  module Helpers
+  end
 
   # detects which language pack to use
   # @param [Array] first argument is a String of the build directory
@@ -26,6 +28,7 @@ $:.unshift File.expand_path("../../vendor", __FILE__)
 require 'dotenv'
 require 'language_pack/instrument'
 require "language_pack/helpers/plugin_installer"
+require "language_pack/helpers/stale_file_cleaner"
 require "language_pack/ruby"
 require "language_pack/rack"
 require "language_pack/rails2"

--- a/lib/language_pack/helpers/stale_file_cleaner.rb
+++ b/lib/language_pack/helpers/stale_file_cleaner.rb
@@ -1,0 +1,34 @@
+class LanguagePack::Helpers::StaleFileCleaner
+  FILE_STAT_CACHE = Hash.new {|h, k| h[k] = File.stat(k) }
+
+  def initialize(dir)
+    @dir  = dir
+    raise "need or dir" if @dir.nil?
+  end
+
+  def clean_over(limit) # limit in bytes
+    old_files_over(limit).each {|asset| FileUtils.rm(asset) }
+  end
+
+  def glob
+    "#{@dir}/**/*"
+  end
+
+  def files
+    @files ||= Dir[glob].select {|file| !File.directory?(file) }
+  end
+
+  def sorted_files
+    @sorted ||= files.sort {|a, b| FILE_STAT_CACHE[a].mtime <=> FILE_STAT_CACHE[b].mtime }
+  end
+
+  def total_size
+    @size   ||= sorted_files.inject(0) {|sum, asset| sum += FILE_STAT_CACHE[asset].size }
+  end
+
+
+  def old_files_over(limit)
+    diff = total_size - limit
+    sorted_files.take_while {|asset| diff -= FILE_STAT_CACHE[asset].size if diff > 0 } || []
+  end
+end

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -3,7 +3,7 @@ require "language_pack/rails3"
 
 # Rails 4 Language Pack. This is for all Rails 4.x apps.
 class LanguagePack::Rails4 < LanguagePack::Rails3
-  ASSETS_CACHE_LIMIT = 52428800
+  ASSETS_CACHE_LIMIT = 52428800 # bytes
 
   # detects if this is a Rails 3.x app
   # @return [Boolean] true if it's a Rails 3.x app
@@ -109,12 +109,7 @@ WARNING
 
   def cleanup_assets_cache
     instrument "rails4.cleanup_assets_cache" do
-      file_stat     = Hash.new {|h, k| h[k] = File.stat(k) }
-      sorted_assets = Dir["#{default_assets_cache}/**/*"].select {|file| !File.directory?(file) }.sort {|a, b| file_stat[a].mtime <=> file_stat[b].mtime }
-      total_size    = sorted_assets.inject(0) {|sum, asset| sum + file_stat[asset].size }
-      diff          = total_size - ASSETS_CACHE_LIMIT
-
-      sorted_assets.take_while {|asset| diff -= file_stat[asset].size if diff > 0 }.each {|asset| FileUtils.rm(asset) }
+      LanguagePack::Helpers::StaleFileCleaner.new(default_assets_cache).clean_over(ASSETS_CACHE_LIMIT)
     end
   end
 end

--- a/spec/helpers/stale_file_cleaner_spec.rb
+++ b/spec/helpers/stale_file_cleaner_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+require 'language_pack'
+
+describe "Cleans Stale Files" do
+
+  it "removes files if they go over the limit" do
+    file_size = 1000
+    Dir.mktmpdir do |dir|
+      old_file = create_file_with_size_in(file_size, dir)
+      sleep 1 # need mtime of files to be different
+      new_file = create_file_with_size_in(file_size, dir)
+
+      expect(old_file.exist?).to be_true
+      expect(new_file.exist?).to be_true
+
+      ::LanguagePack::Helpers::StaleFileCleaner.new(dir).clean_over(2*file_size - 50)
+
+      expect(old_file.exist?).to be_false
+      expect(new_file.exist?).to be_true
+    end
+  end
+
+  it "leaves files if they are under the limit" do
+    file_size = 1000
+    Dir.mktmpdir do |dir|
+      old_file = create_file_with_size_in(file_size, dir)
+      sleep 1 # need mtime of files to be different
+      new_file = create_file_with_size_in(file_size, dir)
+
+      expect(old_file.exist?).to be_true
+      expect(new_file.exist?).to be_true
+      dir_size = File.stat(dir)
+
+      ::LanguagePack::Helpers::StaleFileCleaner.new(dir).clean_over(2*file_size + 50)
+
+      expect(old_file.exist?).to be_true
+      expect(new_file.exist?).to be_true
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,11 @@ require 'rspec/retry'
 ENV['RACK_ENV'] = 'test'
 
 RSpec.configure do |config|
-  config.filter_run :focused => true
+  config.filter_run focused: true unless ENV['IS_RUNNING_ON_TRAVIS']
   config.run_all_when_everything_filtered = true
-  config.alias_example_to :fit, :focused => true
-  config.full_backtrace = true
-  config.verbose_retry = true # show retry status in spec process
+  config.alias_example_to :fit, focused: true
+  config.full_backtrace      = true
+  config.verbose_retry       = true # show retry status in spec process
   config.default_retry_count = 2 if ENV['IS_RUNNING_ON_TRAVIS'] # retry all tests that fail again
 
   config.expect_with :rspec do |c|
@@ -35,4 +35,10 @@ end
 def successful_body(app, options = {})
   retry_limit = options[:retry_limit] || 50
   Excon.get("http://#{app.name}.herokuapp.com", :idempotent => true, :expects => 200, :retry_limit => retry_limit).body
+end
+
+def create_file_with_size_in(size, dir)
+  name = File.join(dir, SecureRandom.hex(16))
+  File.open(name, 'w') {|f| f.print([ 1 ].pack("C") * size) }
+  Pathname.new name
 end


### PR DESCRIPTION
Speed up the Rails 4 asset pipeline by caching the Rails `tmp/cache/assets` directory so sprockets can only compile the diff. There's also code to make sure the cache doesn't grow unbounded since sprockets/rails does not clean up after itself currently. We've limited the assets cache to 50mb.
