### PR TITLE
ensure s3 objects are coming out of Virginia

### DIFF
--- a/config/cdn.yml
+++ b/config/cdn.yml
@@ -1,2 +1,2 @@
 ---
-https://s3.amazonaws.com/heroku-buildpack-ruby: https://d3nlvu62nhllo4.cloudfront.net
+https://s3-external-1.amazonaws.com/heroku-buildpack-ruby: https://d3nlvu62nhllo4.cloudfront.net

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -14,7 +14,7 @@ Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
 class LanguagePack::Base
   include LanguagePack::ShellHelpers
 
-  VENDOR_URL = "https://s3.amazonaws.com/heroku-buildpack-ruby"
+  VENDOR_URL = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
 
   attr_reader :build_path, :cache
 


### PR DESCRIPTION
From @mfine:

S3 objects are sitting in the wrong side of the country, eventual
consistency be damned. There is no US East region in S3; there is
something called US Standard, and it runs out of Virginia AND Seattle
datacenters. It's a legacy artifact and a source of endless operational
pain within AWS. Objects are intended to be replicated across the
datacenters, but sometimes this doesn't work out, and objects get stuck
in one datacenter or the other. Since we run everything out of US East,
it's operationally prohibitive to get things stuck in Seattle. This is a
per object issue, not a per bucket issue - objects in the same bucket
can end up in either Virginia or Seattle.

This is really easy to do by accident - upload an object from your
laptop in San Francisco, and you get bound to the Seattle datacenter.
AWS provides endpoints that will bind objects either to Virginia or
Seattle in US Standard. Be safe and prefer using
s3-external-1.amazonaws.com.

You can read more about it here:
https://forums.aws.amazon.com/message.jspa?messageID=185820
