### PR TITLE
Increase curl timeout to two minutes

### DIFF
--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -28,8 +28,11 @@ module LanguagePack
 
     private
     def curl_command(command)
-      # TODO: Make max-time variable. Users have different requirements for this.
-      "set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 120 #{command}"
+      "set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time #{curl_timeout_in_seconds} #{command}"
+    end
+
+    def curl_timeout_in_seconds
+      ENV['CURL_TIMEOUT'] || 30
     end
 
     def load_config


### PR DESCRIPTION
In #165, a few users are getting time outs.

```
  Compiling Ruby
 !
    ERROR: Command: 'set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 20 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/ruby-1.9.3-jruby-1.7.3.tgz -s -o - | tar zxf -' failed unexpectedly:
    ERROR: 
    ERROR: gzip: stdin: invalid compressed data--format violated
    ERROR: tar: Unexpected EOF in archive
    ERROR: tar: Unexpected EOF in archive
    ERROR: tar: Error is not recoverable: exiting now
 !
```
