### PR TITLE
Use current node version for new applications.

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,8 +14,8 @@ class LanguagePack::Ruby < LanguagePack::Base
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
   BUNDLER_VERSION      = "1.3.2"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
-  NODE_VERSION         = "0.4.7"
-  NODE_JS_BINARY_PATH  = "node-#{NODE_VERSION}"
+  LEGACY_NODE_VERSION  = "0.4.7"
+  NODE_BASE_URL        = "http://heroku-buildpack-nodejs.s3.amazonaws.com"
   JVM_BASE_URL         = "http://heroku-jdk.s3.amazonaws.com"
   LATEST_JVM_VERSION   = "openjdk7-latest"
   LEGACY_JVM_VERSION   = "openjdk1.7.0_25"
@@ -64,8 +64,9 @@ class LanguagePack::Ruby < LanguagePack::Base
 
   def initialize(build_path, cache_path=nil)
     super(build_path, cache_path)
-    @fetchers[:jvm] = LanguagePack::Fetcher.new(JVM_BASE_URL)
-    @fetchers[:rbx] = LanguagePack::Fetcher.new(RBX_BASE_URL)
+    @fetchers[:jvm]  = LanguagePack::Fetcher.new(JVM_BASE_URL)
+    @fetchers[:rbx]  = LanguagePack::Fetcher.new(RBX_BASE_URL)
+    @fetchers[:node] = LanguagePack::Fetcher.new(NODE_BASE_URL)
   end
 
   def name
@@ -118,6 +119,7 @@ class LanguagePack::Ruby < LanguagePack::Base
         build_bundler
         create_database_yml
         install_binaries
+        install_node
         run_assets_precompile_rake_task
       end
       super
@@ -395,10 +397,48 @@ WARNING
     end
   end
 
+  # Installs node if execjs is found in the Gemfile. For new
+  # applications this will use the latest version of nodejs
+  # listed in the heroku-buildpack-nodejs's manifest file.
+  # Otherwise, it will use the LEGACY_NODE_VERSION ('0.4.7').
+  def install_node
+    return [] unless gem_is_bundled?('execjs')
+    return [] unless `which node`.empty?
+
+    instrument 'ruby.install_node' do
+      puts "No JS runtime detected, installing node version: #{node_version}"
+      @fetchers[:node].fetch_untar("node-#{node_version}.tgz")
+
+      FileUtils.cp "node-#{node_version}/bin/node","bin/node"
+      run("chmod +x bin/node")
+    end
+  end
+
+  def cache_node_version
+    @metadata.write("buildpack_node_version", latest_node_version)
+  end
+
+  def node_version
+    if new_app?
+      latest_node_version
+    elsif @metadata.exists?('buildpack_node_version')
+      @metadata.read('buildpack_node_version')
+    else
+      LEGACY_NODE_VERSION
+    end
+  end
+
+  def latest_node_version
+    @latest_node_version ||= begin
+                               @fetcher[:node].fetch('manifest.nodejs')
+                               File.read('manifest.nodejs').split("\n").first
+                             end
+  end
+
   # default set of binaries to install
   # @return [Array] resulting list
   def binaries
-    add_node_js_binary
+    []
   end
 
   # vendors binaries into the slug

--- a/spec/rails3_spec.rb
+++ b/spec/rails3_spec.rb
@@ -4,6 +4,7 @@ describe "Rails 3.x" do
   it "should deploy on ruby 1.9.3" do
     Hatchet::Runner.new("rails3_mri_193").deploy do |app, heroku|
       expect(app.output).to include("Asset precompilation completed")
+      expect(app.output).to include("No JS runtime detected, installing node version:")
       add_database(app, heroku)
 
       expect(app.output).to match("WARNINGS")

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -12,6 +12,7 @@ describe "Rails 4.x" do
   it "upgraded from 3 to 4 missing ./bin still works" do
     Hatchet::Runner.new("rails3-to-4-no-bin").deploy do |app, heroku|
       expect(app.output).to include("Asset precompilation completed")
+      expect(app.output).to include("No JS runtime detected, installing node version:")
       add_database(app, heroku)
 
       expect(app.output).to match("WARNINGS")


### PR DESCRIPTION
If `node` is already available (by using multi-buildpacks or otherwise 
manually vendoring a custom version) it will not install another node version.

Otherwise, it will lock the version of node for applications as follows:
- Existing Applications - `0.4.7`
- New Applications - Will be locked to the latest node version supported
  by the `heroku-buildpack-nodejs` (using the `nodejs.manifest`
  published by that project) at the time of first publishing.

Closes https://github.com/heroku/heroku-buildpack-ruby/issues/140.
