### PR TITLE
[fix #182] Show Warning In-line for Windows Gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Master
 
+Features:
+
+Bugfixes:
+
+* Windows warnings will now display before bundle install, this prevents an un-resolvable `Gemfile` from erroring which previously prevented the warning roll up from being shown. When this happened the developer did not see that we are clearing the `Gemfile.lock` from the git repository when bundled on a windows machine.
+
 
 ## v85 (12/05/2012)
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -482,10 +482,12 @@ WARNING
         end
 
         if has_windows_gemfile_lock?
-          warn(<<WARNING)
+          warn(<<WARNING, inline: true)
 Removing `Gemfile.lock` because it was generated on Windows.
 Bundler will do a full resolve so native gems are handled properly.
 This may result in unexpected gem versions being used in your app.
+In rare occasions Bundler may not be able to resolve your dependencies at all.
+https://devcenter.heroku.com/articles/bundler-windows-gemfile
 WARNING
 
           log("bundle", "has_windows_gemfile_lock")

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -67,7 +67,11 @@ module LanguagePack
       $stdout.flush
     end
 
-    def warn(message)
+    def warn(message, options = {})
+      if options.key?(:inline) ? options[:inline] : false
+        topic "Warning:"
+        puts message
+      end
       @warnings ||= []
       @warnings << message
     end

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -33,6 +33,9 @@ describe "Rails 4.x" do
 
       result = app.run("bundle show rails")
       expect(result).to match("rails-4.0.0")
+
+      before_warnings = app.output.split("WARNINGS:").first
+      expect(before_warnings).to match("Removing `Gemfile.lock`")
     end
   end
 


### PR DESCRIPTION
When deploying a Gemfile.lock that has been generated via windows, we must remove the file which can cause bundler to not be able to resolve.

When bundler does not resolve, the end user never sees the windows warning message due to the resolver never finishing (since warnings are saved until the end of the output).

This change allows warnings to be emitted inline and changes the default behavior of the windows warning to display before the `bundle install` is run, thus mitigating this problem.

Even when the `bundle install` fails the warnings are not displayed since the process `exits` rather than continues to print out the warnings. 

Here is a link to the devcenter article I wrote for this PR https://devcenter.heroku.com/articles/bundler-windows-gemfile
