### PR TITLE
In .ruby-version files, handle version names more like rvm/rbenv

### DIFF
--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -29,7 +29,7 @@ module LanguagePack
     def ruby_version_file
       rvs = File.read(DOT_RV_FILE).split("\n")
       rvs.map do |rv|
-        if rv.match(/^\d/)
+        if rv.match(/\A[\d.]+(-p[\d]+)?\Z/)
           "ruby-#{rv}"
         else
           rv


### PR DESCRIPTION
Both rbenv and rvm tools emit and change the .ruby-version file.  rvm
prefers to emit with the 'ruby-' prefix but allows input without it.
rbenv warns all the time about the optional prefix being there for MRI
implementations[0](https://github.com/sstephenson/rbenv/issues/380).

To avoid such rbenv warnings while understanding the same MRI version
requirement, expand the regular expression definition to handle the
patch level.
