### PR TITLE
If a manifest file was detected skip rake detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Features:
 Bugfixes:
 
 * Windows warnings will now display before bundle install, this prevents an un-resolvable `Gemfile` from erroring which previously prevented the warning roll up from being shown. When this happened the developer did not see that we are clearing the `Gemfile.lock` from the git repository when bundled on a windows machine.
-
+* Checks for `public/assets/manifest*.json` and `public/assets/manifest.yml` will now come before Rake task detection introduced in v85.
 
 ## v85 (12/05/2013)
 

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -60,14 +60,15 @@ private
       log("assets_precompile") do
         setup_database_url_env
 
-        precompile = rake.task("assets:precompile")
-        return true unless precompile.is_defined?
-
-        topic("Preparing app for Rails asset pipeline")
         if File.exists?("public/assets/manifest.yml")
           puts "Detected manifest.yml, assuming assets were compiled locally"
           return true
         end
+
+        precompile = rake.task("assets:precompile")
+        return true unless precompile.is_defined?
+
+        topic("Preparing app for Rails asset pipeline")
 
         ENV["RAILS_GROUPS"] ||= "assets"
         ENV["RAILS_ENV"]    ||= "production"

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -73,13 +73,13 @@ WARNING
       log("assets_precompile") do
         setup_database_url_env
 
-        precompile = rake.task("assets:precompile")
-        return true unless precompile.is_defined?
-
         if Dir.glob('public/assets/manifest-*.json').any?
           puts "Detected manifest file, assuming assets were compiled locally"
           return true
         end
+
+        precompile = rake.task("assets:precompile")
+        return true unless precompile.is_defined?
 
         topic("Preparing app for Rails asset pipeline")
         ENV["RAILS_GROUPS"] ||= "assets"


### PR DESCRIPTION
When a user is deploying with a manifest, we don't not need to load up their Rake to see if they have the `asset:precompile` task. Changing the order of the checks prevents users from seeing debugging information that is not needed and helps speed up apps by doing less work.
