### PR TITLE
Extract Default cache into Class

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -26,7 +26,8 @@
     "sharpstone/mri_187_nokogiri",
     "sharpstone/mri_192",
     "sharpstone/mri_193",
-    "sharpstone/mri_200"
+    "sharpstone/mri_200",
+    "sharpstone/mri_210"
   ],
   "rails2": [
     "sharpstone/rails23_mri_187"

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -33,6 +33,8 @@ require 'language_pack/instrument'
 require "language_pack/helpers/plugin_installer"
 require "language_pack/helpers/stale_file_cleaner"
 require "language_pack/helpers/rake_runner"
+require "language_pack/helpers/default_cache"
+
 require "language_pack/ruby"
 require "language_pack/rack"
 require "language_pack/rails2"

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -26,6 +26,11 @@ module LanguagePack
       run!("#{curl} - | tar jxf -")
     end
 
+    def exist?(path)
+      run("curl #{@host_url.join(path)} --head --silent --fail --retry 3")
+      $?.success?
+    end
+
     private
     def curl_command(command)
       "set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time #{curl_timeout_in_seconds} #{command}"

--- a/lib/language_pack/helpers/default_cache.rb
+++ b/lib/language_pack/helpers/default_cache.rb
@@ -1,0 +1,25 @@
+class LanguagePack::Helpers::DefaultCache
+  include LanguagePack::ShellHelpers
+
+  def initialize(version, cache_dir_missing, fetcher)
+    @version           = version
+    @cache_dir_missing = cache_dir_missing
+    @fetcher           = fetcher
+  end
+
+  def can_load?
+    @can_load ||= if @cache_dir_missing
+      @fetcher.exist?(path)
+    end
+  end
+
+  def load(msg = "Empty Cache detected, loading default bundler cache")
+    return false unless can_load?
+    puts msg
+    @fetcher.fetch_untar(path)
+  end
+
+  def path
+    "#{@version}-default-cache.tgz"
+  end
+end

--- a/spec/default_cache_spec.rb
+++ b/spec/default_cache_spec.rb
@@ -1,10 +1,15 @@
 require 'spec_helper'
 
 describe "Default Cache" do
-  it "gets loaded successfully" do
+  it "gets loaded successfully on default Ruby" do
     Hatchet::Runner.new("default_ruby").deploy do |app|
       expect(app.output).to match("loading default bundler cache")
     end
   end
-end
 
+  it "gets loaded correctly on Ruby 2.1.0" do
+    Hatchet::Runner.new("mri_210").deploy do |app|
+      expect(app.output).to match("loading default bundler cache")
+    end
+  end
+end

--- a/spec/helpers/default_cache_spec.rb
+++ b/spec/helpers/default_cache_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "DefaultCache" do
+
+  it "Works with 2.0.0p353" do
+    version = "2.0.0-p353"
+    fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
+    cache   = LanguagePack::Helpers::DefaultCache.new("ruby-#{version}",
+                                                            true,
+                                                            fetcher)
+    expect(cache.can_load?).to be_true
+  end
+
+  it "Works with 2.1.0" do
+    version = "2.1.0"
+    fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
+    cache   = LanguagePack::Helpers::DefaultCache.new("ruby-#{version}",
+                                                            true,
+                                                            fetcher)
+    expect(cache.can_load?).to be_true
+  end
+
+  it "Does not works with 1.8.7 raw" do
+    version = "1.8.7"
+    fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
+    cache   = LanguagePack::Helpers::DefaultCache.new("ruby-#{version}",
+                                                            true,
+                                                            fetcher)
+    expect(cache.can_load?).to be_false
+  end
+end
+


### PR DESCRIPTION
- Enable use for **any** Ruby version that has an available cache.

I also pushed a default cache for Ruby 2.1.0
