### PR TITLE
Use ruby-git gem via https instead of git protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :development, :test do
   gem "parallel_tests"
   gem 'rspec-retry'
   gem "netrc"
-  gem "git", github: "hone/ruby-git", branch: "master"
+  gem "git", git: "https://github.com/hone/ruby-git.git", branch: "master"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/hone/ruby-git.git
+  remote: https://github.com/hone/ruby-git.git
   revision: 264836fcff3c037d8d8fc44bd770b150b46fdc4e
   branch: master
   specs:


### PR DESCRIPTION
Most corporate firewalls block the git:// protocol. Use https:// instead
to allow the ruby-buildpack to be built in corporate firewalls.