### PR TITLE
Fix buildpack increment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -160,6 +160,8 @@ FILE
       git.commit "bump to #{new_version}"
 
       stashes.pop if stashes
+
+      puts "Bumped to #{new_version}"
     else
       puts "Already on #{new_version}"
     end


### PR DESCRIPTION
This fixes `git stash pop` errors when there are no commits to stage during `rake buildpack:increment`.
