### PR TITLE
Fix parallel bundler tests

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -31,23 +31,11 @@ class LanguagePack::Ruby < LanguagePack::Base
   end
 
   def self.bundler
-    @bundler ||= LanguagePack::Helpers::BundlerWrapper.new
+    @bundler ||= LanguagePack::Helpers::BundlerWrapper.new.install
   end
 
   def bundler
     self.class.bundler
-  end
-
-  def self.bundle
-    bundler.lockfile_parser
-  end
-
-  def bundle
-    self.class.bundle
-  end
-
-  def bundler_path
-    bundler.bundler_path
   end
 
   def initialize(build_path, cache_path=nil)
@@ -102,7 +90,7 @@ class LanguagePack::Ruby < LanguagePack::Base
       setup_language_pack_environment
       setup_profiled
       allow_git do
-        install_language_pack_gems
+        install_bundler_in_app
         build_bundler
         create_database_yml
         install_binaries
@@ -365,21 +353,12 @@ WARNING
     end
   end
 
-  # list of default gems to vendor into the slug
-  # @return [Array] resulting list of gems
-  def gems
-    [BUNDLER_GEM_PATH]
-  end
-
   # installs vendored gems into the slug
-  def install_language_pack_gems
+  def install_bundler_in_app
     instrument 'ruby.install_language_pack_gems' do
       FileUtils.mkdir_p(slug_vendor_base)
       Dir.chdir(slug_vendor_base) do |dir|
-        gems.each do |g|
-          @fetchers[:buildpack].fetch_untar("#{g}.tgz")
-        end
-        Dir["bin/*"].each {|path| run("chmod 755 #{path}") }
+        `cp -R #{bundler.bundler_path}/. .`
       end
     end
   end

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -2,14 +2,17 @@ require 'spec_helper'
 
 describe "BundlerWrapper" do
 
+  before(:each) do
+    @bundler = LanguagePack::Helpers::BundlerWrapper.new
+  end
+
   after(:each) do
-    FileUtils.remove_entry_secure("tmp") if Dir.exist?("tmp")
+    @bundler.clean
   end
 
   it "detects windows gemfiles" do
     Hatchet::App.new("rails4_windows_mri193").in_directory do |dir|
-      @bundler = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
-      expect(@bundler.windows_gemfile_lock?).to be_true
+      expect(@bundler.install.windows_gemfile_lock?).to be_true
     end
   end
 end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -2,17 +2,16 @@ require 'spec_helper'
 
 describe "RubyVersion" do
   before(:each) do
-    # bundler wrapper must be initialized relative to the target Gemfile
+    @bundler = LanguagePack::Helpers::BundlerWrapper.new
   end
 
   after(:each) do
-    FileUtils.remove_entry_secure("tmp") if Dir.exist?("tmp")
+    @bundler.clean
   end
 
   it "correctly sets ruby version for bundler specified versions" do
     Hatchet::App.new("mri_193").in_directory do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler, {is_new: true})
+      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install, is_new: true)
       version_number = "1.9.3"
       version        = "ruby-#{version_number}"
       expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -24,9 +23,7 @@ describe "RubyVersion" do
 
   it "correctly sets default ruby versions" do
     Hatchet::App.new("default_ruby").in_directory do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
-
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler, {is_new: true})
+      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install, is_new: true)
       version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
       version        = LanguagePack::RubyVersion::DEFAULT_VERSION
       expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -39,8 +36,7 @@ describe "RubyVersion" do
 
   it "correctly sets default legacy version" do
     Hatchet::App.new("default_ruby").in_directory do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler, {is_new: false})
+      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install, is_new: false)
       version_number = LanguagePack::RubyVersion::LEGACY_VERSION_NUMBER
       version        = LanguagePack::RubyVersion::LEGACY_VERSION
       expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -52,8 +48,7 @@ describe "RubyVersion" do
 
   it "detects Ruby 2.0.0" do
     Hatchet::App.new("mri_200").in_directory do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler, {is_new: true})
+      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install, is_new: true)
       version_number = "2.0.0"
       version        = "ruby-#{version_number}"
       expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -66,8 +61,7 @@ describe "RubyVersion" do
 
   it "detects non mri engines" do
     Hatchet::App.new("ruby_193_jruby_173").in_directory do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler, {is_new: true})
+      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install, is_new: true)
       version_number = "1.9.3"
       engine_version = "1.7.3"
       engine         = :jruby
@@ -84,7 +78,7 @@ describe "RubyVersion" do
     bundle_error_msg = "Zomg der was a problem in da gemfile"
     error_klass      = LanguagePack::Helpers::BundlerWrapper::GemfileParseError
     Hatchet::App.new("bad_gemfile_on_platform").in_directory do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: "./Gemfile")
+      @bundler       = LanguagePack::Helpers::BundlerWrapper.new()
       expect {LanguagePack::RubyVersion.new(@bundler)}.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
     end
   end


### PR DESCRIPTION
- Always use a tmpdir to download bundler.
- Remove un-used methods `Ruby.bundle` and `Ruby.bundler_path`.
- Re-name `install_language_pack_gems` to `install_bundler_in_app` since that's all it ever does
- Copy bundler into app path instead of re-downloading
