### PR TITLE
Enhanced error message on app deploys missing db

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -704,13 +704,12 @@ params = CGI.parse(uri.query || "")
 
   def precompile_fail(output)
     log "assets_precompile", :status => "failure"
+    msg = "Precompiling assets failed.\n"
     if output.match(/(127\.0\.0\.1)|(org\.postgresql\.util)/)
-      puts ""
-      puts "Attempted to access a non existant database:"
-      puts "https://devcenter.heroku.com/articles/pre-provision-database"
-      puts ""
+      msg << "Attempted to access a non existant database:\n"
+      msg << "https://devcenter.heroku.com/articles/pre-provision-database\n"
     end
-    error "Precompiling assets failed."
+    error msg
   end
 
   def bundler_cache


### PR DESCRIPTION
When deploying for the first time there is no database present. If a customer's application relies on a database connection for deploy it will fail. We can give instructions to mitigate this issue to users who encounter this error.
