### PR TITLE
Avoid "Running: rake assets:precompile" stutter in build pack output

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -692,7 +692,7 @@ params = CGI.parse(uri.query || "")
       precompile = rake.task("assets:precompile")
       return true unless precompile.is_defined?
 
-      topic "Running: rake assets:precompile"
+      topic "Precompiling assets"
       precompile.invoke(env: rake_env)
       if precompile.success?
         puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"


### PR DESCRIPTION
To fix this, use a distinct title intended to convey the purpose of
the step to humans, using the same jargon as the completion message
("asset precompile").

As seen in Rack applications, this banner would appear as follows:

-----> Running: rake assets:precompile
       Running: rake assets:precompile

Normally, the banner and the performed command are different, e.g.:

-----> Installing dependencies using 1.5.2
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
