### PR TITLE
compatibilty with the node.js buildpack for installing node

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -21,6 +21,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   LEGACY_JVM_VERSION   = "openjdk1.7.0_25"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
+  NODE_BP_PATH         = "vendor/node/bin"
 
   # detects if this is a valid Ruby app
   # @return [Boolean] true if it's a Ruby app
@@ -219,6 +220,7 @@ private
   def setup_language_pack_environment
     instrument 'ruby.setup_language_pack_environment' do
       setup_ruby_install_env
+      ENV["PATH"] += ":#{node_bp_bin_path}" if node_js_installed?
 
       # TODO when buildpack-env-args rolls out, we can get rid of
       # ||= and the manual setting below
@@ -683,7 +685,15 @@ params = CGI.parse(uri.query || "")
   # @note execjs will blow up if no JS RUNTIME is detected and is loaded.
   # @return [Array] the node.js binary path if we need it or an empty Array
   def add_node_js_binary
-    bundler.has_gem?('execjs') ? [NODE_JS_BINARY_PATH] : []
+    bundler.has_gem?('execjs') && !node_js_installed? ? [NODE_JS_BINARY_PATH] : []
+  end
+
+  def node_bp_bin_path
+    "#{Dir.pwd}/#{NODE_BP_PATH}"
+  end
+
+  def node_js_installed?
+    @node_js_installed ||= run("node -v", env: {"PATH" => "#{node_bp_bin_path}:#{ENV["PATH"]}" }) && $?.success?
   end
 
   def run_assets_precompile_rake_task


### PR DESCRIPTION
This adds special support for using `package.json` for installing a specific version of the node when using [multibuildpack](https://github.com/ddollar/heroku-buildpack-multi) and the [node.js buildpack](https://github.com/heroku/heroku-buildpack-nodejs). So you can now add the following to your `package.json`:

```
  "engines": {
          "node": "0.10.x"
  }
```

To use this, you'll need to set `BUILDPACK_URL` to the multibuildpack:

```
$ heroku config:add BUILDPACK_URL=git://github.com/ddollar/heroku-buildpack-multi.git
```

/cc @rjackson
