### PR TITLE
ruby_version is never falsy

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -255,7 +255,7 @@ private
 
       FileUtils.mkdir_p(slug_vendor_ruby)
 
-      if ruby_version.changed?
+      if ruby_version.changed? or not(cache.exist? slug_vendor_ruby)
         puts "Preparing binaries ..."
         fetch_ruby
         cache.store(slug_vendor_ruby)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -308,6 +308,7 @@ ERROR
       app_bin_dir = "bin"
       FileUtils.mkdir_p app_bin_dir
 
+      puts("ln -s ruby #{slug_vendor_ruby}/bin/ruby.exe")
       run("ln -s ruby #{slug_vendor_ruby}/bin/ruby.exe")
 
       Dir["#{slug_vendor_ruby}/bin/*"].each do |vendor_bin|

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -261,9 +261,8 @@ ERROR
       if ruby_version.build?
         FileUtils.mkdir_p(build_ruby_path)
         Dir.chdir(build_ruby_path) do
-          ruby_vm = "ruby"
           instrument "ruby.fetch_build_ruby" do
-            @fetchers[:buildpack].fetch_untar("#{ruby_version.version.sub(ruby_vm, "#{ruby_vm}-build")}.tgz")
+            @fetchers[:buildpack].fetch_untar("#{ruby_version.to_buildpack_version}.tgz")
           end
         end
         error invalid_ruby_version_message unless $?.success?

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -251,57 +251,13 @@ private
   # @return [Boolean] true if it installs the vendored ruby and false otherwise
   def install_ruby
     instrument 'ruby.install_ruby' do
-      invalid_ruby_version_message = <<ERROR
-Invalid RUBY_VERSION specified: #{ruby_version.version}
-Valid versions: #{ruby_versions.join(", ")}
-ERROR
       topic "Using Ruby version: #{ruby_version.version}"
-
 
       FileUtils.mkdir_p(slug_vendor_ruby)
 
       if ruby_version.changed?
         puts "Preparing binaries ..."
-
-        if ruby_version.build?
-          FileUtils.mkdir_p(build_ruby_path)
-          Dir.chdir(build_ruby_path) do
-            instrument "ruby.fetch_build_ruby" do
-              @fetchers[:buildpack].fetch_untar("#{ruby_version.to_buildpack_version}.tgz")
-            end
-          end
-          error invalid_ruby_version_message unless $?.success?
-        end
-
-        Dir.chdir(slug_vendor_ruby) do
-          instrument "ruby.fetch_ruby" do
-            if ruby_version.rbx?
-              file     = "#{ruby_version.version}.tar.bz2"
-              sha_file = "#{file}.sha1"
-              @fetchers[:rbx].fetch(file)
-              @fetchers[:rbx].fetch(sha_file)
-
-              expected_checksum = File.read(sha_file).chomp
-              actual_checksum   = Digest::SHA1.file(file).hexdigest
-
-              error <<-ERROR_MSG unless expected_checksum == actual_checksum
-  RBX Checksum for #{file} does not match.
-  Expected #{expected_checksum} but got #{actual_checksum}.
-  Please try pushing again in a few minutes.
-  ERROR_MSG
-
-              run("tar jxf #{file}")
-              FileUtils.mv(Dir.glob("app/#{slug_vendor_ruby}/*"), ".")
-              FileUtils.rm_rf("app")
-              FileUtils.rm(file)
-              FileUtils.rm(sha_file)
-            else
-              @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
-            end
-          end
-        end
-        error invalid_ruby_version_message unless $?.success?
-
+        fetch_ruby
         cache.store(slug_vendor_ruby)
       else
         puts "Using cached binaries ..."
@@ -321,7 +277,7 @@ ERROR
       @metadata.write("buildpack_ruby_version", ruby_version.version)
 
       if !ruby_version.set
-        warn(<<WARNING)
+        warn(<<-WARNING)
 You have not declared a Ruby version in your Gemfile.
 To set your Ruby version add this line to your Gemfile:
 #{ruby_version.to_gemfile}
@@ -331,6 +287,53 @@ WARNING
     end
 
     true
+  end
+
+  # fetches the ruby specified by ruby_version
+  def fetch_ruby
+    invalid_ruby_version_message = <<ERROR
+Invalid RUBY_VERSION specified: #{ruby_version.version}
+Valid versions: #{ruby_versions.join(", ")}
+ERROR
+
+    if ruby_version.build?
+      FileUtils.mkdir_p(build_ruby_path)
+      Dir.chdir(build_ruby_path) do
+        instrument "ruby.fetch_build_ruby" do
+          @fetchers[:buildpack].fetch_untar("#{ruby_version.to_buildpack_version}.tgz")
+        end
+      end
+      error invalid_ruby_version_message unless $?.success?
+    end
+
+    Dir.chdir(slug_vendor_ruby) do
+      instrument "ruby.fetch_ruby" do
+        if ruby_version.rbx?
+          file     = "#{ruby_version.version}.tar.bz2"
+          sha_file = "#{file}.sha1"
+          @fetchers[:rbx].fetch(file)
+          @fetchers[:rbx].fetch(sha_file)
+
+          expected_checksum = File.read(sha_file).chomp
+          actual_checksum   = Digest::SHA1.file(file).hexdigest
+
+          error <<-ERROR_MSG unless expected_checksum == actual_checksum
+RBX Checksum for #{file} does not match.
+Expected #{expected_checksum} but got #{actual_checksum}.
+Please try pushing again in a few minutes.
+ERROR_MSG
+
+          run("tar jxf #{file}")
+          FileUtils.mv(Dir.glob("app/#{slug_vendor_ruby}/*"), ".")
+          FileUtils.rm_rf("app")
+          FileUtils.rm(file)
+          FileUtils.rm(sha_file)
+        else
+          @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
+        end
+      end
+    end
+    error invalid_ruby_version_message unless $?.success?
   end
 
   def new_app?

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -251,7 +251,7 @@ private
   # @return [Boolean] true if it installs the vendored ruby and false otherwise
   def install_ruby
     instrument 'ruby.install_ruby' do
-      return false unless ruby_version
+      return false unless ruby_version.changed?
 
       invalid_ruby_version_message = <<ERROR
 Invalid RUBY_VERSION specified: #{ruby_version.version}

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -255,8 +255,11 @@ private
 Invalid RUBY_VERSION specified: #{ruby_version.version}
 Valid versions: #{ruby_versions.join(", ")}
 ERROR
+      topic "Using Ruby version: #{ruby_version.version}"
+
 
       if ruby_version.changed?
+        puts "Preparing binaries ..."
 
         if ruby_version.build?
           FileUtils.mkdir_p(build_ruby_path)
@@ -298,7 +301,7 @@ ERROR
         end
         error invalid_ruby_version_message unless $?.success?
       else
-        topic "Using Ruby version: #{ruby_version.version} (from cache)"
+        puts "Using cached binaries ..."
         return false
       end
 
@@ -313,7 +316,6 @@ ERROR
 
       @metadata.write("buildpack_ruby_version", ruby_version.version)
 
-      topic "Using Ruby version: #{ruby_version.version}"
       if !ruby_version.set
         warn(<<WARNING)
 You have not declared a Ruby version in your Gemfile.

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -251,52 +251,56 @@ private
   # @return [Boolean] true if it installs the vendored ruby and false otherwise
   def install_ruby
     instrument 'ruby.install_ruby' do
-      return false unless ruby_version.changed?
-
       invalid_ruby_version_message = <<ERROR
 Invalid RUBY_VERSION specified: #{ruby_version.version}
 Valid versions: #{ruby_versions.join(", ")}
 ERROR
 
-      if ruby_version.build?
-        FileUtils.mkdir_p(build_ruby_path)
-        Dir.chdir(build_ruby_path) do
-          instrument "ruby.fetch_build_ruby" do
-            @fetchers[:buildpack].fetch_untar("#{ruby_version.to_buildpack_version}.tgz")
+      if ruby_version.changed?
+
+        if ruby_version.build?
+          FileUtils.mkdir_p(build_ruby_path)
+          Dir.chdir(build_ruby_path) do
+            instrument "ruby.fetch_build_ruby" do
+              @fetchers[:buildpack].fetch_untar("#{ruby_version.to_buildpack_version}.tgz")
+            end
+          end
+          error invalid_ruby_version_message unless $?.success?
+        end
+
+        FileUtils.mkdir_p(slug_vendor_ruby)
+        Dir.chdir(slug_vendor_ruby) do
+          instrument "ruby.fetch_ruby" do
+            if ruby_version.rbx?
+              file     = "#{ruby_version.version}.tar.bz2"
+              sha_file = "#{file}.sha1"
+              @fetchers[:rbx].fetch(file)
+              @fetchers[:rbx].fetch(sha_file)
+
+              expected_checksum = File.read(sha_file).chomp
+              actual_checksum   = Digest::SHA1.file(file).hexdigest
+
+              error <<-ERROR_MSG unless expected_checksum == actual_checksum
+  RBX Checksum for #{file} does not match.
+  Expected #{expected_checksum} but got #{actual_checksum}.
+  Please try pushing again in a few minutes.
+  ERROR_MSG
+
+              run("tar jxf #{file}")
+              FileUtils.mv(Dir.glob("app/#{slug_vendor_ruby}/*"), ".")
+              FileUtils.rm_rf("app")
+              FileUtils.rm(file)
+              FileUtils.rm(sha_file)
+            else
+              @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
+            end
           end
         end
         error invalid_ruby_version_message unless $?.success?
+      else
+        topic "Using Ruby version: #{ruby_version.version} (from cache)"
+        return false
       end
-
-      FileUtils.mkdir_p(slug_vendor_ruby)
-      Dir.chdir(slug_vendor_ruby) do
-        instrument "ruby.fetch_ruby" do
-          if ruby_version.rbx?
-            file     = "#{ruby_version.version}.tar.bz2"
-            sha_file = "#{file}.sha1"
-            @fetchers[:rbx].fetch(file)
-            @fetchers[:rbx].fetch(sha_file)
-
-            expected_checksum = File.read(sha_file).chomp
-            actual_checksum   = Digest::SHA1.file(file).hexdigest
-
-            error <<-ERROR_MSG unless expected_checksum == actual_checksum
-RBX Checksum for #{file} does not match.
-Expected #{expected_checksum} but got #{actual_checksum}.
-Please try pushing again in a few minutes.
-ERROR_MSG
-
-            run("tar jxf #{file}")
-            FileUtils.mv(Dir.glob("app/#{slug_vendor_ruby}/*"), ".")
-            FileUtils.rm_rf("app")
-            FileUtils.rm(file)
-            FileUtils.rm(sha_file)
-          else
-            @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
-          end
-        end
-      end
-      error invalid_ruby_version_message unless $?.success?
 
       app_bin_dir = "bin"
       FileUtils.mkdir_p app_bin_dir

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -258,6 +258,8 @@ ERROR
       topic "Using Ruby version: #{ruby_version.version}"
 
 
+      FileUtils.mkdir_p(slug_vendor_ruby)
+
       if ruby_version.changed?
         puts "Preparing binaries ..."
 
@@ -271,7 +273,6 @@ ERROR
           error invalid_ruby_version_message unless $?.success?
         end
 
-        FileUtils.mkdir_p(slug_vendor_ruby)
         Dir.chdir(slug_vendor_ruby) do
           instrument "ruby.fetch_ruby" do
             if ruby_version.rbx?
@@ -300,9 +301,11 @@ ERROR
           end
         end
         error invalid_ruby_version_message unless $?.success?
+
+        cache.store(slug_vendor_ruby)
       else
         puts "Using cached binaries ..."
-        return false
+        cache.load(slug_vendor_ruby)
       end
 
       app_bin_dir = "bin"

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -63,6 +63,10 @@ module LanguagePack
       engine == :ruby && %w(1.8.7 1.9.2).include?(ruby_version)
     end
 
+    def changed?
+      version != @app[:last_version]
+    end
+
     # convert to a Gemfile ruby DSL incantation
     # @return [String] the string representation of the Gemfile ruby DSL
     def to_gemfile

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -77,7 +77,13 @@ module LanguagePack
       end
     end
 
+    def to_buildpack_version
+      version.sub(engine, "#{engine}-build")
+    end
+
+
     private
+
     def gemfile
       ruby_version = @bundler.ruby_version
       return "" unless ruby_version


### PR DESCRIPTION
I was wondering if there was some opportunity for a speedup by caching ruby installation, perusing the source code I found [these lines](https://github.com/heroku/heroku-buildpack-ruby/blob/cb9b6c85bc482fac5ff23f81a57cf80dc257e0fb/lib/language_pack/ruby.rb#L254):

```ruby
  def install_ruby
    instrument 'ruby.install_ruby' do
      return false unless ruby_version
```

and apparently there's no way ruby_version can be falsy ([is always an instance of `RubyVersion`](https://github.com/heroku/heroku-buildpack-ruby/blob/cb9b6c85bc482fac5ff23f81a57cf80dc257e0fb/lib/language_pack/ruby.rb#L177)), maybe it's a legacy of the extraction of `RubyVersion` (15df63760f18fd1197de06f75923dd295d2d3d85).

happy to be proved wrong :)