### PR TITLE
Allow to parametrize curl connect timeout with env variable

### DIFF
--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -28,11 +28,15 @@ module LanguagePack
 
     private
     def curl_command(command)
-      "set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time #{curl_timeout_in_seconds} #{command}"
+      "set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
     end
 
     def curl_timeout_in_seconds
       ENV['CURL_TIMEOUT'] || 30
+    end
+
+    def curl_connect_timeout_in_seconds
+      ENV['CURL_CONNECT_TIMEOUT'] || 3
     end
 
     def load_config


### PR DESCRIPTION
Useful when one is not curl'ing from EC2.
