### PR TITLE
Initialize environment before loading library code

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,12 +4,14 @@
 $stdout.sync = true
 
 $:.unshift File.expand_path("../../lib", __FILE__)
-require "language_pack"
+
 require "language_pack/shell_helpers"
+LanguagePack::ShellHelpers.initialize_env(ARGV[2])
+
+require "language_pack"
 
 LanguagePack::Instrument.trace 'compile', 'app.compile' do
   if pack = LanguagePack.detect(ARGV[0], ARGV[1])
-    LanguagePack::ShellHelpers.initialize_env(ARGV[2])
     pack.topic("Compiling #{pack.name}")
     pack.log("compile") do
       pack.compile

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -13,8 +13,9 @@ Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
 # abstract class that all the Ruby based Language Packs inherit from
 class LanguagePack::Base
   include LanguagePack::ShellHelpers
+  extend LanguagePack::ShellHelpers
 
-  VENDOR_URL = ENV['BUILDPACK_VENDOR_URL'] || "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
+  VENDOR_URL = env('BUILDPACK_VENDOR_URL') || "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
 
   attr_reader :build_path, :cache
 

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -1,4 +1,5 @@
 require "shellwords"
+require "pathname"
 
 class NoShellEscape < String
   def shellescape


### PR DESCRIPTION
When `lib/language_pack/base.rb` is evaluated, it tries to define the
`VENDOR_URL` constant by looking in the environment. However in the case where
`user-env-compile` is not enabled, the environment won't yet have been copied 
from the filesystem. So, require the `shell_helpers` and initialize the 
environment before loading the rest of the library code.