### PR TITLE
Force the bundler version to override possible newer versions

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -475,7 +475,7 @@ WARNING
       log("bundle") do
         bundle_without = env("BUNDLE_WITHOUT") || "development:test"
         bundle_bin     = "bundle"
-        bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
+        bundle_command = "#{bundle_bin} _#{BUNDLER_VERSION}_ install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
         bundle_command << " -j4"
 
         if bundler.windows_gemfile_lock?


### PR DESCRIPTION
If multiple versions of bundler are installed the latest version will be used regardless of the version specified in BUNDLER_VERSION. Bundler lets you use an older version by providing it as the first argument. (Surrounded by underscores)

```
bundle _1.5.2_ install
```

instead of

```
bundle install
```

This PR adds BUNDLER_VERSION as the first arg during the install step. I tested it on my heroku app where 1.6.1 and 1.5.2 both exist at the moment, and I needed to force the use of 1.5.2.
