### PR TITLE
fix node.js check on anvil

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -692,6 +692,8 @@ params = CGI.parse(uri.query || "")
     "#{Dir.pwd}/#{NODE_BP_PATH}"
   end
 
+  # checks if node.js is installed via the official heroku-buildpack-nodejs using multibuildpack
+  # @return [Boolean] true if it's detected and false if it isn't
   def node_js_installed?
     @node_js_installed ||= run("#{node_bp_bin_path}/node -v") && $?.success?
   end


### PR DESCRIPTION
Since the anvil service which Travis uses is built using node and
anvil leaks its path into the build enviroment, node is always on the
path, so `node_js_installed?` will always return true. This executes the
direct binary skipping the PATH completely.
