### PR TITLE
Fix Rails 4.1 apps with a database.yml file checked in

### DIFF
--- a/lib/language_pack/rails41.rb
+++ b/lib/language_pack/rails41.rb
@@ -17,6 +17,10 @@ class LanguagePack::Rails41 < LanguagePack::Rails4
 
   def create_database_yml
     instrument 'ruby.create_database_yml' do
+      if File.exist?("config/database.yml")
+        warn "You have your database.yml file checked into git.\nBest practice is to remove it from version control."
+        super
+      end
     end
   end
 

--- a/spec/rails41_spec.rb
+++ b/spec/rails41_spec.rb
@@ -10,11 +10,27 @@ describe "Rails 4.1.x" do
     end
   end
 
-  it "should be able to run a migration without heroku specific database.yml" do
-    Hatchet::Runner.new("rails41_scaffold").deploy do |app, heroku|
-      add_database(app, heroku)
-      expect(app.output).not_to include("Writing config/database.yml to read from DATABASE_URL")
-      expect(app.run("rake db:migrate")).to include("20140218165801 CreatePeople")
+  context "without a database.yml" do
+    it "should run the database migration correctly" do
+      Hatchet::Runner.new("rails41_scaffold").deploy do |app, heroku|
+        app.run("rm config/database.yml")
+        add_database(app, heroku)
+        expect(app.output).not_to include("Writing config/database.yml to read from DATABASE_URL")
+        expect(app.run("rake db:migrate")).to include("20140218165801 CreatePeople")
+      end
+    end
+  end
+
+  context "with a database.yml" do
+    it "should warn about removing the database.yml and write a new database.yml" do
+      Hatchet::Runner.new("rails41_scaffold").deploy do |app, heroku|
+        app.run("touch config/database.yml")
+        add_database(app, heroku)
+        expect(app.output).to include("You have your database.yml file checked into git.")
+        expect(app.output).to include("Best practice is to remove it from version control.")
+        expect(app.output).to include("Writing config/database.yml to read from DATABASE_URL")
+        expect(app.run("rake db:migrate")).to include("20140218165801 CreatePeople")
+      end
     end
   end
 


### PR DESCRIPTION
The new functionality for Rails 4.1 apps is to no longer write a `database.yml` file.

This works if `database.yml` is not checking into git,
but in the case that it is, apps can get strange failures.

This patch brings back the old functionality with a warning in the case that `database.yml` is present.

```
You have your database.yml file checked into git.
Best practice is to remove it from version control.
```
