### PR TITLE
allows setting RAILS/RACK env from environment variables.  re: #239

### DIFF
--- a/lib/language_pack/rack.rb
+++ b/lib/language_pack/rack.rb
@@ -19,7 +19,7 @@ class LanguagePack::Rack < LanguagePack::Ruby
   def default_config_vars
     instrument "rack.default_config_vars" do
       super.merge({
-        "RACK_ENV" => "production"
+        "RACK_ENV" => ENV["RACK_ENV"] || "production"
       })
     end
   end
@@ -42,7 +42,7 @@ private
   # sets up the profile.d script for this buildpack
   def setup_profiled
     super
-    set_env_default "RACK_ENV", "production"
+    set_env_default "RACK_ENV", ENV["RACK_ENV"] || "production"
   end
 
 end

--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -23,8 +23,8 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
   def default_config_vars
     instrument "rails2.default_config_vars" do
       super.merge({
-        "RAILS_ENV" => "production",
-        "RACK_ENV" => "production"
+        "RAILS_ENV" => ENV["RAILS_ENV"] || "production",
+        "RACK_ENV" => ENV["RACK_ENV"] || "production"
       })
     end
   end
@@ -69,8 +69,8 @@ private
   # sets up the profile.d script for this buildpack
   def setup_profiled
     super
-    set_env_default "RACK_ENV",  "production"
-    set_env_default "RAILS_ENV", "production"
+    set_env_default "RACK_ENV",  ENV["RACK_ENV"] || "production"
+    set_env_default "RAILS_ENV", ENV["RAILS_ENV"] || "production"
   end
 
 end

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -91,7 +91,7 @@ private
     else
       default_env = {
         "RAILS_GROUPS" => "assets",
-        "RAILS_ENV"    => "production",
+        "RAILS_ENV"    => ENV["RAILS_ENV"] || "production",
         "DATABASE_URL" => database_url
       }
     end


### PR DESCRIPTION
The buildpack essentially ignores the RAILS_ENV and RACK_ENV environment variable.   This is probably not the best way to solve this, but it allows for specifying the RAILS_ENV at build time, and run time. 

reference #239
