### PR TITLE
Raise error if rake file exists but cannot load

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -5,6 +5,7 @@
     "sharpstone/asset_precompile_not_found",
     "sharpstone/database_url_expected_in_rakefile",
     "sharpstone/connect_to_database_on_first_push",
+    "sharpstone/bad_rakefile_rails_4",
     "sharpstone/no_rakefile",
     "sharpstone/bad_rakefile",
     "sharpstone/mri_187_no_rake",

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -104,29 +104,6 @@ class LanguagePack::Base
     end
   end
 
-  # log output
-  # Ex. log "some_message", "here", :someattr="value"
-  def log(*args)
-    args.concat [:id => @id]
-    args.concat [:framework => self.class.to_s.split("::").last.downcase]
-
-    start = Time.now.to_f
-    log_internal args, :start => start
-
-    if block_given?
-      begin
-        ret = yield
-        finish = Time.now.to_f
-        log_internal args, :status => "complete", :finish => finish, :elapsed => (finish - start)
-        return ret
-      rescue StandardError => ex
-        finish = Time.now.to_f
-        log_internal args, :status => "error", :finish => finish, :elapsed => (finish - start), :message => ex.message
-        raise ex
-      end
-    end
-  end
-
 private ##################################
 
   # sets up the environment variables for the build process
@@ -146,22 +123,6 @@ private ##################################
 
   def set_env_override(key, val)
     add_to_profiled %{export #{key}="#{val.gsub('"','\"')}"}
-  end
-
-  def log_internal(*args)
-    message = build_log_message(args)
-    %x{ logger -p user.notice -t "slugc[$$]" "buildpack-ruby #{message}" }
-  end
-
-  def build_log_message(args)
-    args.map do |arg|
-      case arg
-        when Float then "%0.2f" % arg
-        when Array then build_log_message(arg)
-        when Hash  then arg.map { |k,v| "#{k}=#{build_log_message([v])}" }.join(" ")
-        else arg
-      end
-    end.join(" ")
   end
 end
 

--- a/lib/language_pack/helpers/rake_runner.rb
+++ b/lib/language_pack/helpers/rake_runner.rb
@@ -95,8 +95,8 @@ class LanguagePack::Helpers::RakeRunner
     msg << "cancel the build (CTRL+C) and fix the error then commit the fix:\n"
     msg << out
     if cannot_load_rakefile?
-      error(msg) if @error_if_cannot_load
       puts msg
+      error("Could not detect rake tasks") if @error_if_cannot_load
     end
     return self
   end

--- a/lib/language_pack/helpers/rake_runner.rb
+++ b/lib/language_pack/helpers/rake_runner.rb
@@ -57,10 +57,11 @@ class LanguagePack::Helpers::RakeRunner
     end
   end
 
-  def initialize(has_rake_gem = true)
-    @has_rake = has_rake_gem && has_rakefile?
+  def initialize(has_rake_gem = true, error_if_cannot_load = false)
+    @has_rake             = has_rake_gem && has_rakefile?
+    @error_if_cannot_load = error_if_cannot_load
     if !@has_rake
-      @rake_tasks    = ""
+      @rake_tasks        = ""
       @rakefile_can_load = false
     end
   end
@@ -93,9 +94,13 @@ class LanguagePack::Helpers::RakeRunner
     msg << "This may be intentional, if you expected rake tasks to be run\n"
     msg << "cancel the build (CTRL+C) and fix the error then commit the fix:\n"
     msg << out
-    puts msg if cannot_load_rakefile?
+    if cannot_load_rakefile?
+      error(msg) if @error_if_cannot_load
+      puts msg
+    end
     return self
   end
+
 
   def task_defined?(task)
     return false if cannot_load_rakefile?
@@ -121,6 +126,6 @@ class LanguagePack::Helpers::RakeRunner
 private
 
   def has_rakefile?
-    %W{ Rakefile rakefile  rakefile.rb Rakefile.rb}.detect {|file| File.exist?(file) }
+    %W{ Rakefile rakefile  rakefile.rb Rakefile.rb }.detect {|file| File.exist?(file) }
   end
 end

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -41,6 +41,10 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
 
 private
 
+  def error_if_rake_cannot_load
+    true
+  end
+
   def install_plugins
     instrument "rails3.install_plugins" do
       return false if bundler.has_gem?('rails_12factor')

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -650,7 +650,8 @@ params = CGI.parse(uri.query || "")
   def rake
     @rake ||= begin
       LanguagePack::Helpers::RakeRunner.new(
-                bundler.has_gem?("rake") || ruby_version.rake_is_vendored?
+                bundler.has_gem?("rake") || ruby_version.rake_is_vendored?,
+                error_if_rake_cannot_load
               ).load_rake_tasks!(env: rake_env)
     end
   end
@@ -712,6 +713,10 @@ params = CGI.parse(uri.query || "")
         precompile_fail(precompile.output)
       end
     end
+  end
+
+  def error_if_rake_cannot_load
+    false
   end
 
   def precompile_fail(output)

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -45,8 +45,31 @@ module LanguagePack
         Kernel.puts " !     #{line.strip}"
       end
       Kernel.puts " !"
-      log "exit", :error => message if respond_to?(:log)
+      log "exit", :error => message
       exit 1
+    end
+
+    # log output
+    # Ex. log "some_message", "here", :someattr="value"
+    def log(*args)
+      args.concat [:id => @id]
+      args.concat [:framework => self.class.to_s.split("::").last.downcase]
+
+      start = Time.now.to_f
+      log_internal args, :start => start
+
+      if block_given?
+        begin
+          ret = yield
+          finish = Time.now.to_f
+          log_internal args, :status => "complete", :finish => finish, :elapsed => (finish - start)
+          return ret
+        rescue StandardError => ex
+          finish = Time.now.to_f
+          log_internal args, :status => "error", :finish => finish, :elapsed => (finish - start), :message => ex.message
+          raise ex
+        end
+      end
     end
 
     def run!(command, options = {})
@@ -136,6 +159,23 @@ module LanguagePack
 
     def noshellescape(string)
       NoShellEscape.new(string)
+    end
+
+  private
+    def log_internal(*args)
+      message = build_log_message(args)
+      %x{ logger -p user.notice -t "slugc[$$]" "buildpack-ruby #{message}" }
+    end
+
+    def build_log_message(args)
+      args.map do |arg|
+        case arg
+          when Float then "%0.2f" % arg
+          when Array then build_log_message(arg)
+          when Hash  then arg.map { |k,v| "#{k}=#{build_log_message([v])}" }.join(" ")
+          else arg
+        end
+      end.join(" ")
     end
   end
 end

--- a/spec/default_cache_spec.rb
+++ b/spec/default_cache_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Default Cache" do
-  fit "gets loaded successfully" do
+  it "gets loaded successfully" do
     pending("needs dep-tracker work")
     Hatchet::Runner.new("default_ruby").deploy do |app|
       expect(app.output).to match("loading default bundler cache")

--- a/spec/helpers/rake_runner_spec.rb
+++ b/spec/helpers/rake_runner_spec.rb
@@ -50,7 +50,8 @@ describe "Rake Runner" do
 
   it "fails if cannot load Rails 4 rakefile" do
     Hatchet::Runner.new('bad_rakefile_rails_4', allow_failure: true).deploy do |app|
-      expect(app.output).to match("ERROR: Could not detect rake tasks")
+      expect(app.output).to match("Could not detect rake tasks")
+      expect(app.deployed?).to eq(false)
     end
   end
 end

--- a/spec/helpers/rake_runner_spec.rb
+++ b/spec/helpers/rake_runner_spec.rb
@@ -47,4 +47,10 @@ describe "Rake Runner" do
       expect(runner.rakefile_can_load?).to be_false
     end
   end
+
+  it "fails if cannot load Rails 4 rakefile" do
+    Hatchet::Runner.new('bad_rakefile_rails_4', allow_failure: true).deploy do |app|
+      expect(app.output).to match("ERROR: Could not detect rake tasks")
+    end
+  end
 end


### PR DESCRIPTION
In Rails 3+ it is a reasonable assumption that most developers want to run `assets:precompile` if the task is present. If they accidentally introduce an error into their Rakefile then we cannot detect properly we should raise instead of continuing. Behavior is the same for regular Ruby projects and Rails2.