### PR TITLE
Make it possible to disable asset compilation

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -64,7 +64,7 @@ private
           return true
         end
 
-        if ENV['RAILS_NO_ASSETS']
+        if env('RAILS_NO_ASSETS')
           puts "RAILS_NO_ASSETS is set, not compiling assets"
           return true
         end

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -74,7 +74,7 @@ WARNING
           return true
         end
 
-        if ENV['RAILS_NO_ASSETS']
+        if env('RAILS_NO_ASSETS')
           puts "RAILS_NO_ASSETS is set, not compiling assets"
           return true
         end


### PR DESCRIPTION
by setting `RAILS_NO_ASSETS` environment variable.

Currently it's only possible to disable asset precompilation by altering the repository. We have a project that is deployed to multiple heroku instances (in our case so that we can have separate NewRelic reporting) and we don't want to wait for assets to compile on the instances that never run web dynos. Since we want to run the same branch on all of our instances, we don't want to have to maintain a separate branch that has `manifest.yml` in it.
