### PR TITLE
Remove sqlite3 from database_url generation.

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -110,8 +110,6 @@ private
         "mysql"
       elsif bundler.has_gem?("mysql2")
         "mysql2"
-      elsif bundler.has_gem?("sqlite3") || bundler.has_gem?("sqlite3-ruby")
-        "sqlite3"
       end
       "#{scheme}://user:pass@127.0.0.1/dbname"
     end


### PR DESCRIPTION
I'm not sure that this lines are needed since `sqlite3` officially is not supported. 

By the way I was able to deploy rails application that uses `sqlite3` by defining `DATABASE_URL=sqlite3:///some-strange-database-name.db`. Yes, it's odd solution, but possibly might be helpful to someone.