### PR TITLE
use the vendored java not the stack image one

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -220,6 +220,7 @@ private
   # sets up the environment variables for the build process
   def setup_language_pack_environment
     instrument 'ruby.setup_language_pack_environment' do
+      ENV["PATH"] += ":bin" if ruby_version.jruby?
       setup_ruby_install_env
       ENV["PATH"] += ":#{node_bp_bin_path}" if node_js_installed?
 


### PR DESCRIPTION
This fixes the problem on cedar-14 where we can't find Java since it's not on the stack image anymore.
