### PR TITLE
rbx now supports cedar and cedar-14

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -42,7 +42,7 @@ class LanguagePack::Ruby < LanguagePack::Base
     super(build_path, cache_path)
     @fetchers[:mri]    = LanguagePack::Fetcher.new(VENDOR_URL, @stack)
     @fetchers[:jvm]    = LanguagePack::Fetcher.new(JVM_BASE_URL)
-    @fetchers[:rbx]    = LanguagePack::Fetcher.new(RBX_BASE_URL)
+    @fetchers[:rbx]    = LanguagePack::Fetcher.new(RBX_BASE_URL, @stack)
     @node_installer    = LanguagePack::NodeInstaller.new(@stack)
   end
 


### PR DESCRIPTION
talked with @brixen about this. we're moving to a directory structure similar to how we lay it out for MRI/JRuby on Heroku for Rubinius. This patch supports multiple Heroku stacks for Rubinius.
