### PR TITLE
Add more generic application setup rake task

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+heroku-buildpack-ruby

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ The buildpack will detect your apps as a Rails 3 app if it has an `application.r
 
 To enable static assets being served on the dyno, [rails3_serve_static_assets](http://github.com/pedro/rails3_serve_static_assets) is installed by default. If the [execjs gem](http://github.com/sstephenson/execjs) is detected then [node.js](http://github.com/joyent/node) will be vendored. The `assets:precompile` rake task will get run if no `public/manifest.yml` is detected.  See [this article](http://devcenter.heroku.com/articles/rails31_heroku_cedar) on how rails 3.1 works on cedar.
 
+This task is no longer supported for non-Rails applications. For additional setup using rake see [Application Setup][#application-setup]
+
+#### <a name="application-setup"></a> Application Setup
+
+If there is additional setup that you need accomplished after the rest of your build has occurred, you can fill in the `application:setup` rake task. If the task is present, Heroku will call it and you can finish setting up your application. If it is not present, it will be skipped harmlessly.
+
 Hacking
 -------
 
@@ -170,7 +176,7 @@ Ruby (Gemfile and Gemfile.lock is detected)
 * runs Bundler
 * installs binaries
   * installs node if the gem execjs is detected
-* runs `rake assets:precompile` if the rake task is detected
+* runs `rake application:setup` if the rake task is detected
 
 Rack (config.ru is detected)
 
@@ -183,10 +189,11 @@ Rails 2 (config/environment.rb is detected)
 * sets RAILS_ENV=production
 * install rails 2 plugins
   * [rails_log_stdout](http://github.com/ddollar/rails_log_stdout)
+* runs `rake assets:precompile` if the rake task is detected
 
 Rails 3 (config/application.rb is detected)
 
 * everything from Rails 2
 * install rails 3 plugins
   * [rails3_server_static_assets](https://github.com/pedro/rails3_serve_static_assets)
-
+* runs `rake assets:precompile` if the rake task is detected

--- a/hatchet.json
+++ b/hatchet.json
@@ -10,7 +10,8 @@
     "sharpstone/mri_187_no_rake",
     "sharpstone/mri_187_rake",
     "sharpstone/mri_200_no_rake",
-    "sharpstone/mri_200_rake"
+    "sharpstone/mri_200_rake",
+    "billywatson/heroku_buildpack_fail_application_setup"
   ],
   "bundler": [
     "sharpstone/bad_gemfile_on_platform",

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -95,7 +95,6 @@ class LanguagePack::Ruby < LanguagePack::Base
         post_bundler
         create_database_yml
         install_binaries
-        run_assets_precompile_rake_task
       end
       super
     end
@@ -696,31 +695,7 @@ params = CGI.parse(uri.query || "")
     @node_js_installed ||= run("#{node_bp_bin_path}/node -v") && $?.success?
   end
 
-  def run_assets_precompile_rake_task
-    instrument 'ruby.run_assets_precompile_rake_task' do
 
-      precompile = rake.task("assets:precompile")
-      return true unless precompile.is_defined?
-
-      topic "Precompiling assets"
-      precompile.invoke(env: rake_env)
-      if precompile.success?
-        puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
-      else
-        precompile_fail(precompile.output)
-      end
-    end
-  end
-
-  def precompile_fail(output)
-    log "assets_precompile", :status => "failure"
-    msg = "Precompiling assets failed.\n"
-    if output.match(/(127\.0\.0\.1)|(org\.postgresql\.util)/)
-      msg << "Attempted to access a nonexistent database:\n"
-      msg << "https://devcenter.heroku.com/articles/pre-provision-database\n"
-    end
-    error msg
-  end
 
   def bundler_cache
     "vendor/bundle"

--- a/spec/ruby_spec.rb
+++ b/spec/ruby_spec.rb
@@ -44,4 +44,13 @@ describe "Ruby apps" do
       end
     end
   end
+
+  describe 'application:setup' do
+    it "fails compile if application:setup fails" do
+      Hatchet::Runner.new('heroku_buildpack_fail_application_setup', allow_failure: true).deploy do |app, heroku|
+        expect(app.output).to include('raising on application:setup on purpose')
+        expect(app).not_to be_deployed
+      end
+    end
+  end
 end


### PR DESCRIPTION
I've added an `application:setup` rake task and moved the Rails-specific `assets:precompile` into the Rails language pack. This will allow all ruby applications to do some final application setup tasks on deploy and not force them to use the Rails-specific name of `assets:precompile` to get it done. I've also updated the docs surrounding this change and added a basic test.