### PR TITLE
Create export file for subsequent processes

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -154,6 +154,21 @@ private ##################################
     add_to_profiled %{export #{key}="#{val.gsub('"','\"')}"}
   end
 
+  def add_to_export(string)
+    export = File.expand_path("../../../export", __FILE__)
+    File.open(export, "a") do |file|
+      file.puts string
+    end
+  end
+
+  def set_export_default(key, val)
+    add_to_export "export #{key}=${#{key}:-#{val}}"
+  end
+
+  def set_export_override(key, val)
+    add_to_export %{export #{key}="#{val.gsub('"','\"')}"}
+  end
+
   def log_internal(*args)
     message = build_log_message(args)
     %x{ logger -p user.notice -t "slugc[$$]" "buildpack-ruby #{message}" }
@@ -170,4 +185,3 @@ private ##################################
     end.join(" ")
   end
 end
-

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -88,6 +88,7 @@ class LanguagePack::Ruby < LanguagePack::Base
       install_ruby
       install_jvm
       setup_language_pack_environment
+      setup_export
       setup_profiled
       allow_git do
         install_bundler_in_app
@@ -218,6 +219,16 @@ private
       ENV["GEM_PATH"] = slug_vendor_base
       ENV["GEM_HOME"] = slug_vendor_base
       ENV["PATH"]     = default_path
+    end
+  end
+
+  # sets up the environment variables for subsequent processes
+  def setup_export
+    instrument 'ruby.setup_export' do
+      paths = ENV["PATH"].split(":")
+      set_export_override "GEM_PATH", "#{build_path}/#{slug_vendor_base}:$GEM_PATH"
+      set_export_default  "LANG",     "en_US.UTF-8"
+      set_export_override "PATH",     paths.map {|path| /^\/.*/ !~ path ? "#{build_path}/#{path}" : path}.join(":")
     end
   end
 


### PR DESCRIPTION
Added a feature to create an "export" file for subsequent processes. "export" file is used in heroku-buildpack-multi.
- https://github.com/ddollar/heroku-buildpack-multi/pull/18

This would be useful when we use ruby packages on build process outside heroku-buildpack-ruby. (e.g. compile sass files using compass)

Sample of generated "export" file

```
export GEM_PATH="/tmp/build_d61113c86a29960955eed25246095d1d/vendor/bundle/ruby/2.1.0:$GEM_PATH"
export LANG=${LANG:-en_US.UTF-8}
export PATH="/tmp/build_d61113c86a29960955eed25246095d1d/vendor/bundle/bin:/tmp/build_d61113c86a29960955eed25246095d1d/vendor/bundle/ruby/2.1.0/bin:/tmp/build_d61113c86a29960955eed25246095d1d/vendor/ruby-2.1.0/bin:/tmp/build_d61113c86a29960955eed25246095d1d/:/tmp/codon/vendor/bin:/app/bin:/usr/ruby1.9.2/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/tmp/build_d61113c86a29960955eed25246095d1d/bin:/usr/local/bin:/usr/bin:/bin"
```
