### PR TITLE
Add JVM install dir to the compile time PATH

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -205,7 +205,6 @@ private
   # sets up the environment variables for the build process
   def setup_language_pack_environment
     instrument 'ruby.setup_language_pack_environment' do
-      ENV["PATH"] += ":bin" if ruby_version.jruby?
       setup_ruby_install_env
       ENV["PATH"] += ":#{node_bp_bin_path}" if node_js_installed?
 
@@ -218,6 +217,7 @@ private
       ENV["GEM_PATH"] = slug_vendor_base
       ENV["GEM_HOME"] = slug_vendor_base
       ENV["PATH"]     = default_path
+      ENV["PATH"] += ":#{Dir.pwd}/vendor/jvm/bin" if ruby_version.jruby?
     end
   end
 


### PR DESCRIPTION
This fixes a bug where gems like `scrypt` cannot be installed on cedar-14. On cedar classic they installed fine because the used the `java` command on the stack image.