### PR TITLE
Scale back JRuby heap size on PX dynos 

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -198,7 +198,7 @@ case $(ulimit -u) in
   JVM_MAX_HEAP=768
   ;;
 32768) # PX Dyno
-  JVM_MAX_HEAP=6144
+  JVM_MAX_HEAP=5120
   ;;
 esac
 EOF


### PR DESCRIPTION
Scale back JRuby heap size on PX dynos to give room for native memory allocation