### PR TITLE
special case for patchlevel rubies. fixes jruby 9.0.0.0.pre1

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -27,6 +27,7 @@
     "sharpstone/ruby_193_jruby_17161",
     "sharpstone/ruby_193_jruby_17161_jdk7",
     "sharpstone/ruby_193_jruby_17161_jdk8",
+    "kissaten/jruby-minimal",
     "sharpstone/empty-procfile",
     "sharpstone/bad_ruby_version"
   ],

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -89,7 +89,7 @@ class LanguagePack::Helpers::BundlerWrapper
       if output.match(/No ruby version specified/)
         ""
       else
-        output.chomp.sub('(', '').sub(')', '').sub("p", " p").split.join('-')
+        output.chomp.sub('(', '').sub(')', '').sub(/(p\d+)/, ' \1').split.join('-')
       end
     end
   end

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -24,5 +24,23 @@ describe "BundlerWrapper" do
       expect(@bundler.install.windows_gemfile_lock?).to be_true
     end
   end
+
+  describe "when executing bundler" do
+    before do
+      @bundler.install
+    end
+
+    it "handles JRuby pre gemfiles" do
+      Hatchet::App.new("jruby-minimal").in_directory do |dir|
+        expect(@bundler.ruby_version).to eq("ruby-2.2.0-jruby-9.0.0.0.pre1")
+      end
+    end
+
+    it "handles MRI patchlevel gemfiles" do
+      Hatchet::App.new("mri_193_p547").in_directory do |dir|
+        expect(@bundler.ruby_version).to eq("ruby-1.9.3-p547")
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
make patchlevel sub on `bundle platform --ruby` more specific, so it doesn't conflict with jruby pres