### PR TITLE
Fail fast if ENV["STACK"] is missing

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -27,7 +27,7 @@ class LanguagePack::Base
   def initialize(build_path, cache_path=nil)
      self.class.instrument "base.initialize" do
       @build_path    = build_path
-      @stack         = ENV["STACK"]
+      @stack         = ENV.fetch("STACK")
       @cache         = LanguagePack::Cache.new(cache_path) if cache_path
       @metadata      = LanguagePack::Metadata.new(@cache)
       @bundler_cache = LanguagePack::BundlerCache.new(@cache, @stack)


### PR DESCRIPTION
Had some minor issues with it while trying to make a Dockerfile work, but TL;DR STACK wasn't set and I was getting a weird error which didn't seem intuitive.

Let me know if this general direction works, we can also maybe pass DEFAULT_LEGACY_STACK as second param to fetch if that's the preferred behavior as well.