### PR TITLE
control all of our test repos

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -27,7 +27,7 @@
     "sharpstone/ruby_193_jruby_17161",
     "sharpstone/ruby_193_jruby_17161_jdk7",
     "sharpstone/ruby_193_jruby_17161_jdk8",
-    "kissaten/jruby-minimal",
+    "sharpstone/jruby-minimal",
     "sharpstone/empty-procfile",
     "sharpstone/bad_ruby_version"
   ],


### PR DESCRIPTION
This test broke when @jkutner updated the kissaten/jruby-minimal repo. I just forked and rolled back so our test continue to work.