### PR TITLE
Make `bundle clean` have the same context as `bundle install`

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -572,7 +572,7 @@ WARNING
           instrument "ruby.bundle_clean" do
             # Only show bundle clean output when not using default cache
             if load_default_cache?
-              run "bundle clean > /dev/null"
+              run "#{bundle_bin} clean > /dev/null"
             else
               pipe("#{bundle_bin} clean", out: "2> /dev/null")
             end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -572,9 +572,9 @@ WARNING
           instrument "ruby.bundle_clean" do
             # Only show bundle clean output when not using default cache
             if load_default_cache?
-              run "#{bundle_bin} clean > /dev/null"
+              run("#{bundle_bin} clean > /dev/null", user_env: true)
             else
-              pipe("#{bundle_bin} clean", out: "2> /dev/null")
+              pipe("#{bundle_bin} clean", out: "2> /dev/null", user_env: true)
             end
           end
           @bundler_cache.store


### PR DESCRIPTION
If a user has a crazy Gemfile where it executes code based on the environment, `bundle clean` might fail while `bundle install` works because the context is different. Let's pass the user env to `bundle clean` as well.