### PR TITLE
Add support for changing number of bundle jobs

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -509,10 +509,11 @@ WARNING
   def build_bundler
     instrument 'ruby.build_bundler' do
       log("bundle") do
+        bundle_jobs    = env("BUNDLE_JOBS") || "4"
         bundle_without = env("BUNDLE_WITHOUT") || "development:test"
         bundle_bin     = "bundle"
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
-        bundle_command << " -j4"
+        bundle_command << " -j#{bundle_jobs}"
 
         if bundler.windows_gemfile_lock?
           warn(<<WARNING, inline: true)

--- a/spec/bundle_jobs_spec.rb
+++ b/spec/bundle_jobs_spec.rb
@@ -1,0 +1,19 @@
+require_relative 'spec_helper'
+
+describe "bundle jobs" do
+  it "defaults to 4 jobs" do
+    Hatchet::Runner.new("default_ruby").deploy do |app|
+      expect(app.output).to match("-j4")
+    end
+  end
+
+  it "allows configuring the number of jobs" do
+    app = Hatchet::Runner.new("default_ruby")
+    app.setup!
+    app.set_config("BUNDLE_JOBS" => "2")
+
+    app.deploy do |app|
+      expect(app.output).to match("-j2")
+    end
+  end
+end


### PR DESCRIPTION
The `BUNDLE_JOBS` environment variable can be used to change the number of jobs that will be used to bundle (defaults to 4).

This can be set to 1 to work around bundler/bundler#3063 or a higher number to speed up deployments in some situations.