### PR TITLE
Support Ruby/Rails apps whose root folder is not the repo folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ vendor/bundle/*
 .ruby-version
 buildpacks/*
 .anvil/
+
+.idea

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,14 @@ require "language_pack/shell_helpers"
 
 begin
   LanguagePack::Instrument.trace 'compile', 'app.compile' do
-    if pack = LanguagePack.detect(ARGV[0], ARGV[1])
+    
+    def app_root
+      path_to_root = Pathname.new(ARGV[0] || "").join(".ruby_app_root")
+      $folder = File.exist?(path_to_root) ? File.read(path_to_root).delete!("\n") + "/": ""
+      File.join(ARGV[0], $folder)
+    end
+
+    if pack = LanguagePack.detect(app_root, ARGV[1])
       LanguagePack::ShellHelpers.initialize_env(ARGV[2])
       pack.topic("Compiling #{pack.name}")
       pack.log("compile") do

--- a/bin/detect
+++ b/bin/detect
@@ -5,6 +5,9 @@ require 'pathname'
 if Pathname.new(ARGV.first).join("Gemfile").exist?
   puts "Ruby"
   exit 0
+elsif Pathname.new(ARGV.first).join(".ruby_app_root").exist?
+  puts "Ruby (non-standard root folder)"
+  exit 0
 else
   puts "no"
   exit 1

--- a/bin/release
+++ b/bin/release
@@ -2,5 +2,11 @@
 
 require 'pathname'
 
-release = Pathname.new(ARGV.first).join("tmp/heroku-buildpack-release-step.yml")
+def app_root
+  path_to_root = Pathname.new(ARGV[0] || "").join(".ruby_app_root")
+  $folder = File.exist?(path_to_root) ? File.read(path_to_root).delete!("\n") + "/": ""
+  File.join(ARGV[0], $folder)
+end
+
+release = Pathname.new(ARGV.first).join("#{app_root}/tmp/heroku-buildpack-release-step.yml")
 puts release.read if release.exist?

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -22,10 +22,16 @@ class LanguagePack::Rails4 < LanguagePack::Rails3
   end
 
   def default_process_types
+    prefixes = [
+        "GEM_PATH=/app/#{$folder}vendor/bundle/ruby/2.2.0",
+        "PATH=/app/#{$folder}bin:/app/#{$folder}vendor/node/bin:$PATH",
+        "BUNDLE_GEMFILE=./#{$folder}Gemfile"
+    ].join(" ")
+
     instrument "rails4.default_process_types" do
       super.merge({
-        "web"     => "bin/rails server -p $PORT -e $RAILS_ENV",
-        "console" => "bin/rails console"
+        "web"     => "#{prefixes} gem env && #{prefixes} rails server -p $PORT -e production",#for some reason I lost $RAILS_ENV value
+        "console" => " #{prefixes} rails console"
       })
     end
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -598,6 +598,7 @@ ERROR
         end
       end
     end
+    p `gem env`
   end
 
   def post_bundler


### PR DESCRIPTION
This is achieved through detecting a `.ruby_app_root` file in the root of the repo, which contains a single line with the relative path to the subdirectory containing the app root.

See https://github.com/shageman/sportsball/tree/web_container_dir for a deployable example (use `web_container_dir` branch).

_I am not looking for this PR to be accepted_, but rather I am looking for input on how to solve this problem with fewer hacks. 

Some of the problems with this code:
* compile: use of global variable `$folder` to not change arity of `detect` on language packs
* default config: `-e $RAILS_ENV` stopped working, so `-e production` is hardcoded for now
* semi-hardcoded paths in env variables
* running rake, e.g., `heroku run rake db:migrate`, does not yet work

Specific questions:
* Is the `.ruby_app_root` detection acceptable for the default ruby buildpack?
* Is the basic approach viable if I work out the kinks and hacks?
* What tests should be added for acceptance to be considered? One version of Rails or all supported language packs?