### PR TITLE
Handle new manifest filename (sprockets 3.x)

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -60,7 +60,8 @@
     "sharpstone/rails41_scaffold"
   ],
   "rails42": [
-    "sharpstone/rails42_scaffold"
+    "sharpstone/rails42_scaffold",
+    "fjg/rails42_sprockets3_manifest"
   ],
   "rails5": [
     "sharpstone/rails5"

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -69,7 +69,7 @@ WARNING
   def run_assets_precompile_rake_task
     instrument "rails4.run_assets_precompile_rake_task" do
       log("assets_precompile") do
-        if Dir.glob('public/assets/manifest-*.json').any?
+        if Dir.glob("public/assets/{.sprockets-manifest-*.json,manifest-*.json}", File::FNM_DOTMATCH).any?
           puts "Detected manifest file, assuming assets were compiled locally"
           return true
         end

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -18,6 +18,15 @@ describe "Rails 4.0.x" do
     end
   end
 
+  it "detects new manifest file (sprockets 3.x: .sprockets-manifest-<digest>.json)" do
+    Hatchet::Runner.new("rails42_sprockets3_manifest").deploy do |app, heroku|
+      expect(LanguagePack::Rails42.use?).to eq(true)
+      add_database(app, heroku)
+      expect(app.output).to include("Detected manifest file, assuming assets were compiled locally")
+    end
+  end
+
+
   it "upgraded from 3 to 4 missing ./bin still works" do
     Hatchet::Runner.new("rails3-to-4-no-bin").deploy do |app, heroku|
       expect(app.output).to include("Asset precompilation completed")

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -19,7 +19,7 @@ describe "Rails 4.0.x" do
   end
 
   it "detects new manifest file (sprockets 3.x: .sprockets-manifest-<digest>.json)" do
-    Hatchet::Runner.new("rails42_sprockets3_manifest").deploy do |app, heroku|
+    Hatchet::Runner.new("rails42_sprockets3_manifest", buildpack_url: "https://github.com/fjg/heroku-buildpack-ruby.git").deploy do |app, heroku|
       expect(LanguagePack::Rails42.use?).to eq(true)
       add_database(app, heroku)
       expect(app.output).to include("Detected manifest file, assuming assets were compiled locally")


### PR DESCRIPTION
Since Version 3.0.0 sprockets has changed the filename of the manifest: now it's **.sprockets-manifest-<digest>.json**

https://github.com/rails/sprockets/blob/master/CHANGELOG.md

This buildpack detects this manifest and avoids to recompile assets during the deployment.