### PR TITLE
Use shell in Detect for speed

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,11 +1,9 @@
-#!/usr/bin/env ruby
+#!/bin/sh
 
-require 'pathname'
-
-if Pathname.new(ARGV.first).join("Gemfile").exist?
-  puts "Ruby"
+if [ -f $1/Gemfile ]; then
+  echo "Ruby"
   exit 0
 else
-  puts "no"
+  echo "no"
   exit 1
-end
+fi


### PR DESCRIPTION
Resolves #368

```shell
# ruby
$ ( for i in {1..1000}; do; bin/detect /ruby-app; done; )  29.98s user 6.32s system 97% cpu 37.266 total

# sh
$ ( for i in {1..1000}; do; bin/detect /ruby-app; done; )  1.32s user 1.43s system 98% cpu 2.789 total
```