### PR TITLE
Update Bundler version

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,7 +14,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.7.12"
+  BUNDLER_VERSION      = "1.9.7"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"


### PR DESCRIPTION
This updates the version of Bundler used to the current newest version, 1.9.6.

We've been continuing to backport bugfixs to the 1.7.x series just for Heroku, but unless Heroku joins Ruby Together I don't have enough time available to make sure that continues to happen. In addition, there are _many_ features that are simply unavailable to Heroku users who want or need to use them, including the ability to keep Gem server credentials out of source control.