### PR TITLE
Update Bundler version

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -92,8 +92,11 @@ class LanguagePack::Helpers::BundlerWrapper
             }
       command = "bundle platform --ruby"
 
+      # Silently check for ruby version
       output  = run_stdout(command, user_env: true, env: env)
-      raise GemfileParseError.new(run(command, user_env: true, env: env)) unless $?.success?
+
+      # If there's a gem in the Gemfile (i.e. syntax error) emit error
+      raise GemfileParseError.new(run("bundle check", user_env: true, env: env)) unless $?.success?
       if output.match(/No ruby version specified/)
         ""
       else

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,7 +14,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.7.12"
+  BUNDLER_VERSION      = "1.9.7"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"

--- a/spec/bugs_spec.rb
+++ b/spec/bugs_spec.rb
@@ -7,7 +7,7 @@ describe "Bugs" do
       app.heroku.put_stack(app.name, "cedar")
       app.deploy do |app, heroku|
         expect(app.output).to match("Installing nokogiri")
-        expect(app.output).to match("Your bundle is complete!")
+        expect(app.output).to match("Bundle complete")
       end
     end
   end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -98,7 +98,7 @@ describe "RubyVersion" do
     error_klass      = LanguagePack::Helpers::BundlerWrapper::GemfileParseError
     Hatchet::App.new("bad_gemfile_on_platform").in_directory do |dir|
       @bundler       = LanguagePack::Helpers::BundlerWrapper.new().install
-      expect {LanguagePack::RubyVersion.new(@bundler.ruby_version)}.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
+      expect { LanguagePack::RubyVersion.new(@bundler.ruby_version) }.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
     end
   end
 end


### PR DESCRIPTION
This updates the version of Bundler used to the current newest version, 1.9.7.

We've been continuing to backport bugfixs to the 1.7.x series just for Heroku, but unless Heroku joins Ruby Together I don't have enough time available to make sure that continues to happen. In addition, there are _many_ features that are simply unavailable to Heroku users who want or need to use them, including the ability to keep Gem server credentials out of checked in files.