### PR TITLE
Allow path with spaces to be detected as Ruby

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -f $1/Gemfile ]; then
+if [ -f "$1/Gemfile" ]; then
   echo "Ruby"
   exit 0
 else


### PR DESCRIPTION
Without the quotes it won't work for path with spaces