### PR TITLE
adding hatchet setup information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ it does not parallelize tests within a test file. To run the tests: clone the re
 $ bundle exec hatchet install
 ```
 
-then go to [hatchet](https://github.com/heroku/hatchet) and follow the
+then go to [hatchet](https://github.com/heroku/hatchet) repo and follow the
 instructions to set it up.
 
 Now run the tests:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ it does not parallelize tests within a test file. To run the tests: clone the re
 $ bundle exec hatchet install
 ```
 
+then go to [hatchet](https://github.com/heroku/hatchet) and follow the
+instructions to set it up.
+
 Now run the tests:
 
 ```sh


### PR DESCRIPTION
# Description

This PR adds information on how to setup hatchet to the heroku-buildpack-ruby README.md file. This is required to run buildpack tests correctly