### PR TITLE
[Rails 4] Don't overwrite public/assets files when loading cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Cached asset file should never take precedent over existing file (#402)
+
 ## v138 (5/19/2015)
 
 * Bump bundler to 1.9.7 [Bundler changelog](https://github.com/bundler/bundler/blob/master/CHANGELOG.md#196-2015-05-02) (#378)

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -42,13 +42,18 @@ class LanguagePack::Cache
     copy (@cache_base + path), dest
   end
 
+  def load_without_overwrite(path, dest=nil)
+    dest ||= path
+    copy (@cache_base + path), dest, '-a -n'
+  end
+
   # copy cache contents
   # @param [String] source directory
   # @param [String] destination directory
-  def copy(from, to)
+  def copy(from, to, options='-a')
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
-    system("cp -a #{from}/. #{to}")
+    system("cp #{options} #{from}/. #{to}")
   end
 
   # copy contents between to places in the cache

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -79,7 +79,7 @@ WARNING
 
         topic("Preparing app for Rails asset pipeline")
 
-        @cache.load public_assets_folder
+        @cache.load_without_overwrite public_assets_folder
         @cache.load default_assets_cache
 
         precompile.invoke(env: rake_env)

--- a/spec/rails41_spec.rb
+++ b/spec/rails41_spec.rb
@@ -24,4 +24,27 @@ describe "Rails 4.1.x" do
       end
     end
   end
+
+  it "should not overwrite existing files with cached files" do
+    string = SecureRandom.hex(13)
+    new_string = SecureRandom.hex(13)
+
+    Hatchet::Runner.new("rails41_scaffold").deploy do |app, heroku|
+      # First Deploy
+      `mkdir public/assets`
+      `echo #{string} > public/assets/file.txt`
+      `git add -A; git commit -m 'adding file.txt'`
+      app.push!
+
+      # Second Deploy
+      `echo #{new_string} > public/assets/file.txt`
+      `git add -A; git commit -m 'updating file.txt'`
+      app.push!
+
+      # Asserts
+      result = app.run('cat public/assets/file.txt')
+      expect(result).not_to match(string)
+      expect(result).to match(new_string)
+    end
+  end
 end


### PR DESCRIPTION
# Background

I'm using a gulp based assets pipeline along with Sprockets. I'm only using Sprockets because I have gems that require it (rails-admin for example). `gulp-rev` generates a manifest file before running the ruby buildpack

The problem comes when we cache `public/assets`, and then load it, since this overwrites the manifest created by `gulp-rev` with an old version. Right now the only way to workaround this is using `heroku repo` plugin and running `heroku repo:purge_cache`

# Description

This PR changes how `public/assets` cache is loaded. Instead of overwriting all the files, we only copy the ones that are missing.

# Questions

I cannot think a way that this will cause problems with normal Rails apps, since `public/assets` should be only populated by `rails assets:precompile`, and if it's run on Heroku, there should not be any files before running this process, but of course, let me know if you see issues happening by merging this PR.

# Related Issues

* https://github.com/vigetlabs/gulp-rails-pipeline/issues/6