### PR TITLE
Clarify top is showing version of bundler

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -532,7 +532,7 @@ WARNING
           cache.load ".bundle"
         end
 
-        topic("Installing dependencies using #{bundler.version}")
+        topic("Installing dependencies using bundler #{bundler.version}")
         load_bundler_cache
 
         bundler_output = ""


### PR DESCRIPTION
Sometimes users are confused with the version number 1.9.7 to be from something other than bundler so it may be better to change

```
remote: -----> Installing dependencies using 1.9.7
```

to

```
remote: -----> Installing dependencies using bundler 1.9.7
```