### PR TITLE
[RFC] Allow projects in subdirectories

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,8 +9,8 @@ require "language_pack/shell_helpers"
 
 begin
   LanguagePack::Instrument.trace 'compile', 'app.compile' do
+    LanguagePack::ShellHelpers.initialize_env(ARGV[2])
     if pack = LanguagePack.detect(ARGV[0], ARGV[1])
-      LanguagePack::ShellHelpers.initialize_env(ARGV[2])
       pack.topic("Compiling #{pack.name}")
       pack.log("compile") do
         pack.compile

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -7,7 +7,8 @@ module LanguagePack
   end
 
   def self.app_dir
-    @app_dir ||= LanguagePack::ShellHelpers.user_env_hash["APP_DIR"]
+    dir = LanguagePack::ShellHelpers.user_env_hash["APP_DIR"]
+    dir && Dir.exists?(dir) ? dir : nil
   end
 
   def self.app_path

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -6,6 +6,14 @@ module LanguagePack
   module Helpers
   end
 
+  def self.app_dir
+    @app_dir ||= LanguagePack::ShellHelpers.user_env_hash["APP_DIR"]
+  end
+
+  def self.app_path
+    @app_path ||= app_dir ? File.join(ARGV[0], app_dir) : ARGV[0]
+  end
+
   # detects which language pack to use
   # @param [Array] first argument is a String of the build directory
   # @return [LanguagePack] the {LanguagePack} detected
@@ -13,8 +21,10 @@ module LanguagePack
     Instrument.instrument 'detect' do
       Dir.chdir(args.first)
 
-      pack = [ NoLockfile, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
-        klass.use?
+      pack = Dir.chdir(app_path) do
+        [ NoLockfile, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
+          klass.use?
+        end
       end
 
       return pack ? pack.new(*args) : nil

--- a/lib/language_pack/helpers/bundler_cache.rb
+++ b/lib/language_pack/helpers/bundler_cache.rb
@@ -5,14 +5,15 @@ require "language_pack/cache"
 # manipulating the `vendor/bundle` Bundler cache directory.
 # supports storing the cache in a "stack" directory
 class LanguagePack::BundlerCache
-  attr_reader :bundler_dir
+  attr_reader :bundler_dir, :app_dir
 
   # @param [LanguagePack::Cache] cache object
   # @param [String] stack buildpack is running on
-  def initialize(cache, stack = nil)
+  def initialize(cache, stack: nil, app_dir: "")
     @cache       = cache
     @stack       = stack
-    @bundler_dir = Pathname.new("vendor/bundle")
+    @app_dir     = Pathname.new(app_dir)
+    @bundler_dir = @app_dir + "vendor/bundle"
     @stack_dir   = @stack ? Pathname.new(@stack) + @bundler_dir : @bundler_dir
   end
 
@@ -41,7 +42,7 @@ class LanguagePack::BundlerCache
 
   # writes cache contents to cache store
   def store
-    @cache.store(".bundle")
+    @cache.store(app_dir + ".bundle")
     @cache.store(@bundler_dir, @stack_dir)
   end
 

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -13,7 +13,6 @@ class LanguagePack::Helpers::BundlerWrapper
   DEFAULT_FETCHER    = LanguagePack::Fetcher.new(VENDOR_URL)         # coupling
   BUNDLER_DIR_NAME   = LanguagePack::Ruby::BUNDLER_GEM_PATH          # coupling
   BUNDLER_PATH       = File.expand_path("../../../../tmp/#{BUNDLER_DIR_NAME}", __FILE__)
-  GEMFILE_PATH       = Pathname.new "./Gemfile"
 
   attr_reader   :bundler_path
 
@@ -21,7 +20,7 @@ class LanguagePack::Helpers::BundlerWrapper
     @fetcher              = options[:fetcher]      || DEFAULT_FETCHER
     @bundler_tmp          = Dir.mktmpdir
     @bundler_path         = options[:bundler_path] || File.join(@bundler_tmp, "#{BUNDLER_DIR_NAME}")
-    @gemfile_path         = options[:gemfile_path] || GEMFILE_PATH
+    @gemfile_path         = options[:gemfile_path] || Pathname.new(LanguagePack.app_path + "/Gemfile")
     @bundler_tar          = options[:bundler_tar]  || "#{BUNDLER_DIR_NAME}.tgz"
     @gemfile_lock_path    = "#{@gemfile_path}.lock"
     @orig_bundle_gemfile  = ENV['BUNDLE_GEMFILE']

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -21,10 +21,11 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
 
   def default_process_types
     instrument "rails3.default_process_types" do
+      rails_path = app_dir + "script/rails"
       # let's special case thin here
       web_process = bundler.has_gem?("thin") ?
         "bundle exec thin start -R config.ru -e $RAILS_ENV -p $PORT" :
-        "bundle exec rails server -p $PORT"
+        "bundle exec #{rails_path} server -p $PORT"
 
       super.merge({
         "web" => web_process,

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -24,8 +24,8 @@ class LanguagePack::Rails4 < LanguagePack::Rails3
   def default_process_types
     instrument "rails4.default_process_types" do
       super.merge({
-        "web"     => "bin/rails server -p $PORT -e $RAILS_ENV",
-        "console" => "bin/rails console"
+        "web"     => app_dir + "bin/rails server -p $PORT -e $RAILS_ENV",
+        "console" => app_dir + "bin/rails console"
       })
     end
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -298,7 +298,7 @@ SHELL
       set_env_default  "LANG",     "en_US.UTF-8"
       set_env_override "GEM_PATH", "$HOME/#{slug_vendor_base}:$GEM_PATH"
       set_env_override "PATH",     binstubs_relative_paths.map {|path| "$HOME/#{path}" }.join(":") + ":$PATH"
-      set_env_default  "BUNDLE_GEMFILE", app_dir + "Gemfile"
+      set_env_default  "BUNDLE_GEMFILE", "$HOME/#{app_dir}/Gemfile"
 
       add_to_profiled set_default_web_concurrency if env("SENSIBLE_DEFAULTS")
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -299,6 +299,7 @@ SHELL
       set_env_override "GEM_PATH", "$HOME/#{slug_vendor_base}:$GEM_PATH"
       set_env_override "PATH",     binstubs_relative_paths.map {|path| "$HOME/#{path}" }.join(":") + ":$PATH"
       set_env_default  "BUNDLE_GEMFILE", "$HOME/#{app_dir}/Gemfile"
+      set_env_default  "RAKEOPT", "'--rakefile #{app_dir}/Rakefile'"
 
       add_to_profiled set_default_web_concurrency if env("SENSIBLE_DEFAULTS")
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -94,9 +94,20 @@ class LanguagePack::Ruby < LanguagePack::Base
         create_database_yml
         install_binaries
         run_assets_precompile_rake_task
+        symlink_procfile
       end
       super
     end
+  end
+
+  # Heroku expects the procfile to be in the root directory
+  # This symlinks the Procfile that might be in @app_dir into root
+  def symlink_procfile
+    # No need to run this task if app_dir doesn't exist
+    return unless @app_dir
+
+    procfile = "#{app_dir}/Procfile"
+    FileUtils.ln(procfile, "Procfile") if File.exists?(procfile)
   end
 
 private
@@ -287,6 +298,7 @@ SHELL
       set_env_default  "LANG",     "en_US.UTF-8"
       set_env_override "GEM_PATH", "$HOME/#{slug_vendor_base}:$GEM_PATH"
       set_env_override "PATH",     binstubs_relative_paths.map {|path| "$HOME/#{path}" }.join(":") + ":$PATH"
+      set_env_default  "BUNDLE_GEMFILE", app_dir + "Gemfile"
 
       add_to_profiled set_default_web_concurrency if env("SENSIBLE_DEFAULTS")
 
@@ -529,7 +541,7 @@ WARNING
         else
           # using --deployment is preferred if we can
           bundle_command += " --deployment"
-          cache.load ".bundle"
+          cache.load(app_dir + ".bundle")
         end
 
         topic("Installing dependencies using bundler #{bundler.version}")
@@ -549,8 +561,8 @@ WARNING
           # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
           # codon since it uses bundler.
           env_vars       = {
-            "BUNDLE_GEMFILE"                => "#{pwd}/Gemfile",
-            "BUNDLE_CONFIG"                 => "#{pwd}/.bundle/config",
+            "BUNDLE_GEMFILE"                => (app_dir + "Gemfile").to_s,
+            "BUNDLE_CONFIG"                 => (app_dir + ".bundle/config").to_s,
             "CPATH"                         => noshellescape("#{yaml_include}:$CPATH"),
             "CPPATH"                        => noshellescape("#{yaml_include}:$CPPATH"),
             "LIBRARY_PATH"                  => noshellescape("#{yaml_lib}:$LIBRARY_PATH"),


### PR DESCRIPTION
We had the use-case of deploying applications that were in a subdirectory in the project. The changes below were required to get it working.

A couple of questions:

1. is this something the main heroku buildpack would want? if so, then how does this PR look?
1. why is caching `.bundle/config` is necessary?