### PR TITLE
allow SSH_KEY for access to private github repos

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -81,6 +81,7 @@ class LanguagePack::Ruby < LanguagePack::Base
       # check for new app at the beginning of the compile
       new_app?
       Dir.chdir(build_path)
+      write_ssh_key
       remove_vendor_bundle
       install_ruby
       install_jvm
@@ -100,6 +101,22 @@ class LanguagePack::Ruby < LanguagePack::Base
   end
 
 private
+
+  def write_ssh_key
+    return unless key = ENV['SSH_KEY']
+    FileUtils.mkdir_p File.expand_path('~/.ssh')
+    File.open(File.expand_path('~/.ssh/id_rsa'), 'w') do |f|
+      f.write key
+      f.chmod(0700)
+    end
+    File.open(File.expand_path('~/.ssh/shim'), 'w') do |f|
+      f.write <<EOF
+#!/bin/sh
+exec /usr/bin/ssh -o StrictHostKeyChecking=no -i "$HOME/.ssh/id_rsa" "$@"
+EOF
+      f.chmod(0700)
+    end
+  end
 
   # the base PATH environment variable to be used
   # @return [String] the resulting PATH
@@ -513,6 +530,7 @@ WARNING
         bundle_without = env("BUNDLE_WITHOUT") || "development:test"
         bundle_bin     = "bundle"
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
+        bundle_command = 'GIT_SSH="$HOME/.ssh/shim" ' + bundle_command if ENV['SSH_KEY']
         bundle_command << " -j4"
 
         if bundler.windows_gemfile_lock?


### PR DESCRIPTION
This change allows setting `SSH_KEY` to allow access to private github repos.

(I think there was a PR/issue a while ago with similar changes, but I couldn't find it.)
