### PR TITLE
Emit more best practice warnings.

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -50,6 +50,16 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
     end
   end
 
+  def best_practice_warnings
+    if env("RAILS_ENV") != "production"
+      warn(<<-WARNING)
+You are deploying to a non-production environment: #{ env("RAILS_ENV").inspect }.
+See https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment for more information.
+WARNING
+    end
+    super
+  end
+
 private
 
   def install_plugins

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -76,6 +76,15 @@ class LanguagePack::Ruby < LanguagePack::Base
     end
   end
 
+  def best_practice_warnings
+    if bundler.has_gem?("asset_sync")
+      warn(<<-WARNING)
+You are using the `asset_sync` gem.
+See https://devcenter.heroku.com/articles/please-do-not-use-asset-sync for more information.
+WARNING
+    end
+  end
+
   def compile
     instrument 'ruby.compile' do
       # check for new app at the beginning of the compile
@@ -95,6 +104,7 @@ class LanguagePack::Ruby < LanguagePack::Base
         install_binaries
         run_assets_precompile_rake_task
       end
+      best_practice_warnings
       super
     end
   end
@@ -357,7 +367,7 @@ ERROR_MSG
 
       topic "Using Ruby version: #{ruby_version.version}"
       if !ruby_version.set
-        warn(<<WARNING)
+        warn(<<-WARNING)
 You have not declared a Ruby version in your Gemfile.
 To set your Ruby version add this line to your Gemfile:
 #{ruby_version.to_gemfile}
@@ -492,7 +502,7 @@ ERROR
   # https://github.com/heroku/heroku-buildpack-ruby/issues/21
   def remove_vendor_bundle
     if File.exists?("vendor/bundle")
-      warn(<<WARNING)
+      warn(<<-WARNING)
 Removing `vendor/bundle`.
 Checking in `vendor/bundle` is not supported. Please remove this directory
 and add it to your .gitignore. To vendor your gems with Bundler, use
@@ -516,7 +526,7 @@ WARNING
         bundle_command << " -j4"
 
         if bundler.windows_gemfile_lock?
-          warn(<<WARNING, inline: true)
+          warn(<<-WARNING, inline: true)
 Removing `Gemfile.lock` because it was generated on Windows.
 Bundler will do a full resolve so native gems are handled properly.
 This may result in unexpected gem versions being used in your app.


### PR DESCRIPTION
Instead of waiting for users to do bad things, and open support tickets to tell them about best practices, lets be a bit more proactive. 

Using asset_sync is bad, don't do it.

Using RAILS_ENV=staging is bad, don't do it.

Switching all HEREDOCS in ruby.rb to `<<-` so my editor parses them correctly.