### PR TITLE
Add support for custom JDK install

### DIFF
--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -14,6 +14,7 @@ class LanguagePack::JvmInstaller
     @vendor_dir = slug_vendor_jvm
     @stack = stack
     @fetcher = LanguagePack::Fetcher.new(JVM_BASE_URL, stack)
+    @custom_fetcher = LanguagePack::Fetcher.new(JVM_BASE_URL)
   end
 
   def system_properties
@@ -27,37 +28,48 @@ class LanguagePack::JvmInstaller
   end
 
   def install(jruby_version, forced = false)
-    jvm_version =
-      case system_properties['java.runtime.version']
-      when "1.8"
-        JVM_1_8_PATH
-      when "1.7"
-        JVM_1_7_PATH
-      when "1.6"
-        JVM_1_6_PATH
-      else
-        if @stack == "cedar"
-          if forced || Gem::Version.new(jruby_version) >= Gem::Version.new("1.7.4")
-            JVM_1_7_PATH
-          else
-            JVM_1_7_25_PATH
-          end
-        else
+    if env('JDK_URL_1_8')
+      fetch_untar(@custom_fetcher, env('JDK_URL_1_8').gsub("#{JVM_BASE_URL}/", ''))
+    elsif env('JDK_URL_1_7')
+      fetch_untar(@custom_fetcher, env('JDK_URL_1_7').gsub("#{JVM_BASE_URL}/", ''))
+    elsif env('JDK_URL_1_6')
+      fetch_untar(@custom_fetcher, env('JDK_URL_1_6').gsub("#{JVM_BASE_URL}/", ''))
+    else
+      jvm_version =
+        case system_properties['java.runtime.version']
+        when "1.8"
           JVM_1_8_PATH
+        when "1.7"
+          JVM_1_7_PATH
+        when "1.6"
+          JVM_1_6_PATH
+        else
+          if @stack == "cedar"
+            if forced || Gem::Version.new(jruby_version) >= Gem::Version.new("1.7.4")
+              JVM_1_7_PATH
+            else
+              JVM_1_7_25_PATH
+            end
+          else
+            JVM_1_8_PATH
+          end
         end
-      end
 
-    topic "Installing JVM: #{jvm_version}"
-
-    FileUtils.mkdir_p(@vendor_dir)
-    Dir.chdir(@vendor_dir) do
-      @fetcher.fetch_untar("#{jvm_version}.tar.gz")
+      fetch_untar(@fetcher, "#{jvm_version}.tar.gz", jvm_version)
     end
 
     bin_dir = "bin"
     FileUtils.mkdir_p bin_dir
     Dir["#{@vendor_dir}/bin/*"].each do |bin|
       run("ln -s ../#{bin} #{bin_dir}")
+    end
+  end
+
+  def fetch_untar(fetcher, jvm_path, jvm_version=nil)
+    topic "Installing JVM: #{jvm_version || jvm_path}"
+    FileUtils.mkdir_p(@vendor_dir)
+    Dir.chdir(@vendor_dir) do
+      fetcher.fetch_untar(jvm_path)
     end
   end
 end

--- a/spec/helpers/jvm_installer_spec.rb
+++ b/spec/helpers/jvm_installer_spec.rb
@@ -12,6 +12,8 @@ describe "JvmInstall" do
 
         expect(`ls bin`).to match("java")
         expect(`cat release 2>&1`).to match("1.8.0_51")
+
+        ENV['JDK_URL_1_8'] = nil
       end
     end
   end
@@ -19,8 +21,6 @@ describe "JvmInstall" do
   it "downloads standard JDK" do
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
-        ENV['JDK_URL_1_8'] = nil
-
         jvm_installer = LanguagePack::JvmInstaller.new(dir, @stack)
         jvm_installer.install("1.8")
 

--- a/spec/helpers/jvm_installer_spec.rb
+++ b/spec/helpers/jvm_installer_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "JvmInstall" do
+
+  it "downloads custom JDK" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        ENV['JDK_URL_1_8'] = "http://lang-jvm.s3.amazonaws.com/jdk/openjdk1.8.0_51-cedar14.tar.gz"
+
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, @stack)
+        jvm_installer.install("1.8")
+
+        expect(`ls bin`).to match("java")
+        expect(`cat release 2>&1`).to match("1.8.0_51")
+      end
+    end
+  end
+
+  it "downloads standard JDK" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        ENV['JDK_URL_1_8'] = nil
+
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, @stack)
+        jvm_installer.install("1.8")
+
+        expect(`ls bin`).to match("java")
+        expect(`cat release 2>&1`).not_to match("1.8.0_51")
+        expect(`cat release 2>&1`).to match("1.8.0")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Do not merge this until after Oct. 10, 2015**

This allows users to set custom JDK tarballs by setting a config var thusly:

```
$ heroku config:set JDK_URL_1_8="http://lang-jvm.s3.amazonaws.com/jdk/openjdk1.8.0_51-cedar14.tar.gz"
```

This is needed to revert to previous version of the JDK if there is problem with an update.

I know it seems hokey to require the `http://lang-jvm.s3.amazonaws.com/jdk` prefix and then remove it. But this way it ensures parity with the [jvm-common buildpack](https://github.com/heroku/heroku-buildpack-jvm-common) and uses the same `Fetcher` class.