### PR TITLE
Added support for custom JDK versions

### DIFF
--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -4,11 +4,12 @@ class LanguagePack::JvmInstaller
   include LanguagePack::ShellHelpers
 
   SYS_PROPS_FILE  = "system.properties"
-  JVM_BASE_URL    = "http://lang-jvm.s3.amazonaws.com/jdk"
-  JVM_1_8_PATH    = "openjdk1.8-latest"
-  JVM_1_7_PATH    = "openjdk1.7-latest"
-  JVM_1_7_25_PATH = "openjdk1.7.0_25"
-  JVM_1_6_PATH    = "openjdk1.6-latest"
+  JVM_BASE_URL    = "https://lang-jvm.s3.amazonaws.com/jdk"
+  JVM_1_9_PATH    = "openjdk1.9-latest.tar.gz"
+  JVM_1_8_PATH    = "openjdk1.8-latest.tar.gz"
+  JVM_1_7_PATH    = "openjdk1.7-latest.tar.gz"
+  JVM_1_7_25_PATH = "openjdk1.7.0_25.tar.gz"
+  JVM_1_6_PATH    = "openjdk1.6-latest.tar.gz"
 
   def initialize(slug_vendor_jvm, stack)
     @vendor_dir = slug_vendor_jvm
@@ -27,31 +28,26 @@ class LanguagePack::JvmInstaller
   end
 
   def install(jruby_version, forced = false)
-    jvm_version =
-      case system_properties['java.runtime.version']
-      when "1.8"
-        JVM_1_8_PATH
-      when "1.7"
-        JVM_1_7_PATH
-      when "1.6"
-        JVM_1_6_PATH
-      else
-        if @stack == "cedar"
-          if forced || Gem::Version.new(jruby_version) >= Gem::Version.new("1.7.4")
-            JVM_1_7_PATH
-          else
-            JVM_1_7_25_PATH
-          end
+    jvm_version = system_properties['java.runtime.version']
+    case jvm_version
+    when "1.9", "9"
+      fetch_env_untar('JDK_URL_1_9') || fetch_untar(JVM_1_9_PATH, "openjdk-9")
+    when "1.7", "7"
+      fetch_env_untar('JDK_URL_1_7') || fetch_untar(JVM_1_7_PATH, "openjdk-7")
+    when "1.6", "6"
+      fetch_env_untar('JDK_URL_1_6') || fetch_untar(JVM_1_6_PATH, "openjdk-6")
+    when nil
+      if @stack == "cedar"
+        if forced || Gem::Version.new(jruby_version) >= Gem::Version.new("1.7.4")
+          fetch_untar(JVM_1_7_PATH, "openjdk-7")
         else
-          JVM_1_8_PATH
+          fetch_untar(JVM_1_7_25_PATH)
         end
+      else
+      fetch_env_untar('JDK_URL_1_8') || fetch_untar(JVM_1_8_PATH, "openjdk-8")
       end
-
-    topic "Installing JVM: #{jvm_version}"
-
-    FileUtils.mkdir_p(@vendor_dir)
-    Dir.chdir(@vendor_dir) do
-      @fetcher.fetch_untar("#{jvm_version}.tar.gz")
+    else
+      fetch_untar("openjdk#{jvm_version}.tar.gz", "openjdk-#{jvm_version}")
     end
 
     bin_dir = "bin"
@@ -59,5 +55,31 @@ class LanguagePack::JvmInstaller
     Dir["#{@vendor_dir}/bin/*"].each do |bin|
       run("ln -s ../#{bin} #{bin_dir}")
     end
+  end
+
+  def fetch_untar(jvm_path, jvm_version=nil)
+    topic "Installing JVM: #{jvm_version || jvm_path}"
+    FileUtils.mkdir_p(@vendor_dir)
+    Dir.chdir(@vendor_dir) do
+      @fetcher.fetch_untar(jvm_path)
+    end
+  rescue LanguagePack::Fetcher::FetchError
+    error <<EOF
+Failed to download JVM: #{jvm_path}
+
+If this was a custom version or URL, please check to ensure it is correct.
+Otherwise, please open a ticket at http://help.heroku.com so we can help.
+EOF
+  end
+
+  def fetch_env_untar(key)
+    val = env(key)
+    return false unless val
+    path = Pathname.new(val)
+    jvm_version = path.basename.to_s
+    base_url = val[0, val.index(jvm_version)]
+    @fetcher =  LanguagePack::Fetcher.new(base_url)
+    fetch_untar(jvm_version)
+    true
   end
 end

--- a/spec/helpers/jvm_installer_spec.rb
+++ b/spec/helpers/jvm_installer_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe "JvmInstall" do
+
+  it "downloads custom JDK" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        begin
+          ENV['JDK_URL_1_8'] = "http://lang-jvm.s3.amazonaws.com/jdk/openjdk1.8.0_51-cedar14.tar.gz"
+
+          jvm_installer = LanguagePack::JvmInstaller.new(dir, "cedar-14")
+          jvm_installer.install("9.0.1.0")
+
+          expect(`ls bin`).to match("java")
+          expect(`cat release 2>&1`).to match("1.8.0_51")
+        ensure
+          ENV['JDK_URL_1_8'] = nil
+        end
+      end
+    end
+  end
+
+  it "downloads standard JDK 7" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.open('system.properties', 'w') { |f| f.write("java.runtime.version=1.7") }
+
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer.install("9.0.1.0")
+
+        expect(`ls bin`).to match("java")
+        expect(`cat release 2>&1`).not_to match("1.8.0")
+        expect(`cat release 2>&1`).to match("1.7.0")
+      end
+    end
+  end
+
+  it "downloads standard JDK 9" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.open('system.properties', 'w') { |f| f.write("java.runtime.version=1.9") }
+
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer.install("9.0.1.0")
+
+        expect(`ls bin`).to match("java")
+        expect(`cat release 2>&1`).not_to match("1.8.0")
+        expect(`cat release 2>&1`).to match("1.9.0")
+      end
+    end
+  end
+
+  it "downloads previous JDK version" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.open('system.properties', 'w') { |f| f.write("java.runtime.version=1.8.0_51") }
+
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer.install("9.0.1.0")
+
+        expect(`ls bin`).to match("java")
+        expect(`cat release 2>&1`).to match("1.8.0_51")
+      end
+    end
+  end
+
+  it "downloads default JDK" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer.install("9.0.1.0")
+
+        expect(`ls bin`).to match("java")
+        expect(`cat release 2>&1`).not_to match("1.8.0_51")
+        expect(`cat release 2>&1`).to match("1.8.0")
+      end
+    end
+  end
+
+  it "fails download gracefully" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.open('system.properties', 'w') { |f| f.write("java.runtime.version=foobar") }
+
+        jvm_installer = LanguagePack::JvmInstaller.new(dir, "cedar-14")
+
+        expect{ jvm_installer.install("9.0.1.0") }.to raise_error(BuildpackError)
+      end
+    end
+  end
+end

--- a/spec/rubies_spec.rb
+++ b/spec/rubies_spec.rb
@@ -49,7 +49,7 @@ describe "Ruby Versions" do
     app.heroku.put_stack(app.name, 'cedar-14')
 
     app.deploy do |app|
-      expect(app.output).to match("Installing JVM: openjdk1.8-latest")
+      expect(app.output).to match("Installing JVM: openjdk-8")
       expect(app.output).to match("JRUBY_OPTS is:  -Xcompile.invokedynamic=false")
       expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
 
@@ -66,7 +66,7 @@ describe "Ruby Versions" do
     app.heroku.put_stack(app.name, 'cedar-14')
 
     app.deploy do |app|
-      expect(app.output).to match("Installing JVM: openjdk1.7-latest")
+      expect(app.output).to match("Installing JVM: openjdk-7")
       expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
     end
   end


### PR DESCRIPTION
**Do not merge this until after Oct. 10, 2015**

This allows users to set custom JDK versions in the `system.properties` file or define custom tarball URLs by setting a config var.

The supported JDK versions can be set in the `system.properties` like so:

```
java.runtime.version=1.8.0_51
```

The custom URL can be set with an env var thusly:

```
$ heroku config:set JDK_URL_1_8="http://lang-jvm.s3.amazonaws.com/jdk/openjdk1.8.0_51-cedar14.tar.gz"
```
This is needed to revert to previous version of the JDK if there is problem with an update.

The env provides parity with the jvm-common buildpack. The custom version in `system.properties` will be a new feature in jvm-common