### PR TITLE
Add warning if not running on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This is a [Heroku Buildpack](http://devcenter.heroku.com/articles/buildpacks) for Ruby, Rack, and Rails apps. It uses [Bundler](http://gembundler.com) for dependency management.
 
+This buildpack requires 64-bit Linux.
+
 ## Usage
 
 ### Ruby


### PR DESCRIPTION
Hello.

I was attempting to get this buildpack up and running on my Mac, and I did not realize during any part of the process that it only works on 64-bit Linux.

I got this warning during the compilation, and it wasn't that helpful.

```sh
-----> Compiling Ruby/Rack
-----> Using Ruby version: ruby-2.2.3
bash: vendor/ruby-2.2.3/bin/ruby: cannot execute binary file: Exec format error
 !
 !     Problem detecting bundler vendor directory:
 !
```

I eventually ran `file vendor/ruby-2.2.3/bin/ruby` and realized it was an ELF/Linux binary. I facepalmed and proceeded to run my tests in Vagrant.

So maybe it makes sense to add this code? If you prefer to only have the warning in the README, I can edit this PR.

Thanks!