### PR TITLE
Don't force the postgresql addons on Rails apps

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -70,12 +70,6 @@ private
     end
   end
 
-  # most rails apps need a database
-  # @return [Array] shared database addon
-  def add_dev_database_addon
-    ['heroku-postgresql:hobby-dev']
-  end
-
   # sets up the profile.d script for this buildpack
   def setup_profiled
     super


### PR DESCRIPTION
This will revert to the global ruby default where the addon is inserted only
if the app has a 'pg' gem in it's Gemfile.

A rails app which uses an external database like RDS will get it's
config/database.yml overwritten because of the PG addon and this will break
the app. Combined with the fact that the new pipeline feature and the app.json
format has no way of disabling the default addons, it means that new review
apps always get broken by default.