### PR TITLE
Use non default node version for tests

### DIFF
--- a/spec/multibuildpack_spec.rb
+++ b/spec/multibuildpack_spec.rb
@@ -4,7 +4,7 @@ describe "Multibuildpack" do
   it "works with node" do
     Hatchet::Runner.new("node_multi", buildpack_url: "https://github.com/ddollar/heroku-buildpack-multi.git").deploy do |app|
       puts app.output
-      expect(app.output).to match("Node Version in Ruby buildpack is: v0.10.3")
+      expect(app.output).to match("Node Version in Ruby buildpack is: v4.1.2")
     end
   end
 end


### PR DESCRIPTION
Previously we were checking for a custom version that coincidentally matched the default version of node that the ruby buildpack was using. This was a mistake and not noticed when the default version was rev-d. The fixture has been updated to use 4.1.2.