### PR TITLE
Replace JAVA_TOOL_OPTIONS with JAVA_MEM to avoid JRuby overriding

### DIFF
--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -59,7 +59,6 @@ class LanguagePack::JvmInstaller
 
   def fetch_untar(jvm_path, jvm_version=nil)
     topic "Installing JVM: #{jvm_version || jvm_path}"
-    puts "Setting JAVA_TOOL_OPTIONS for dyno size. Use JRUBY_BUILD_OPTS to override."
 
     FileUtils.mkdir_p(@vendor_dir)
     Dir.chdir(@vendor_dir) do

--- a/spec/rubies_spec.rb
+++ b/spec/rubies_spec.rb
@@ -50,7 +50,6 @@ describe "Ruby Versions" do
 
     app.deploy do |app|
       expect(app.output).to match("Installing JVM: openjdk-8")
-      expect(app.output).to match("Picked up JAVA_TOOL_OPTIONS: -Xmx2048m")
       expect(app.output).to match("JRUBY_OPTS is:  -Xcompile.invokedynamic=false")
       expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
 


### PR DESCRIPTION
After doing a bit of profiling, I found that JRuby overrides JAVA_TOOL_OPTIONS on it's own (without users setting JAVA_OPTS manually). I've replaced it with JAVA_MEM, which will [override JAVA_OPTS](https://github.com/jruby/jruby/blob/master/bin/jruby.sh#L267) but will also be [overriden by JRUBY_OPTS](https://github.com/jruby/jruby/blob/master/bin/jruby.sh#L171). For that reason, I've added a guard to prevent JAVA_MEM from overriding any Xmx setting in JAVA_OPTS.

This PR will need to accompanied by updates to the docs, but users should not be drastically affected, and will likely see performance improvements during the build.