### PR TITLE
Add retry to `bundle install`

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -542,7 +542,7 @@ WARNING
       log("bundle") do
         bundle_without = env("BUNDLE_WITHOUT") || "development:test"
         bundle_bin     = "bundle"
-        bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
+        bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path} --retry 3"
         bundle_command << " -j4"
 
         if bundler.windows_gemfile_lock?


### PR DESCRIPTION
It’d be nice that `bundle install` can retry a bit instead of failing the deployment.

Related: https://github.com/heroku/api/issues/5129.