### PR TITLE
Java Memory should use the default 384m

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -220,7 +220,7 @@ EOF
   def set_java_mem
     <<-EOF
 if ! [[ "${JAVA_OPTS}" == *-Xmx* ]]; then
-  export JAVA_MEM=${JAVA_MEM:--Xmx${JVM_MAX_HEAP}m}
+  export JAVA_MEM=${JAVA_MEM:--Xmx${JVM_MAX_HEAP:-384}m}
 fi
 EOF
   end


### PR DESCRIPTION
Java Memory should use the default 384m when setting the JAVA_MEM env variable. This is in regards to [issue #437](https://github.com/heroku/heroku-buildpack-ruby/issues/437)

Signed-off-by: @bdshroyer