### PR TITLE
Support local builds via BUNDLE_LOCAL env variable

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -544,6 +544,7 @@ WARNING
         bundle_bin     = "bundle"
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
         bundle_command << " -j4"
+        bundle_command << " --local" if env("BUNDLE_LOCAL")
 
         if bundler.windows_gemfile_lock?
           warn(<<-WARNING, inline: true)


### PR DESCRIPTION
Projects that use `bundle package` should not connect to rubygems for installations.  If BUNDLE_LOCAL flag is set, install gems without network calls.