### PR TITLE
Instruct curl to follow redirects.

### DIFF
--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -31,7 +31,7 @@ module LanguagePack
 
     private
     def curl_command(command)
-      "set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
+      "set -o pipefail; curl -L --fail --retry 3 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
     end
 
     def curl_timeout_in_seconds


### PR DESCRIPTION
The curl command is able to follow redirects but this option was not used previously. Since redirects are a fundamental aspect of how things work on the internet, it would be super helpful to use this.

Thanks! :heart: 