### PR TITLE
Added pgconfig jar to JDK for JRuby JDBC

### DIFF
--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -11,6 +11,8 @@ class LanguagePack::JvmInstaller
   JVM_1_7_25_PATH = "openjdk1.7.0_25.tar.gz"
   JVM_1_6_PATH    = "openjdk1.6-latest.tar.gz"
 
+  PG_CONFIG_JAR   = "https://lang-jvm.s3.amazonaws.com/pgconfig.jar"
+
   def initialize(slug_vendor_jvm, stack)
     @vendor_dir = slug_vendor_jvm
     @stack = stack
@@ -60,6 +62,8 @@ class LanguagePack::JvmInstaller
     Dir["#{@vendor_dir}/bin/*"].each do |bin|
       run("ln -s ../#{bin} #{bin_dir}")
     end
+
+    install_pgconfig_jar(PG_CONFIG_JAR)
   end
 
   def fetch_untar(jvm_path, jvm_version=nil)
@@ -87,5 +91,9 @@ EOF
     @fetcher =  LanguagePack::Fetcher.new(base_url)
     fetch_untar(jvm_version)
     true
+  end
+
+  def install_pgconfig_jar(url)
+    run("curl --retry 3 -s -L #{url} -o #{@vendor_dir}/jre/lib/ext/pgconfig.jar")
   end
 end

--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -4,19 +4,21 @@ class LanguagePack::JvmInstaller
   include LanguagePack::ShellHelpers
 
   SYS_PROPS_FILE  = "system.properties"
-  JVM_BASE_URL    = "https://lang-jvm.s3.amazonaws.com/jdk"
+  JVM_BUCKET      = "https://lang-jvm.s3.amazonaws.com"
+  JVM_BASE_URL    = "#{JVM_BUCKET}/jdk"
   JVM_1_9_PATH    = "openjdk1.9-latest.tar.gz"
   JVM_1_8_PATH    = "openjdk1.8-latest.tar.gz"
   JVM_1_7_PATH    = "openjdk1.7-latest.tar.gz"
   JVM_1_7_25_PATH = "openjdk1.7.0_25.tar.gz"
   JVM_1_6_PATH    = "openjdk1.6-latest.tar.gz"
 
-  PG_CONFIG_JAR   = "https://lang-jvm.s3.amazonaws.com/pgconfig.jar"
+  PG_CONFIG_JAR   = "pgconfig.jar"
 
   def initialize(slug_vendor_jvm, stack)
     @vendor_dir = slug_vendor_jvm
     @stack = stack
     @fetcher = LanguagePack::Fetcher.new(JVM_BASE_URL, stack)
+    @pg_config_jar_fetcher = LanguagePack::Fetcher.new(JVM_BUCKET)
   end
 
   def system_properties
@@ -63,7 +65,7 @@ class LanguagePack::JvmInstaller
       run("ln -s ../#{bin} #{bin_dir}")
     end
 
-    install_pgconfig_jar(PG_CONFIG_JAR)
+    install_pgconfig_jar
   end
 
   def fetch_untar(jvm_path, jvm_version=nil)
@@ -93,7 +95,12 @@ EOF
     true
   end
 
-  def install_pgconfig_jar(url)
-    run("curl --retry 3 -s -L #{url} -o #{@vendor_dir}/jre/lib/ext/pgconfig.jar")
+  def install_pgconfig_jar
+    jdk_ext_dir="#{@vendor_dir}/jre/lib/ext"
+    if Dir.exist?(jdk_ext_dir)
+      Dir.chdir(jdk_ext_dir) do
+        @pg_config_jar_fetcher.fetch(PG_CONFIG_JAR)
+      end
+    end
   end
 end

--- a/spec/helpers/jvm_installer_spec.rb
+++ b/spec/helpers/jvm_installer_spec.rb
@@ -73,6 +73,7 @@ describe "JvmInstall" do
         expect(`ls bin`).to match("java")
         expect(`cat release 2>&1`).not_to match("1.8.0_51")
         expect(`cat release 2>&1`).to match("1.8.0")
+        expect(`ls #{dir}/jre/lib/ext`).to match("pgconfig.jar")
       end
     end
   end

--- a/spec/jvm_spec.rb
+++ b/spec/jvm_spec.rb
@@ -11,6 +11,7 @@ describe "JvmInstaller" do
     app.deploy do |app|
       expect(app.output).to match("Using pre-installed JDK")
       expect(app.run("java -version")).to match("1.8.0")
+      expect(app.run("ls .jdk/jre/lib/ext")).to match("pgconfig.jar")
     end
   end
 end

--- a/spec/rubies_spec.rb
+++ b/spec/rubies_spec.rb
@@ -57,6 +57,8 @@ describe "Ruby Versions" do
       app.set_config("JRUBY_BUILD_OPTS" => "--dev")
       app.push!
       expect(app.output).to match("JRUBY_OPTS is:  --dev")
+
+      expect(app.run("ls vendor/jvm/jre/lib/ext")).to match("pgconfig.jar")
     end
   end
 


### PR DESCRIPTION
This change is necessary to support new dedicated single-tenant instances of postgres that require an SSL connection. By default the Postgres JDBC driver defaults to using an unencrypted connection. 

This change has already been rolled out for Java, Scala, Clojure and Groovy apps. For more information [read this  blog post](http://jkutner.github.io/2016/01/12/postgres-ssl.html).

/cc @neovintage 