### PR TITLE
change default ruby to 2.2.4 from 2.0.0

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
   BUNDLER_VERSION      = "1.9.7"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
-  DEFAULT_RUBY_VERSION = "ruby-2.0.0"
+  DEFAULT_RUBY_VERSION = "ruby-2.2.4"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"
 


### PR DESCRIPTION
Ruby 2.0.0 is being sunset on Feb. 24, 2016. This changes the default
for new apps that haven't set a ruby in their Gemfile. By doing so, we
won't be putting users on a Ruby being sunset soon.

In addition to Ruby being sunset, Rails 5 beta needs a newer Ruby as
well.

This replaces #441 with 2.2.4 instead of 2.2.3.