### PR TITLE
[close #358] Fail on Rake detect for Rails Apps

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -49,7 +49,9 @@
     "sharpstone/rails3_12factor",
     "sharpstone/rails3_one_plugin",
     "sharpstone/rails3_runtime_assets",
-    "sharpstone/rails3-fail-assets-compile"
+    "sharpstone/rails3-fail-assets-compile",
+    "sharpstone/rails3-fail-rakefile"
+
   ],
   "rails4": [
     "sharpstone/rails4-manifest",

--- a/lib/language_pack/helpers/rake_runner.rb
+++ b/lib/language_pack/helpers/rake_runner.rb
@@ -1,6 +1,9 @@
 class LanguagePack::Helpers::RakeRunner
   include LanguagePack::ShellHelpers
 
+  class CannotLoadRakefileError < StandardError
+  end
+
   class RakeTask
     ALLOWED = [:pass, :fail, :no_load, :not_found]
     include LanguagePack::ShellHelpers
@@ -59,8 +62,8 @@ class LanguagePack::Helpers::RakeRunner
   end
 
   def initialize(has_rake_gem = true)
-    @has_rake = has_rake_gem && has_rakefile?
-    if !@has_rake
+    @has_rake_gem = has_rake_gem
+    if !has_rake_installed?
       @rake_tasks    = ""
       @rakefile_can_load = false
     end
@@ -86,13 +89,20 @@ class LanguagePack::Helpers::RakeRunner
     end
   end
 
-  def load_rake_tasks!(options = {})
-    out =  load_rake_tasks(options)
-    msg =  "Could not detect rake tasks\n"
-    msg << "ensure you can run `$ bundle exec rake -P` against your app with no environment variables present\n"
-    msg << "and using the production group of your Gemfile.\n"
-    msg << out
-    puts msg if cannot_load_rakefile?
+  def load_rake_tasks!(options = {}, raise_on_fail = false)
+    return if !has_rake_installed?
+
+    out = load_rake_tasks(options)
+
+    if cannot_load_rakefile?
+      msg =  "Could not detect rake tasks\n"
+      msg << "ensure you can run `$ bundle exec rake -P` against your app\n"
+      msg << "and using the production group of your Gemfile.\n"
+      msg << out
+      raise CannotLoadRakefileError, msg if raise_on_fail
+      puts msg
+    end
+
     return self
   end
 
@@ -115,6 +125,10 @@ class LanguagePack::Helpers::RakeRunner
 
   def invoke(task, options = {})
     self.task(task, options).invoke
+  end
+
+  def has_rake_installed?
+    @has_rake ||= (@has_rake_gem && has_rakefile?)
   end
 
 private

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -725,9 +725,12 @@ params = CGI.parse(uri.query || "")
 
   def rake
     @rake ||= begin
-      LanguagePack::Helpers::RakeRunner.new(
-                bundler.has_gem?("rake") || ruby_version.rake_is_vendored?
-              ).load_rake_tasks!(env: rake_env)
+      rake_gem_available = bundler.has_gem?("rake") || ruby_version.rake_is_vendored?
+      raise_on_fail      = bundler.gem_version('railties') && bundler.gem_version('railties') < Gem::Version.new('3.x')
+
+      rake = LanguagePack::Helpers::RakeRunner.new(rake_gem_available)
+      rake.load_rake_tasks!({ env: rake_env }, raise_on_fail)
+      rake
     end
   end
 

--- a/spec/rails3_spec.rb
+++ b/spec/rails3_spec.rb
@@ -42,6 +42,13 @@ describe "Rails 3.x" do
     end
   end
 
+  it "fails if rake tasks cannot be detected" do
+    Hatchet::Runner.new("rails3-fail-rakefile", allow_failure: true).deploy do |app|
+      expect(app.output).to include("raising so the rake task will not load")
+      expect(app).not_to be_deployed
+    end
+  end
+
   it "fails compile if assets:precompile fails" do
     Hatchet::Runner.new("rails3-fail-assets-compile", allow_failure: true).deploy do |app, heroku|
       expect(app.output).to include("raising on assets:precompile on purpose")


### PR DESCRIPTION
Rails applications should be reasonably expected to run `rake` when a Rakefile is present.

Right now this is the behavior we support https://github.com/heroku/heroku-buildpack-ruby/issues/358#issuecomment-90250883. While it might be reasonable that a Ruby application might not expect us to run Rake, a Rails app with the asset pipeline, while they might not be using the asset pipeline, should be able to run the `rake` command when a Rakefile is present.