### PR TITLE
Special Bundler Warning

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -89,6 +89,8 @@ WARNING
       # check for new app at the beginning of the compile
       new_app?
       Dir.chdir(build_path)
+      @old_bundler_version = @metadata.read(bundler_version_cache)
+
       remove_vendor_bundle
       install_ruby
       install_jvm
@@ -106,6 +108,17 @@ WARNING
       best_practice_warnings
       super
     end
+  rescue => e
+    if @old_bundler_version && @old_bundler_version != BUNDLER_VERSION
+      warn(<<-WARNING)
+An error occured while deploying using bundler #{ BUNDLER_VERSION }.
+Previously you had a successful deploy with bundler #{ @old_bundler_version }.
+
+If you believe the failure related to the bundler version change please refer to:
+https://devcenter.heroku.com/articles/bundler-version
+WARNING
+    end
+    raise e
   end
 
 private


### PR DESCRIPTION
If a build fails on the compile that we first try to upgrade a bundler version on an app call that out as a possible reason and link to article telling them how to try a previous bundler version.