### PR TITLE
Platform changes prevent unacceptable env vars

### DIFF
--- a/spec/user_env_compile_edge_case_spec.rb
+++ b/spec/user_env_compile_edge_case_spec.rb
@@ -16,14 +16,4 @@ describe "User env compile" do
       expect(app.output).to match("Asset precompilation completed")
     end
   end
-
-  it "allows weird characters in the env" do
-    app = Hatchet::Runner.new("rails41_scaffold")
-    app.setup!
-    app.set_config("BAD VALUE"      => %Q{ )(*&^%$#'$'\n''@!~\'\ })
-    app.set_config(%Q{ un"matched } => "bad key" )
-    app.deploy do |app|
-      expect(app.output).to match("Launching")
-    end
-  end
 end


### PR DESCRIPTION
Due to platform changes we can no longer set weird env var names. This test was for a very intermittent problem not likely to reproduce again, we can safely get rid of this test for now and reintroduce if needed.

Originally introduced in 

- https://github.com/heroku/heroku-buildpack-ruby/pull/229
- https://github.com/heroku/heroku-buildpack-ruby/commit/8b6126f1497a85dff8b897bf0426b5d8333c6d7f