### PR TITLE
Warn on .bundle/config file presence

### DIFF
--- a/lib/language_pack/helpers/bundler_cache.rb
+++ b/lib/language_pack/helpers/bundler_cache.rb
@@ -41,7 +41,6 @@ class LanguagePack::BundlerCache
 
   # writes cache contents to cache store
   def store
-    @cache.store(".bundle")
     @cache.store(@bundler_dir, @stack_dir)
   end
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -544,6 +544,16 @@ WARNING
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
         bundle_command << " -j4"
 
+        if File.exist?("#{Dir.pwd}/.bundle/config")
+          warn(<<-WARNING, inline: true)
+You have the `.bundle/config` file checked into your repository
+ It contains local state like the location of the installed bundle
+ as well as configured git local gems, and other settings that should
+not be shared between multiple checkouts of a single repo. Please
+remove the `.bundle/` folder from your repo and add it to your `.gitignore` file.
+WARNING
+        end
+
         if bundler.windows_gemfile_lock?
           warn(<<-WARNING, inline: true)
 Removing `Gemfile.lock` because it was generated on Windows.
@@ -558,7 +568,6 @@ WARNING
         else
           # using --deployment is preferred if we can
           bundle_command += " --deployment"
-          cache.load ".bundle"
         end
 
         topic("Installing dependencies using bundler #{bundler.version}")
@@ -837,7 +846,6 @@ params = CGI.parse(uri.query || "")
       old_stack = @metadata.read(stack_cache).chomp if @metadata.exists?(stack_cache)
       old_stack ||= DEFAULT_LEGACY_STACK
 
-
       if old_bundler_version && old_bundler_version != BUNDLER_VERSION
         puts(<<-WARNING)
 Your app was upgraded to bundler #{ BUNDLER_VERSION }.
@@ -848,8 +856,6 @@ https://devcenter.heroku.com/articles/bundler-version
 
 WARNING
       end
-
-
 
       stack_change  = old_stack != @stack
       convert_stack = @bundler_cache.old?


### PR DESCRIPTION
Discussion at https://github.com/bundler/bundler/issues/4351#issuecomment-194490139

Also do not load the stored `.bundle` directory. We are passing in all the flags that we need to `bundle install`. If we also store a `.bundle/config` file between builds than if you accidentally include `.bundle/config` file in your repo with a `BUNDLE_WITHOUT` value ,it will get persisted to the `.bundle/config` file to the cache and deleting the file from your repo does not get rid of the problem. The config is un-needed, since we're using all flags all the time, let's not rely on the `.bundle/config` file.