### PR TITLE
add mirror function for ruby source

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -539,6 +539,19 @@ WARNING
     "vendor/bundle/bin"
   end
 
+  def gem_source_http
+    "http://rubygems.org"
+  end
+
+  def gem_source_https
+    "https://rubygems.org"
+  end
+
+  def mirror(mirror_param)
+    return !ENV[mirror_param].to_s.empty?
+  end
+
+
   # runs bundler to install the dependencies
   def build_bundler
     instrument 'ruby.build_bundler' do
@@ -601,6 +614,26 @@ WARNING
             "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true"
           }
           env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
+          
+          #Add mirror support
+          if mirror("GEM_SOURCE_MIRROR_HTTP")
+            instrument "ruby.bundle_config" do
+              mirror_command = "#{bundle_bin} config mirror.#{gem_source_http} #{ENV['GEM_SOURCE_MIRROR_HTTP']}"
+              puts "Running: #{mirror_command}"
+              bundle_config_mirror = run_no_pipe("#{mirror_command}", env: env_vars, user_env: true)
+              error "Problem detecting bundler config mirror.http: #{bundle_config_mirror}" unless $?.success?
+            end
+          end
+          if mirror("GEM_SOURCE_MIRROR_HTTPS")
+            instrument "ruby.bundle_config" do
+              mirror_command = "#{bundle_bin} config mirror.#{gem_source_https} #{ENV['GEM_SOURCE_MIRROR_HTTPS']}"
+              puts "Running: #{mirror_command}"   
+              bundle_config_mirror = run_no_pipe("#{mirror_command}", env: env_vars, user_env: true)
+              error "Problem detecting bundler config mirror.https: #{bundle_config_mirror}" unless $?.success?
+            end
+          end
+
+          
           puts "Running: #{bundle_command}"
           instrument "ruby.bundle_install" do
             bundle_time = Benchmark.realtime do


### PR DESCRIPTION
This request is to add source mirror function during staging. If user sets environment GEM_SOURCE_MIRROR_HTTP or GEM_SOURCE_MIRROR_HTTPS, the mirror config will be triggered. This function can be helpful in some places where the network access to "rubygems.org" is blocked, a mirror in local would be a good option.