### PR TITLE
Allow custom asset prefix for rails 4 and up

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -69,7 +69,7 @@ WARNING
   def run_assets_precompile_rake_task
     instrument "rails4.run_assets_precompile_rake_task" do
       log("assets_precompile") do
-        if Dir.glob("public/assets/{.sprockets-manifest-*.json,manifest-*.json}", File::FNM_DOTMATCH).any?
+        if Dir.glob(["public/**/*/{.sprockets-manifest-*.json,manifest-*.json}"], File::FNM_DOTMATCH).any?
           puts "Detected manifest file, assuming assets were compiled locally"
           return true
         end


### PR DESCRIPTION
# Heroku ruby buildpack and assets in custom path

Although most developera will let heroku handle compiling their assets there are some use cases when precompiling your assets locally make sense.

By default the heroku buildpack for ruby checks in the  **public/assets** directory for a manifest. If a manifest is found it is assumed that assets are already compiled and this step of the [compile step](https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/rails4.rb#L72) is skipped.

With the default rails settings this works out of the box. However if you use the *config.assets.prefix* setting as described in the [Rails documentation](http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets) this stops working.

The build pack only check in the **public/assets** directory so if the manifest is saved in an other directory it will not be detected and thus assets will always be compiled during deploy.

I created a little example app to showcase current and (in my eyes) desired behaviour.

## Current behaviour - default settings

```
git clone git@github.com:dennisvdvliet/heroku-buildpack-rails-demo.git
git checkout current-behaviour-default-settings
heroku create
git push heroku current-behaviour-default-settings:master
```

This will trigger a build on heroku and after installing your gems you will see this in the log.

```
remote:        Cleaning up the bundler cache.
remote:        Detected manifest file, assuming assets were compiled locally
```

## Current behaviour - custom prefix

Now we alter application.rb and add

```ruby
config.assets.prefix = '/custom/path'
```

Assets will now be precompiled in **public/custom/path**
Now push to heroku again.

```
git checkout current-behaviour-custom-prefix
git push heroku current-behaviour-custom-prefix:master --force
```

This will result in the following log message, that clearly tells us that the precompiled assets were ignored.

```
remote: -----> Preparing app for Rails asset pipeline
remote:        Running: rake assets:precompile
remote:        Asset precompilation completed (1.52s)
remote:        Cleaning assets
```

## Desired behaviour

For this I made a small change to the [buildpack](https://github.com/dennisvdvliet/heroku-buildpack-ruby/commit/87f3aa169818c88d6dd09a1663c1f1cc6a779a2e) to scan the **public** and subdirectories directory for the manifest.

```
heroku create --buildpack https://github.com/dennisvdvliet/heroku-buildpack-ruby.git#rails-asset-prefix rails-asset-prefix
heroku git:remote --app rails-asset-prefix --remote rails-asset-prefix
git push rails-asset-prefix current-behaviour-custom-prefix:master --force
```

Checking the output from the deploy log confirms that this does what is expected.

```
remote:        Bundle completed (26.14s)
remote:        Cleaning up the bundler cache.
remote:        Detected manifest file, assuming assets were compiled locally
```

I'm no buildpack expert so happy to hear what the rest of you think about this.