### PR TITLE
Removed hard-coded error about Ruby 2.1

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -403,9 +403,9 @@ ERROR
       message = <<ERROR
 An error occurred while installing Ruby #{ruby_version.version}
 For supported Ruby versions see https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
-Note: Only the most recent version of Ruby #{ruby_version.version.match(/(\d\.\d)/)[0]} is supported on Cedar-14
 #{error.message}
 ERROR
+      message << "Note: Only the most recent version of Ruby 2.1 is supported on Cedar-14" if ruby_version.version.match(/(\d\.\d)/)[0] == "2.1"
     end
     error message
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -403,7 +403,7 @@ ERROR
       message = <<ERROR
 An error occurred while installing Ruby #{ruby_version.version}
 For supported Ruby versions see https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
-Note: Only the most recent version of Ruby 2.1 is supported on Cedar-14
+Note: Only the most recent version of Ruby #{ruby_version.version.match(/(\d\.\d)/)[0]} is supported on Cedar-14
 #{error.message}
 ERROR
     end


### PR DESCRIPTION
```
irb(main):012:0> version = "ruby-2.3.0-p0"
=> "ruby-2.3.0-p0"
irb(main):013:0> version.match(/(\d\.\d)/)[0]
=> "2.3"
```

New string will read: 

> Note: Only the most recent version of Ruby 2.3 is supported on Cedar-14

