### PR TITLE
Revert "Revert "Bump bundler 1.12.5""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Bump bundler to 1.12.5 [Bundler changfelog](https://github.com/bundler/bundler/blob/master/CHANGELOG.md#1123-2016-05-06). Allows for use of Ruby version operators.
+
 ## v146 (03/23/2016)
 
 * Warn when `.bundle/config` is checked in (#471)

--- a/hatchet.json
+++ b/hatchet.json
@@ -14,10 +14,12 @@
   ],
   "bundler": [
     "sharpstone/bad_gemfile_on_platform",
+    "sharpstone/problem_gemfile_version",
     "sharpstone/git_gemspec",
     "sharpstone/no_lockfile",
     "sharpstone/sqlite3_gemfile",
-    "sharpstone/nokogiri_160"
+    "sharpstone/nokogiri_160",
+    "sharpstone/bundle-ruby-version-not-in-lockfile"
   ],
   "ruby": [
     "sharpstone/mri_187",

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -31,7 +31,7 @@ module LanguagePack
 
     private
     def curl_command(command)
-      "set -o pipefail; curl -L --fail --retry 3 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
+      "set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
     end
 
     def curl_timeout_in_seconds

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -38,6 +38,21 @@ module LanguagePack
       @version_without_patchlevel = @version.sub(/-p[\d]+/, '')
     end
 
+    # https://github.com/bundler/bundler/issues/4621
+    def version_for_download
+      if patchlevel_is_significant?
+        @version
+      else
+        version_without_patchlevel
+      end
+    end
+
+    # Before Ruby 2.1 patch releases were done via patchlevel i.e. 1.9.3-p426 versus 1.9.3-p448
+    # With 2.1 and above patches are released in the "minor" version instead i.e. 2.1.0 versus 2.1.1
+    def patchlevel_is_significant?
+      Gem::Version.new(self.ruby_version) <= Gem::Version.new("2.1")
+    end
+
     def rake_is_vendored?
       Gem::Version.new(self.ruby_version) >= Gem::Version.new("1.9")
     end

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -30,6 +30,15 @@ describe "BundlerWrapper" do
       @bundler.install
     end
 
+    it "handles apps with ruby versions locked in Gemfile.lock" do
+      Hatchet::App.new("problem_gemfile_version").in_directory do |dir|
+        expect(@bundler.ruby_version).to eq("ruby-2.3.0-p0")
+
+        ruby_version = LanguagePack::RubyVersion.new(@bundler.ruby_version, is_new: true)
+        expect(ruby_version.version_for_download).to eq("ruby-2.3.0")
+      end
+    end
+
     it "handles JRuby pre gemfiles" do
       Hatchet::App.new("jruby-minimal").in_directory do |dir|
         expect(@bundler.ruby_version).to eq("ruby-2.2.0-jruby-9.0.0.0.pre1")

--- a/spec/rails4_spec.rb
+++ b/spec/rails4_spec.rb
@@ -40,7 +40,6 @@ describe "Rails 4.0.x" do
   #   Hatchet::Runner.new("rails4_windows_mri193").deploy do |app, heroku|
   #     result = app.run("rails -v")
   #     expect(result).to match("4.0.0")
-
   #     result = app.run("rake -T")
   #     expect(result).to match("assets:precompile")
 

--- a/spec/ruby_spec.rb
+++ b/spec/ruby_spec.rb
@@ -1,6 +1,20 @@
 require_relative 'spec_helper'
 
 describe "Ruby apps" do
+  describe "bundler ruby version matcher" do
+    it "installs a version even when not present in the Gemfile.lock" do
+      Hatchet::Runner.new('bundle-ruby-version-not-in-lockfile').deploy do |app|
+        expect(app.output).to         match("2.3.1")
+        expect(app.run("ruby -v")).to match("2.3.1")
+      end
+    end
+
+    it "works even when patchfile is specified" do
+      Hatchet::Runner.new('problem_gemfile_version').deploy do |app|
+        expect(app.output).to match("2.3.0")
+      end
+    end
+  end
 
   # describe "default WEB_CONCURRENCY" do
   #   it "auto scales WEB_CONCURRENCY" do


### PR DESCRIPTION
This reverts commit 088683acf9f6edde85179061480ec1850956cc2f.

This PR bumps up the version of bundler to 1.12.5 which allows us to use Ruby version specifiers.

Due to change in behavior in bundler https://github.com/bundler/bundler/issues/4621 we must now detect the when patchlevel is not needed and strip it everywhere we were previously using a version.

Right now there is no way to know when a bundle platform failed with an invalid output, it doesn't do Ruby version validations so if you put "2.3.x" in your Gemfile, then it will return `ruby 2.3.x` back out at you which isn't a valid version and we can't download it. 

I'm going to update the "specify a ruby version" docs to include the ruby version specifiers. I've made this error when a build fails a bit cleaner. We're now only warning about Ruby 2.1 when they're trying to use Ruby 2.1. Also i'm identifying the curl output as "debug information" so hopefully fewer people will think that there is some really strange buildpack error and instead focus on our well written message with links. 

I would like to call out that for failed downloads people should try to re-deploy before declaring it a lost cause, but that's a bit too verbose for writing in an encyclopedic way inside the error output. Think most people will retry anyway. I'm also bumping up the retries to 5, because why not? It might mean that people deploying bad versions of Ruby get delayed by an extra 2 seconds, but hopefully it will cut down on the number of tickets that are solved by people re-running the deploy.