### PR TITLE
Announce when we detect Rake tasks

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -747,6 +747,7 @@ params = CGI.parse(uri.query || "")
       rake_gem_available = bundler.has_gem?("rake") || ruby_version.rake_is_vendored?
       raise_on_fail      = bundler.gem_version('railties') && bundler.gem_version('railties') > Gem::Version.new('3.x')
 
+      topic "Detecting rake tasks"
       rake = LanguagePack::Helpers::RakeRunner.new(rake_gem_available)
       rake.load_rake_tasks!({ env: rake_env }, raise_on_fail)
       rake


### PR DESCRIPTION
Right now people are putting infinite scripts in their rakefile and it looks like it's getting stuck in `bundle clean` when it should look like it's getting stuck while detecting rake tasks.
