### PR TITLE
Initialize env before detecting the app type

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,8 +9,8 @@ require "language_pack/shell_helpers"
 
 begin
   LanguagePack::Instrument.trace 'compile', 'app.compile' do
+    LanguagePack::ShellHelpers.initialize_env(ARGV[2])
     if pack = LanguagePack.detect(ARGV[0], ARGV[1])
-      LanguagePack::ShellHelpers.initialize_env(ARGV[2])
       pack.topic("Compiling #{pack.name}")
       pack.log("compile") do
         pack.compile


### PR DESCRIPTION
Detecting the app type requires bundler, which makes a curl call.
Initializing the env after means we cannot override CURL_CONNECT_TIMEOUT or CURL_TIMEOUT.