### PR TITLE
Use ShellHelper#env in language pack fetcher

### DIFF
--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -35,11 +35,11 @@ module LanguagePack
     end
 
     def curl_timeout_in_seconds
-      ENV['CURL_TIMEOUT'] || 30
+      env('CURL_TIMEOUT') || 30
     end
 
     def curl_connect_timeout_in_seconds
-      ENV['CURL_CONNECT_TIMEOUT'] || 3
+      env('CURL_CONNECT_TIMEOUT') || 3
     end
 
     def load_config


### PR DESCRIPTION
This complements #509.

Custom env vars aren't set into the global `ENV` variable.
Without this change, we can't set custom CURL timeouts in curl requests.