### PR TITLE
[close #507] Show bundler warning earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Guarantee we always show warning when upgrading bundler version.
+
 ## v148 (11/17/2016)
 
 * Default Ruby Version is 2.2.6

--- a/hatchet.json
+++ b/hatchet.json
@@ -29,6 +29,7 @@
     "sharpstone/ruby_193_jruby_17161",
     "sharpstone/ruby_193_jruby_17161_jdk7",
     "sharpstone/ruby_193_jruby_17161_jdk8",
+    "sharpstone/ruby_193_bad_patch_cedar_14",
     "sharpstone/jruby-minimal",
     "sharpstone/empty-procfile",
     "sharpstone/bad_ruby_version",

--- a/spec/ruby_spec.rb
+++ b/spec/ruby_spec.rb
@@ -57,6 +57,14 @@ describe "Ruby apps" do
     end
   end
 
+  describe "bundler upgrade warning" do
+    it "Shows when using a bad patch level of Ruby" do
+      Hatchet::Runner.new("ruby_193_bad_patch_cedar_14").deploy do |app, heroku|
+        expect(app.output).to include("Your app was upgraded to bundler")
+      end
+    end
+  end
+
   describe "database configuration" do
     context "no active record" do
       it "writes a heroku specific database.yml" do


### PR DESCRIPTION
We should be showing a bundler upgrade warning as soon as possible. Currently if you select a "bad" version of ruby in your Gemfile.lock you will not get this error. This is a problem for users who are running into https://devcenter.heroku.com/articles/bundler-version#known-upgrade-issues, while the bug is well known and documented, they're not being directed to that page. 

This patch will emit an upgrade warning for bundler before we even try downloading it. This should ensure the warning is always present in build outputs.