### PR TITLE
Fix initialize_env fails if env path contains a directory

### DIFF
--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -33,9 +33,10 @@ module LanguagePack
     def self.initialize_env(path)
       env_dir = Pathname.new("#{path}")
       if env_dir.exist? && env_dir.directory?
-        env_dir.each_child do |file|
-          key   = file.basename.to_s
-          value = file.read.strip
+        env_dir.each_child do |child|
+          next unless child.file?
+          key   = child.basename.to_s
+          value = child.read.strip
           user_env_hash[key] = value unless blacklist?(key)
         end
       end


### PR DESCRIPTION
The method initialize_env assumes that the env path argument contains only files, this is causing an exception in a deis/kubernetes environment. This is very dependent on the environment where the buildpack is used and it probably only affects Deis setups. Still it seems reasonable to check if each path is a file before trying to read the contents.