### PR TITLE
Ruby Preview Relase compatibility with Gemfile.lock

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -100,7 +100,7 @@ class LanguagePack::Helpers::BundlerWrapper
       if output.match(/No ruby version specified/)
         ""
       else
-        output.chomp.sub('(', '').sub(')', '').sub(/(p\d+)/, ' \1').split.join('-')
+        output.chomp.sub('(', '').sub(')', '').sub(/(p-?\d+)/, ' \1').split.join('-')
       end
     end
   end

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -18,7 +18,7 @@ module LanguagePack
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}"
     RUBY_VERSION_REGEX     = %r{
         (?<ruby_version>\d+\.\d+\.\d+){0}
-        (?<patchlevel>p\d+){0}
+        (?<patchlevel>p-?\d+){0}
         (?<engine>\w+){0}
         (?<engine_version>.+){0}
 
@@ -35,12 +35,12 @@ module LanguagePack
       set_version
       parse_version
 
-      @version_without_patchlevel = @version.sub(/-p[\d]+/, '')
+      @version_without_patchlevel = @version.sub(/-p-?\d+/, '')
     end
 
     # https://github.com/bundler/bundler/issues/4621
     def version_for_download
-      if patchlevel_is_significant?
+      if patchlevel_is_significant? && @patchlevel.sub(/p/, '').to_i >= 0
         @version
       else
         version_without_patchlevel

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -28,6 +28,14 @@ describe "RubyVersion" do
     end
   end
 
+  it "does not include patchlevels when the patchlevel is negative for download" do
+    ruby_version = LanguagePack::RubyVersion.new("ruby-2.0.0-p-1")
+    expect(ruby_version.version_for_download).to eq("ruby-2.0.0")
+
+    ruby_version = LanguagePack::RubyVersion.new("ruby-2.4.0-p-1")
+    expect(ruby_version.version_for_download).to eq("ruby-2.4.0")
+  end
+
   it "correctly sets ruby version for bundler specified versions" do
     Hatchet::App.new("mri_193").in_directory do |dir|
       ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)


### PR DESCRIPTION
Since #502, the ruby version is now being pulled from the `Gemfile.lock` if it exists. This adds logic to handle the fact that preview releases have negative patchlevels.