### PR TITLE
switch from ddollar multi to heroku multi

### DIFF
--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Multibuildpack" do
   it "works with node" do
-    Hatchet::Runner.new("node_multi", buildpack_url: "https://github.com/ddollar/heroku-buildpack-multi.git").deploy do |app|
+    Hatchet::Runner.new("node_multi", buildpack_url: "https://github.com/heroku/heroku-buildpack-multi.git").deploy do |app|
       expect(app.output).to match("Node Version in Ruby buildpack is: v4.1.2")
       expect(app.run("node -v")).to match("v4.1.2")
     end


### PR DESCRIPTION
Fixes the broken test from the deprecation of heroku-buildpack-multi by ddollar. Instead, we use the heroku fork.

```
       remote: -----> Multipack app detected
       remote: WARNING: This buildpack is no longer maintained.
       remote: 
       remote: Please choose a different buildpack or go to https://github.com/ddollar/heroku-buildpack-multi
       remote: and fork it to your own account.
       remote: 
       remote: This buildpack will cease to function at the stroke of midnight on January 1, 2017.
       remote:  !     Push rejected, failed to compile Multipack app.
```