### PR TITLE
RAILS_GROUPS should only be used for rake execution and not set in .profile.d

### DIFF
--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -19,12 +19,6 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
     "Ruby/Rails"
   end
 
-  def default_env_vars
-    super.merge({
-      "RAILS_GROUPS" => "assets"
-    })
-  end
-
   def default_process_types
     instrument "rails3.default_process_types" do
       # let's special case thin here
@@ -37,6 +31,10 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
         "console" => "bundle exec rails console"
       })
     end
+  end
+
+  def rake_env
+    super.merge(default_env_vars.merge("RAILS_GROUPS" => "assets"))
   end
 
   def compile

--- a/spec/rails3_spec.rb
+++ b/spec/rails3_spec.rb
@@ -20,6 +20,10 @@ describe "Rails 3.x" do
     Hatchet::Runner.new("rails3_12factor").deploy do |app, heroku|
       expect(app.output).not_to match("Add 'rails_12factor' gem to your Gemfile to skip plugin injection")
       expect(successful_body(app)).to eq("hello")
+
+      # https://github.com/heroku/heroku-buildpack-ruby/issues/525
+      env = app.run("env")
+      expect(env).not_to match("RAILS_GROUPS")
     end
   end
 


### PR DESCRIPTION
This fixes #525.

#516 accidentally wrote `RAILS_GROUPS` in rails3+ to `.profile.d`, which was not intended behavior.