### PR TITLE
New year rollovers are hard. =)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## Master
 
-## v153 (01/18/2016)
+## v153 (01/18/2017)
 
 * Fix regression, where defaults would override user env with rake (#528)
 
-## v152 (01/18/2016)
+## v152 (01/18/2017)
 
 * Remove RAILS_GROUPS=assets from being set in .profile.d (#526)
 
-## v151 (01/16/2016)
+## v151 (01/16/2017)
 
 * Upgrade to bundler 1.13.7 (#519)
 * Vendor Default Ruby to execute the buildpack (#515)


### PR DESCRIPTION
I saw that the dates were incorrect for January releases while reading the Changelog.