### PR TITLE
Limit the creation of postgres databases to apps using one of the pg adapters

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -79,12 +79,6 @@ private
     end
   end
 
-  # most rails apps need a database
-  # @return [Array] shared database addon
-  def add_dev_database_addon
-    ['heroku-postgresql']
-  end
-
   # sets up the profile.d script for this buildpack
   def setup_profiled
     super

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -761,7 +761,19 @@ params = CGI.parse(uri.query || "")
   # decides if we need to enable the dev database addon
   # @return [Array] the database addon if the pg gem is detected or an empty Array if it isn't.
   def add_dev_database_addon
-    bundler.has_gem?("pg") ? ['heroku-postgresql'] : []
+    pg_adapters.any? {|a| bundler.has_gem?(a) } ? ['heroku-postgresql'] : []
+  end
+
+  def pg_adapters
+    [
+      "pg",
+      "activerecord-jdbcpostgresql-adapter",
+      "jdbc-postgres",
+      "jdbc-postgresql",
+      "jruby-pg",
+      "rjack-jdbc-postgres",
+      "tgbyte-activerecord-jdbcpostgresql-adapter"
+    ]
   end
 
   # decides if we need to install the node.js binary


### PR DESCRIPTION
And extend that to rails apps, so we don't provision a database needlessly for them either.
Closes heroku/heroku-buildpack-ruby/issues/532