### PR TITLE
Add jruby to patchlevel_is_significant test

### DIFF
--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -52,7 +52,7 @@ module LanguagePack
     # Before Ruby 2.1 patch releases were done via patchlevel i.e. 1.9.3-p426 versus 1.9.3-p448
     # With 2.1 and above patches are released in the "minor" version instead i.e. 2.1.0 versus 2.1.1
     def patchlevel_is_significant?
-      Gem::Version.new(self.ruby_version) <= Gem::Version.new("2.1")
+      !jruby? && Gem::Version.new(self.ruby_version) <= Gem::Version.new("2.1")
     end
 
     def rake_is_vendored?


### PR DESCRIPTION
This prevents the patch level in the `Gemfile.lock` from being added to the calculated download path for the JRuby binary tarball. This manifested itself as the following error at build time:

```
-----> Rails plugin injection
 !
 !     An error occurred while installing ruby-1.8.7-p376-jruby-1.7.25
 !    
```

No specs were changed, but I did change the [Gemfile.lock in the test app repos](https://github.com/sharpstone/ruby_193_jruby_17161_jdk7/commit/c1b632f8a96cf9b902f5cdcd7a190d46544a8144), which is sufficient to validate this PR.