### PR TITLE
Update heroku_hatchet in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,22 +8,23 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+    activesupport (4.2.8)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     anvil-cli (0.16.2)
       progress (~> 2.4, >= 2.4.0)
       rest-client (~> 1.6, >= 1.6.7)
       thor (~> 0.15, >= 0.15.2)
     diff-lcs (1.2.5)
-    excon (0.45.4)
-    heroku-api (0.4.0)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
+    excon (0.55.0)
+    heroku-api (0.4.2)
       excon (~> 0.45)
       multi_json (~> 1.8)
-    heroku_hatchet (1.4.1)
+    heroku_hatchet (1.4.3)
       activesupport (~> 4)
       anvil-cli (~> 0)
       excon (~> 0)
@@ -32,12 +33,14 @@ GEM
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (0.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.8.1)
     json (2.0.2)
-    mime-types (2.4.3)
-    minitest (4.7.5)
-    multi_json (1.11.2)
-    netrc (0.10.2)
+    mime-types (2.99.3)
+    minitest (5.10.1)
+    multi_json (1.12.1)
+    netrc (0.11.0)
     parallel (1.8.0)
     parallel_tests (2.5.0)
       parallel
@@ -45,7 +48,8 @@ GEM
     rake (10.0.4)
     repl_runner (0.0.3)
       activesupport
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rrrretry (1.0.0)
@@ -57,10 +61,14 @@ GEM
     rspec-retry (0.4.5)
       rspec-core
     rspec-support (3.4.1)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     threaded (0.0.4)
-    tzinfo (0.3.52)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -78,4 +86,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
Hatchet 1.4.3 includes better support for Git repos over HTTPS.