### PR TITLE
Fix `buildpacks:release`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -256,7 +256,15 @@ FILE
   task :publish do
     buildpack_name = "heroku/ruby"
     puts "Publishing #{buildpack_name} buildpack"
-    resp = connection.post(multipart_form_data("buildpacks/buildpack.tgz").merge(path: "/buildpacks/#{buildpack_name}"))
+
+    print "Enter your yubikey > "
+    yubikey = STDIN.gets.chomp
+
+    request_hash = multipart_form_data("buildpacks/buildpack.tgz").merge(path: "/buildpacks/#{buildpack_name}")
+    request_hash[:headers]["heroku-two-factor-code"] = yubikey
+
+    resp = connection.post(request_hash)
+
     puts resp.status
     puts resp.body
   end

--- a/Rakefile
+++ b/Rakefile
@@ -204,10 +204,8 @@ FILE
     Dir.mktmpdir("heroku-buildpack-ruby") do |tmpdir|
       Git.clone(File.expand_path("."), 'heroku-buildpack-ruby', path: tmpdir)
       Dir.chdir(tmpdir) do
-        streamer = lambda do |chunk, remaining_bytes, total_bytes|
-          File.open("ruby.tgz", "w") {|file| file.print(chunk) }
-        end
-        Excon.get(latest_release["tar_link"], :response_block => streamer)
+        sh "curl #{latest_release["tar_link"]} > ruby.tgz"
+
         Dir.chdir("heroku-buildpack-ruby") do |buildpack_dir|
           $:.unshift File.expand_path("../lib", __FILE__)
           require "language_pack/installers/heroku_ruby_installer"


### PR DESCRIPTION
- Replaces excon file download with curl
- Enables yubikey authorization when pushing to buildkits
