### PR TITLE
Rails 4.x Improved Asset Pipeline Cleanup

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -1,3 +1,4 @@
+require "fileutils"
 require "language_pack"
 require "language_pack/rails3"
 
@@ -89,11 +90,12 @@ WARNING
           puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
 
           puts "Cleaning assets"
-          rake.task("assets:clean").invoke(env: rake_env)
+          rake.task("assets:clean[0]").invoke(env: rake_env)
 
           cleanup_assets_cache
           @cache.store public_assets_folder
           @cache.store default_assets_cache
+          FileUtils.rm_rf(default_assets_cache)
         else
           precompile_fail(precompile.output)
         end


### PR DESCRIPTION
Makes two modifications to how the `rake:precompile` step of the Heroku
slug compilation process behaves.

The first is to specify the argument `keep=0` to the `rake:cleanup` task,
which instructs the `rake:cleanup` task to keep around zero previously
compiled/fingerprinted files. The effect of this is that `public/assets/*`
will only contain the 'current' version of each asset file, without
keeping the previous three versions (the default).

The second change is to remove the `tmp/cache/assets` directory after this
directory has been cached by the Heroku build cache.

Both of these changes can drastically reduce the resulting Heroku
slug filesize.