### PR TITLE
Fix case where CI uses System Ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     heroku-api (0.4.2)
       excon (~> 0.45)
       multi_json (~> 1.8)
-    heroku_hatchet (2.0.2)
+    heroku_hatchet (2.0.3)
       activesupport (~> 4)
       anvil-cli (~> 0)
       excon (~> 0)
@@ -78,7 +78,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.3)
 
 PLATFORMS
   ruby

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -23,7 +23,12 @@ heroku_buildpack_ruby_install_ruby()
   local buildpack_dir=$2
   heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK"
 
-  # The -d flag checks to see if a file exists and is a directory
+  # The -d flag checks to see if a file exists and is a directory.
+  # This directory may be non-empty if a previous compile has
+  # already placed a Ruby executable here. Also
+  # when the buildpack is deployed we vendor a ruby executable
+  # at this location so it doesn't have to be downloaded for
+  # every app compile
   if [ ! -d "$heroku_buildpack_ruby_dir" ]; then
     heroku_buildpack_ruby_dir=$(mktemp -d)
     # bootstrap ruby
@@ -32,8 +37,10 @@ heroku_buildpack_ruby_install_ruby()
       rm -rf $heroku_buildpack_ruby_dir
     }
     trap atexit EXIT
-
-    export PATH=$heroku_buildpack_ruby_dir/bin/:$PATH
-    unset GEM_PATH
   fi
+
+  # Even if a Ruby is already downloaded for use by the
+  # buildpack we still have to set up it's PATH and GEM_PATH
+  export PATH=$heroku_buildpack_ruby_dir/bin/:$PATH
+  unset GEM_PATH
 }


### PR DESCRIPTION
Even when a version of Ruby is already installed for the Buildpack to use we must still set the appropriate `PATH` and `GEM_PATH`.