### PR TITLE
Blacklist JAVA_OPTS and JAVA_TOOL_OPTIONS during build

### DIFF
--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -27,7 +27,7 @@ module LanguagePack
     end
 
     def self.blacklist?(key)
-      %w(PATH GEM_PATH GEM_HOME GIT_DIR JRUBY_OPTS).include?(key)
+      %w(PATH GEM_PATH GEM_HOME GIT_DIR JRUBY_OPTS JAVA_OPTS JAVA_TOOL_OPTIONS).include?(key)
     end
 
     def self.initialize_env(path)


### PR DESCRIPTION
Like `JRUBY_OPTS`, these should be blacklisted during build to prevent errors when running `bundle` or other `ruby` commands.