### PR TITLE
Ask on yarnpkg rather than yarn

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -836,7 +836,7 @@ params = CGI.parse(uri.query || "")
   def yarn_preinstall_bin_path
     return @yarn_preinstall_bin_path if defined?(@yarn_preinstall_bin_path)
 
-    path = run("which yarn")
+    path = run("which yarnpkg")
     if path && $?.success?
       @yarn_preinstall_bin_path = path
     else


### PR DESCRIPTION
This is because later on we actually run `yarnpkg` and not `yarn`.
So the install step can be skipped if `yarn` is available but
fail later if `yarnpkg` is not.

I run into this on dokku where in my setup the first check worked