### PR TITLE
move rails db schema checking to only be done for rails apps

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -79,6 +79,7 @@
     "sharpstone/heroku-ci-json-example",
     "sharpstone/rails5_sql_schema_format",
     "sharpstone/rails_31_ruby_schema_format",
-    "sharpstone/rails_31_sql_schema_format"
+    "sharpstone/rails_31_sql_schema_format",
+    "sharpstone/ruby_no_rails_test"
   ]
 }

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -24,4 +24,10 @@ describe "CI" do
       expect(test_run.output).to match("db:schema:load completed")
     end
   end
+
+  it "Works with a vanilla ruby app" do
+    Hatchet::Runner.new("ruby_no_rails_test").run_ci do |test_run|
+      # Expect success test run
+    end
+  end
 end


### PR DESCRIPTION
stick to `db:schema:load` and `db:migrate` for general ruby apps if they exist