### PR TITLE
Bundler 1.15.0

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.13.7"
+  BUNDLER_VERSION      = "1.15.0"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
Bundler fixed this bug https://github.com/bundler/bundler/pull/5388 which causes this issue https://github.com/ruby/openssl/issues/103. To be able to deploy Ruby 2.4 and the openssl gem on Heroku.