### PR TITLE
Fix errors when rake tasks missing in CI

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -80,6 +80,7 @@
     "sharpstone/rails5_sql_schema_format",
     "sharpstone/rails_31_ruby_schema_format",
     "sharpstone/rails_31_sql_schema_format",
-    "sharpstone/ruby_no_rails_test"
+    "sharpstone/ruby_no_rails_test",
+    "sharpstone/activerecord_rake_tasks_does_not_exist"
   ]
 }

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -30,4 +30,10 @@ describe "CI" do
       # Expect success test run
     end
   end
+
+  it "Works with a rails app that does not have activerecord" do
+    Hatchet::Runner.new("activerecord_rake_tasks_does_not_exist").run_ci do |test_run|
+      expect(test_run.output).to_not match("db:migrate")
+    end
+  end
 end


### PR DESCRIPTION
There are two modes of errors that were causing failures. 

1) `db:test:purge` or other task does not exist it, yet we try to clear it.

Solution: check the task exists before trying to clear

```
if Rake::Task.task_defined?('db:test:purge')
```

2) Rails apps aren't required to have a database or activerecord.

When this happens the `db:schema:load_if_ruby` and `db:structure:load_if_sql` will fail which will cause the testpack to look up schema format and fail when it's not set.

Solution: Exit early if no `db:migrate` task is present.

```
return [] if db_migrate.not_defined?
```