### PR TITLE
Update Bundler to 1.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - secure: xFS5oLPMGyT6N0LKwU7wllaEZEVLzE/D5HuD14q3Vfd4L369XpV6ORYJF/2mkf765m+LH1MaN09rJaKc00ZcQfQECMuzyWagLsr1bVKs+szta3G/nFjjVTwmoPX5kVw5q7e6TYvS/KAzo+n8u5pW+zu8MMTwnv40QI6LfcbZkTc=
   - secure: wd/FBYI9I37PJ+eXhO8vesvWELkklNgGRA1xo/tuA31+ACpY/jG5EjrHd+semsfDTxM8fZe3s0foIch+jeMTIOcGs98tDC/L/8b/h6i0Qic0DqkAk6B30fT+5Nl3dufjiXsBJg5xj1zYqW6ka3DKIDjnn+3ao2cme05MtDQBHdc=
 sudo: false
+dist: trusty
 addons:
   apt:
     sources:

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.13.7"
+  BUNDLER_VERSION      = "1.15.1"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
This update includes several bugfixes:

- `bundle lock --update GEM` will fail gracefully when the gem is not in the lockfile
- `bundle init --gemspec` will fail gracefully when the gemspec is invalid
- `bundle install --force` works when the gemfile contains git gems
- `bundle env` will print well-formed markdown when there are no settings

Full details: https://github.com/bundler/bundler/compare/v1.15.0...v1.15.1