### PR TITLE
Revert "Merge pull request #569 from heroku/schneems/bundler-1.15.0"

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.15.0"
+  BUNDLER_VERSION      = "1.13.7"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
Multiple issues have been reported through support tickets and through GitHub issues.

1.15.0 is not stable enough and 1.15.1 does not appear to have fixes to these issues listed in the Changelog. We will revert until we can triage all issues and report them to bundler and get them fixed.

GitHub Issue: #578

This reverts commit 2a7c1c9dc6464e0895bcc9a76607939f105d3952, reversing
changes made to 8fed8683c92dc35d1382a0fc9c0532df93c70f3f.