### PR TITLE
Update comment to reflect support file location

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,6 @@
 #!/bin/bash
-# The actual `bin/compile` code lives in `bin/ruby_compile`. This file instead
-# bootstraps the ruby needed and then executes `bin/ruby_compile`
+# The actual compilation code lives in `bin/support/ruby_compile`. This file instead
+# bootstraps the ruby needed and then executes `bin/support/ruby_compile`
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 BUILDPACK_DIR=$(dirname $BIN_DIR)


### PR DESCRIPTION
The other comment change is a clarification. I think that "compilation code" is a clearer name than "bin/compile code".