### PR TITLE
Update `heroku_hatchet` to use V3 of the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem "heroku_hatchet", github: "heroku/hatchet", branch: "schneems/enhance"
+  gem "heroku_hatchet", "~>3.0.1"
   gem "rspec-core"
   gem "rspec-expectations"
   gem "excon"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem "heroku_hatchet"
+  gem "heroku_hatchet", github: "heroku/hatchet", branch: "schneems/enhance"
   gem "rspec-core"
   gem "rspec-expectations"
   gem "excon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: git://github.com/heroku/hatchet.git
+  revision: 6bfbf1e55ab31f6395a073f3ee92a53dae389236
+  branch: schneems/enhance
+  specs:
+    heroku_hatchet (3.0.0)
+      activesupport (~> 4)
+      anvil-cli (~> 0)
+      excon (~> 0)
+      heroku-api (~> 0)
+      platform-api (~> 2)
+      repl_runner (~> 0.0.3)
+      rrrretry (~> 1)
+      thor (~> 0)
+      threaded (~> 0)
+
+GIT
   remote: git://github.com/hone/ruby-git.git
   revision: 264836fcff3c037d8d8fc44bd770b150b46fdc4e
   branch: master
@@ -29,16 +45,6 @@ GEM
     heroku-api (0.4.2)
       excon (~> 0.45)
       multi_json (~> 1.8)
-    heroku_hatchet (3.0.0)
-      activesupport (~> 4)
-      anvil-cli (~> 0)
-      excon (~> 0)
-      heroku-api (~> 0)
-      platform-api (~> 2)
-      repl_runner (~> 0.0.3)
-      rrrretry (~> 1)
-      thor (~> 0)
-      threaded (~> 0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.4)
@@ -86,7 +92,7 @@ PLATFORMS
 DEPENDENCIES
   excon
   git!
-  heroku_hatchet
+  heroku_hatchet!
   json (~> 2.0.2)
   netrc
   parallel_tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,27 +21,27 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    excon (0.55.0)
-    heroics (0.0.21)
+    excon (0.57.0)
+    heroics (0.0.22)
       erubis (~> 2.0)
       excon
       multi_json (>= 1.9.2)
     heroku-api (0.4.2)
       excon (~> 0.45)
       multi_json (~> 1.8)
-    heroku_hatchet (2.0.3)
+    heroku_hatchet (3.0.0)
       activesupport (~> 4)
       anvil-cli (~> 0)
       excon (~> 0)
       heroku-api (~> 0)
-      platform-api (~> 1)
+      platform-api (~> 2)
       repl_runner (~> 0.0.3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.8.1)
+    i18n (0.8.4)
     json (2.0.4)
     mime-types (2.99.3)
     minitest (5.10.2)
@@ -51,8 +51,8 @@ GEM
     parallel (1.11.2)
     parallel_tests (2.14.1)
       parallel
-    platform-api (1.0.1)
-      heroics (~> 0.0.21)
+    platform-api (2.0.0)
+      heroics (~> 0.0.22)
       moneta (~> 0.8.1)
     progress (2.4.0)
     rake (12.0.0)
@@ -96,4 +96,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,4 @@
 GIT
-  remote: git://github.com/heroku/hatchet.git
-  revision: 6bfbf1e55ab31f6395a073f3ee92a53dae389236
-  branch: schneems/enhance
-  specs:
-    heroku_hatchet (3.0.0)
-      activesupport (~> 4)
-      anvil-cli (~> 0)
-      excon (~> 0)
-      heroku-api (~> 0)
-      platform-api (~> 2)
-      repl_runner (~> 0.0.3)
-      rrrretry (~> 1)
-      thor (~> 0)
-      threaded (~> 0)
-
-GIT
   remote: git://github.com/hone/ruby-git.git
   revision: 264836fcff3c037d8d8fc44bd770b150b46fdc4e
   branch: master
@@ -45,6 +29,16 @@ GEM
     heroku-api (0.4.2)
       excon (~> 0.45)
       multi_json (~> 1.8)
+    heroku_hatchet (3.0.1)
+      activesupport (~> 4)
+      anvil-cli (~> 0)
+      excon (~> 0)
+      heroku-api (~> 0)
+      platform-api (~> 2)
+      repl_runner (~> 0.0.3)
+      rrrretry (~> 1)
+      thor (~> 0)
+      threaded (~> 0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.4)
@@ -92,7 +86,7 @@ PLATFORMS
 DEPENDENCIES
   excon
   git!
-  heroku_hatchet!
+  heroku_hatchet (~> 3.0.1)
   json (~> 2.0.2)
   netrc
   parallel_tests

--- a/spec/hatchet/jvm_spec.rb
+++ b/spec/hatchet/jvm_spec.rb
@@ -2,13 +2,10 @@ require 'spec_helper'
 
 describe "JvmInstaller" do
   it "JVM is installed by jvm-common only" do
-    app = Hatchet::Runner.new("ruby_193_jruby_17161")
+    buildpacks = ["https://github.com/heroku/heroku-buildpack-jvm-common",
+                  Hatchet::App.default_buildpack] # default is heroku-ruby-buildpack here
+    app = Hatchet::Runner.new("ruby_193_jruby_17161", stack: 'cedar-14', buildpacks: buildpacks)
     app.setup!
-    app.heroku.put_stack(app.name, 'cedar-14')
-
-    bp = app.heroku.get_config_vars(app.name).body["BUILDPACK_URL"]
-    app.heroku.delete_config_var(app.name, "BUILDPACK_URL")
-    app.heroku.put_buildpacks(app.name, ["https://github.com/heroku/heroku-buildpack-jvm-common", bp])
 
     app.deploy do |app|
       expect(app.output).to match("Using pre-installed JDK")

--- a/spec/hatchet/rails23_spec.rb
+++ b/spec/hatchet/rails23_spec.rb
@@ -2,8 +2,7 @@ require_relative '../spec_helper'
 
 describe "Rails 2.3.x" do
   it "should deploy on ruby 1.9.3 on cedar-14" do
-    app = Hatchet::Runner.new('rails23_mri_193').setup!
-    app.heroku.put_stack(app.name, "cedar-14")
+    app = Hatchet::Runner.new('rails23_mri_193', stack: "cedar-14").setup!
     app.deploy do |app, heroku|
       # assert deploy is successful
     end

--- a/spec/hatchet/rails3_spec.rb
+++ b/spec/hatchet/rails3_spec.rb
@@ -2,9 +2,8 @@ require_relative '../spec_helper'
 
 describe "Rails 3.x" do
   it "should deploy on ruby 1.9.3" do
-    app = Hatchet::Runner.new("rails3_mri_193")
+    app = Hatchet::Runner.new("rails3_mri_193", stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, "cedar-14")
     app.deploy do |app, heroku|
       expect(app.output).to include("Asset precompilation completed")
 

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -2,9 +2,8 @@ require_relative '../spec_helper'
 
 describe "Ruby Versions on cedar-14" do
   it "should allow patchlevels" do
-    app = Hatchet::Runner.new('mri_193_p547')
+    app = Hatchet::Runner.new('mri_193_p547', stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, "cedar-14")
     app.deploy do |app|
       version = '1.9.3p547'
       expect(app.output).to match("ruby-1.9.3-p547")
@@ -13,9 +12,8 @@ describe "Ruby Versions on cedar-14" do
   end
 
   it "should deploy ruby 1.9.2 properly" do
-    app = Hatchet::Runner.new('mri_192')
+    app = Hatchet::Runner.new('mri_192', stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, "cedar-14")
     app.deploy do |app|
       version = '1.9.2'
       expect(app.output).to match(version)
@@ -24,9 +22,8 @@ describe "Ruby Versions on cedar-14" do
   end
 
   it "should deploy ruby 1.9.3 properly" do
-    app = Hatchet::Runner.new('mri_193')
+    app = Hatchet::Runner.new('mri_193', stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, "cedar-14")
     app.deploy do |app|
       version = '1.9.3'
       expect(app.output).to match(version)
@@ -35,9 +32,8 @@ describe "Ruby Versions on cedar-14" do
   end
 
   it "should deploy ruby 2.0.0 properly" do
-    app = Hatchet::Runner.new('mri_200')
+    app = Hatchet::Runner.new('mri_200', stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, "cedar-14")
     app.deploy do |app|
       version = '2.0.0'
       expect(app.output).to match(version)
@@ -48,9 +44,8 @@ describe "Ruby Versions on cedar-14" do
   end
 
   it "should deploy jdk 8 on cedar-14 by default" do
-    app = Hatchet::Runner.new("ruby_193_jruby_17161")
+    app = Hatchet::Runner.new("ruby_193_jruby_17161", stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, 'cedar-14')
     app.deploy do |app|
       expect(app.output).to match("Installing JVM: openjdk-8")
       expect(app.output).to match("JRUBY_OPTS is:  -Xcompile.invokedynamic=false")
@@ -66,9 +61,8 @@ describe "Ruby Versions on cedar-14" do
   end
 
   it "should deploy jruby 1.7.16.1 (jdk 7) properly on cedar-14 with sys props file" do
-    app = Hatchet::Runner.new("ruby_193_jruby_17161_jdk7")
+    app = Hatchet::Runner.new("ruby_193_jruby_17161_jdk7", stack: "cedar-14")
     app.setup!
-    app.heroku.put_stack(app.name, 'cedar-14')
     app.deploy do |app|
       expect(app.output).to match("Installing JVM: openjdk-7")
       expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -2,10 +2,9 @@ require_relative "../spec_helper"
 
 describe "Stack Changes" do
   xit "should reinstall gems on stack change" do
-    app = Hatchet::Runner.new('default_ruby').setup!
-    app.heroku.put_stack(app.name, "heroku-16")
+    app = Hatchet::Runner.new('default_ruby', stack: "heroku-16").setup!
     app.deploy do |app, heroku|
-      heroku.put_stack(app.name, "cedar-14")
+      app.update_stack("cedar-14")
       `git commit --allow-empty -m "cedar-14 migrate"`
 
       app.push!
@@ -16,10 +15,9 @@ describe "Stack Changes" do
   end
 
   it "should not reinstall gems if the stack did not change" do
-    app = Hatchet::Runner.new('default_ruby').setup!
-    app.heroku.put_stack(app.name, "cedar-14")
+    app = Hatchet::Runner.new('default_ruby', stack: "cedar-14").setup!
     app.deploy do |app, heroku|
-      heroku.put_stack(app.name, "cedar-14")
+      app.update_stack("cedar-14")
       `git commit --allow-empty -m "cedar migrate"`
 
       app.push!


### PR DESCRIPTION
V2 of the Heroku API is being deprecated. Hatchet 3.0.0 uses V3 of the Heroku API.