### PR TITLE
Retry failed downlads for untar

### DIFF
--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -21,7 +21,9 @@ module LanguagePack
 
     def fetch_untar(path, files_to_extract = nil)
       curl = curl_command("#{@host_url.join(path)} -s -o")
-      run!("#{curl} - | tar zxf - #{files_to_extract}", error_class: FetchError)
+      run! "#{curl} - | tar zxf - #{files_to_extract}",
+        error_class: FetchError,
+        max_attempts: 3
     end
 
     def fetch_bunzip2(path, files_to_extract = nil)

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -41,14 +41,25 @@ module LanguagePack
       end
     end
 
+    # run a shell command (deferring to #run), and raise an error if it fails
+    # @param [String] command to be run
+    # @return [String] result of #run
+    # @option options [Error] :error_class Class of error to raise, defaults to Standard Error
+    # @option options [Integer] :max_attempts Number of times to attempt command before raising
     def run!(command, options = {})
-      result      = run(command, options)
-      error_class = options.delete(:error_class) || StandardError
-      unless $?.success?
-        message = "Command: '#{command}' failed unexpectedly:\n#{result}"
-        raise error_class, message
+      max_attempts = options[:max_attempts] || 1
+      error_class = options[:error_class] || StandardError
+      max_attempts.times do |attempt_number|
+        result = run(command, options)
+        if $?.success?
+          return result
+        end
+        if attempt_number == max_attempts - 1
+          raise error_class, "Command: '#{command}' failed unexpectedly:\n#{result}"
+        else
+          puts "Command: '#{command}' failed on attempt #{attempt_number + 1} of #{max_attempts}."
+        end
       end
-      return result
     end
 
     # doesn't do any special piping. stderr won't be redirected.

--- a/spec/helpers/shell_spec.rb
+++ b/spec/helpers/shell_spec.rb
@@ -1,23 +1,44 @@
 require 'spec_helper'
 
-
-class FakeShell
-  include LanguagePack::ShellHelpers
-end
-
-
 describe "ShellHelpers" do
-  it "format ugly keys correctly" do
-    env      = {%Q{ un"matched } => "bad key"}
-    result   = FakeShell.new.command_options_to_string("bundle install", env:  env)
-    expected = %r{env \\ un\\\"matched\\ =bad\\ key bash -c bundle\\ install 2>&1}
-    expect(result.strip).to match(expected)
+  module RecordPuts
+    attr_reader :puts_calls
+    def puts(*args)
+      @puts_calls ||= []
+      @puts_calls << args
+    end
   end
 
-  it "formats ugly values correctly" do
-    env      = {"BAD VALUE"      => %Q{ )(*&^%$#'$'\n''@!~\'\ }}
-    result   = FakeShell.new.command_options_to_string("bundle install", env:  env)
-    expected = %r{env BAD\\ VALUE=\\ \\\)\\\(\\\*\\&\\\^\\%\\\$\\#\\'\\\$\\''\n'\\'\\'@\\!\\~\\'\\  bash -c bundle\\ install 2>&1}
-    expect(result.strip).to match(expected)
+  class FakeShell
+    include RecordPuts
+    include LanguagePack::ShellHelpers
+  end
+
+  describe "#command_options_to_string" do
+    it "formats ugly keys correctly" do
+      env      = {%Q{ un"matched } => "bad key"}
+      result   = FakeShell.new.command_options_to_string("bundle install", env:  env)
+      expected = %r{env \\ un\\\"matched\\ =bad\\ key bash -c bundle\\ install 2>&1}
+      expect(result.strip).to match(expected)
+    end
+
+    it "formats ugly values correctly" do
+      env      = {"BAD VALUE"      => %Q{ )(*&^%$#'$'\n''@!~\'\ }}
+      result   = FakeShell.new.command_options_to_string("bundle install", env:  env)
+      expected = %r{env BAD\\ VALUE=\\ \\\)\\\(\\\*\\&\\\^\\%\\\$\\#\\'\\\$\\''\n'\\'\\'@\\!\\~\\'\\  bash -c bundle\\ install 2>&1}
+      expect(result.strip).to match(expected)
+    end
+  end
+
+  describe "#run!" do
+    it "retries failed commands when passed max_attempts: > 1" do
+      sh = FakeShell.new
+      expect { sh.run!("false", max_attempts: 3) }.to raise_error(StandardError)
+
+      expect(sh.puts_calls).to eq([
+        ["       Command: 'false' failed on attempt 1 of 3."],
+        ["       Command: 'false' failed on attempt 2 of 3."],
+      ])
+    end
   end
 end


### PR DESCRIPTION
On occasion, S3 drops connections or cURL fails for other reasons. It
can happen that cURL's inbuilt retry behavior also fails for these
dropped connections. If downloads fail, retry three times.

This is different than the retry behavior in the `curl` command (5
retries, 1s delay, 3s connect timeout, 30s total timeout) also
implements, which are used for what cURL considers "temporary" problems.
These [problems] include the operation timing out, failure to resolve
host/proxy, or FTP timeouts. We'd like to get additional behavior for
other failure reasons so we retry the full command.

[problems]: <https://github.com/curl/curl/blob/0feb762fc076d46d386793a0f7280373d706bbf1/src/tool_operate.c#L1592-L1595>