### PR TITLE
Warn if ruby/rails/bundle binstub shebangs are bad

### DIFF
--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -22,5 +22,20 @@ class LanguagePack::Installers::HerokuRubyInstaller
       @fetcher.fetch_untar(file)
     end
   end
+
+  def setup_binstubs(*)
+    super
+    Dir["#{DEFAULT_BIN_DIR}/{rake,bundle,rails}"].select do |binstub|
+      begin
+        if File.file?(binstub)
+          shebang = File.open(binstub, &:readline)
+          if !shebang.match %r{\A#!/usr/bin/env ruby(.exe)?\z}
+            warn("Binstub #{binstub} contains shebang #{shebang}. This may cause issues if the program specified is unavailable.", inline: true)
+          end
+        end
+      rescue EOFError
+      end
+    end
+  end
 end
 

--- a/spec/installers/heroku_ruby_installer_spec.rb
+++ b/spec/installers/heroku_ruby_installer_spec.rb
@@ -48,4 +48,41 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
     end
 
   end
+
+  describe "#setup_binstubs" do
+    it "warns about malformed shebangs" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          Dir.mkdir("bin")
+          File.open("bin/rake", 'w') { |f| f.write("#!/usr/bin/env ruby") }
+          File.open("bin/rails", 'w') { |f| f.write("#!/usr/bin/env ruby.exe") }
+          File.open("bin/bundle", 'w') { |f| f.write("#!/usr/bin/env ruby1.7") }
+
+          output = capture(:stdout) { installer.setup_binstubs("#{dir}/vendor/ruby") }
+
+          expect(output).to include(<<-WARNING)
+###### WARNING:
+       Binstub bin/bundle contains shebang #!/usr/bin/env ruby1.7. This may cause issues if the program specified is unavailable.
+          WARNING
+        end
+      end
+    end
+
+    def capture(stream)
+      stream = stream.to_s
+      captured_stream = Tempfile.new(stream)
+      stream_io = eval("$#{stream}")
+      origin_stream = stream_io.dup
+      stream_io.reopen(captured_stream)
+
+      yield
+
+      stream_io.rewind
+      return captured_stream.read
+    ensure
+      captured_stream.close
+      captured_stream.unlink
+      stream_io.reopen(origin_stream)
+    end
+  end
 end


### PR DESCRIPTION
Binstubs, which RubyGems and Bundler generate to prepare the environment
before dispatching calls to original executables, can sometimes include
shebangs that worked on developer machines, but won't work on Heroku.
Often, this is caused by ruby binaries being named other than `ruby` (or
`ruby.exe` on Windows).

While it can happen for any binstub, we're mostly concerned about
`rake`, `rails`, and `bundler` stubs. Check each of these to see if they
are `!#/usr/bin/env ruby` or `!#/usr/bin/env ruby.exe` and issue a
warning if this is not the case.