### PR TITLE
Set JAVA_HOME env var for JRuby apps

### DIFF
--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -14,11 +14,25 @@ class LanguagePack::Helpers::JvmInstaller
 
   PG_CONFIG_JAR   = "pgconfig.jar"
 
+  PREINSTALLED_JDK_DIR = ".jdk"
+
   def initialize(slug_vendor_jvm, stack)
     @vendor_dir = slug_vendor_jvm
     @stack = stack
     @fetcher = LanguagePack::Fetcher.new(JVM_BASE_URL, stack)
     @pg_config_jar_fetcher = LanguagePack::Fetcher.new(JVM_BUCKET)
+  end
+
+  def java_home
+    if preinstalled_jdk?
+      PREINSTALLED_JDK_DIR
+    else
+      @vendor_dir
+    end
+  end
+
+  def preinstalled_jdk?
+    Dir.exist?(PREINSTALLED_JDK_DIR)
   end
 
   def system_properties
@@ -32,7 +46,7 @@ class LanguagePack::Helpers::JvmInstaller
   end
 
   def install(jruby_version, forced = false)
-    if Dir.exist?(".jdk")
+    if preinstalled_jdk?
       topic "Using pre-installed JDK"
       return
     end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -290,6 +290,7 @@ EOF
 echo #{default_java_mem}
 SHELL
         ENV["JRUBY_OPTS"] = env('JRUBY_BUILD_OPTS') || env('JRUBY_OPTS')
+        ENV["JAVA_HOME"] = @jvm_installer.java_home
       end
       setup_ruby_install_env
       ENV["PATH"] += ":#{node_preinstall_bin_path}" if node_js_installed?


### PR DESCRIPTION
This change sets the `JAVA_HOME` environment variable at build time, which enables the use of Rake tasks like [JBundler](https://rubygems.org/gems/jbundler).