### PR TITLE
Update Node to 6.11.1

### DIFF
--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -11,7 +11,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_node_lts
-    version = "6.10.0"
+    version = "6.11.1"
     {
       "number" => version,
       "url"    => "https://s3pository.heroku.com/node/v#{version}/node-v#{version}-linux-x64.tar.gz"


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/
    
Fix CVE-2017-1000381 - c-ares NAPTR parser out of bounds access
Fix #597