### PR TITLE
Skip Bundler version check

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -90,7 +90,8 @@ class LanguagePack::Helpers::BundlerWrapper
     instrument 'detect_ruby_version' do
       env = { "PATH"     => "#{bundler_path}/bin:#{ENV['PATH']}",
               "RUBYLIB"  => File.join(bundler_path, "gems", BUNDLER_DIR_NAME, "lib"),
-              "GEM_PATH" => "#{bundler_path}:#{ENV["GEM_PATH"]}"
+              "GEM_PATH" => "#{bundler_path}:#{ENV["GEM_PATH"]}",
+              "BUNDLE_DISABLE_VERSION_CHECK" => "true"
             }
       command = "bundle platform --ruby"
 


### PR DESCRIPTION
There is an issue in Bundler 1.15.1 that was exposed when Bundler 1.15.2 was released. Bundler now checks rubygems.org on all `bundle` commands and checks to see if a newer version of `bundler` has been released and if it is newer than the one currently in use it will emit a warning.

Ruby parses the output of `bundle platform --ruby` from bundler and in some cases this causes failures because it gets extra output.

This is an issue for Heroku ruby users who are using 2 ruby buildpacks by mistakes.

- heroku/ruby
- https://github.com/heroku/heroku-buildpack-ruby

The bundler version check adds a tiny bit of performance overhead. 

We can avoid the performance overhead and any build failures by skipping this check on installs. 

More info in https://github.com/bundler/bundler/pull/5884