### PR TITLE
install node when using execjs OR webpacker

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -74,6 +74,9 @@
   "multibuildpack": [
     "sharpstone/node_multi"
   ],
+  "node": [
+    "sharpstone/webpacker_no_execjs"
+  ],
   "ci": [
     "sharpstone/rails5_ruby_schema_format",
     "sharpstone/heroku-ci-json-example",

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -800,7 +800,11 @@ params = CGI.parse(uri.query || "")
   # @note execjs will blow up if no JS RUNTIME is detected and is loaded.
   # @return [Array] the node.js binary path if we need it or an empty Array
   def add_node_js_binary
-    bundler.has_gem?('execjs') && node_not_preinstalled? ? [@node_installer.binary_path] : []
+    if (bundler.has_gem?('execjs') || bundler.has_gem?('webpacker')) && node_not_preinstalled?
+      [@node_installer.binary_path]
+    else
+      []
+    end
   end
 
   def add_yarn_binary

--- a/spec/hatchet/node_spec.rb
+++ b/spec/hatchet/node_spec.rb
@@ -16,9 +16,15 @@ describe "Multibuildpack" do
     end
   end
 
-  it "doesn't install node without exec JS" do
+  it "doesn't install node without execjs or webpacker" do
     Hatchet::Runner.new("default_ruby").deploy do |app|
       expect(app.run("node -v")).to match("node: command not found")
+    end
+  end
+
+  it "installs node when webpacker is detected but no execjs" do
+    Hatchet::Runner.new("webpacker_no_execjs").deploy do |app|
+      expect(app.output).to match("Installing node-v")
     end
   end
 end


### PR DESCRIPTION
With `webpacker` now a part of Rails 5.1, you can now get in a case where you're using `webpacker` but not using `execjs` pulled in by `uglifier`. When this happens you'll get this error message:

```
-----> Installing yarn-0.22.0
-----> Detecting rake tasks
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       /usr/bin/env: ‘node’: No such file or directory
       rake aborted!
```

This patch checks for both `execjs` or `webpacker` to see if `node` should be installed.