### PR TITLE
Added explicit case for JVM version 8 or 1.8 in system.properties

### DIFF
--- a/lib/language_pack/helpers/jvm_installer.rb
+++ b/lib/language_pack/helpers/jvm_installer.rb
@@ -59,7 +59,7 @@ class LanguagePack::Helpers::JvmInstaller
       fetch_env_untar('JDK_URL_1_7') || fetch_untar(JVM_1_7_PATH, "openjdk-7")
     when "1.6", "6"
       fetch_env_untar('JDK_URL_1_6') || fetch_untar(JVM_1_6_PATH, "openjdk-6")
-    when nil
+    when "1.8", "8", nil
       if @stack == "cedar"
         if forced || Gem::Version.new(jruby_version) >= Gem::Version.new("1.7.4")
           fetch_untar(JVM_1_7_PATH, "openjdk-7")


### PR DESCRIPTION
This catches cases where `system.properties` is configured to the same value as the default JDK version. It fixes the following:

https://support.heroku.com/tickets/502207
https://twitter.com/fkchang2000/status/897238534125305861
