### PR TITLE
update yarn version to 0.25.2

### DIFF
--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -19,7 +19,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_yarn
-    version = "0.22.0"
+    version = "0.25.2"
     {
       "number" => version,
       "url"    => "https://yarnpkg.com/downloads/#{version}/yarn-v#{version}.tar.gz"


### PR DESCRIPTION
Heroku deploy fails with the new version of rails/webpacker 3.x  (npm: `@rails/webpacker@3.0.1`) with this error:

```
error @rails/webpacker@3.0.1: The engine "yarn" is incompatible with this module. Expected version ">=0.25.2"
```

EDIT: I see there is an issue opened on topic: #616