### PR TITLE
Ruby 2.5.0 and vendored Bundler

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -26,6 +26,7 @@
     "sharpstone/ruby_193_jruby_17161_jdk7",
     "sharpstone/ruby_193_jruby_17161_jdk8",
     "sharpstone/ruby_193_bad_patch_cedar_14",
+    "sharpstone/ruby_25",
     "sharpstone/jruby-minimal",
     "sharpstone/empty-procfile",
     "sharpstone/bad_ruby_version",

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -540,6 +540,10 @@ WARNING
     "vendor/bundle/bin"
   end
 
+  def bundler_path
+    @bundler_path ||= "#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}"
+  end
+
   # runs bundler to install the dependencies
   def build_bundler(default_bundle_without)
     instrument 'ruby.build_bundler' do
@@ -576,7 +580,15 @@ WARNING
           bundle_command += " --deployment"
         end
 
-        topic("Installing dependencies using bundler #{bundler.version}")
+        # If Ruby's bundler is >= buildpack version, it will win. Get the
+        # version of bundler actually being used
+        bundler_version =
+          if ruby_version.ruby_version >= "2.5.0"
+            `#{bundler_path}/exe/#{bundle_bin} -v`.downcase.chomp
+          else
+            "bundler #{bundler.version}"
+          end
+        topic("Installing dependencies using #{bundler_version}")
         load_bundler_cache
 
         bundler_output = ""
@@ -589,7 +601,6 @@ WARNING
           yaml_include   = File.expand_path("#{libyaml_dir}/include").shellescape
           yaml_lib       = File.expand_path("#{libyaml_dir}/lib").shellescape
           pwd            = Dir.pwd
-          bundler_path   = "#{pwd}/#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}/lib"
           # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
           # codon since it uses bundler.
           env_vars       = {
@@ -601,8 +612,14 @@ WARNING
             "RUBYOPT"                       => syck_hack,
             "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true"
           }
-          env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
+          env_vars["BUNDLER_LIB_PATH"] = "#{pwd}/#{bundler_path}/lib" if ruby_version.ruby_version == "1.8.7"
           puts "Running: #{bundle_command}"
+          # bundler binstub bug in Ruby 2.5.0-preview1
+          # https://bugs.ruby-lang.org/issues/13997
+          if ruby_version.ruby_version == "2.5.0"
+            bundle_command.prepend("#{bundler_path}/exe/")
+          end
+
           instrument "ruby.bundle_install" do
             bundle_time = Benchmark.realtime do
               bundler_output << pipe("#{bundle_command} --no-clean", out: "2>&1", env: env_vars, user_env: true)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -584,7 +584,7 @@ WARNING
         # version of bundler actually being used
         bundler_version =
           if ruby_version.ruby_version >= "2.5.0"
-            `#{bundler_path}/exe/#{bundle_bin} -v`.downcase.chomp
+            run!("#{bundler_path}/exe/#{bundle_bin} -v").downcase.chomp
           else
             "bundler #{bundler.version}"
           end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -16,6 +16,14 @@ describe "Ruby apps" do
     end
   end
 
+  describe "2.5.0" do
+    it "works" do
+      Hatchet::Runner.new("ruby_25").deploy do
+        # works
+      end
+    end
+  end
+
   # describe "default WEB_CONCURRENCY" do
   #   it "auto scales WEB_CONCURRENCY" do
   #     pending("https://github.com/heroku/api/issues/4426")


### PR DESCRIPTION
Make the Ruby buildpack work with Ruby vendored Bundler.

With Bundler being vendored in Ruby, we have no choice but to use the Ruby vendored Bundler if it's >= than the one we package in the Ruby buildpack since Ruby comes first in the `GEM_PATH` and `require 'bundler'` will always pull the latest. This still allows us the ability to update Bundler when we need to. Forcing the version of Bundler with `bundle _1.15.2_` won't be propagated during runtime. Having a different version used during build and runtime is not a good idea.

This patch works also works around the [binstub `Kernel#load` issue](https://bugs.ruby-lang.org/issues/13997) in preview1.