### PR TITLE
Use full path when setting JAVA_HOME during bundle install

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -32,6 +32,9 @@
     "sharpstone/bad_ruby_version",
     "sharpstone/activerecord41_scaffold"
   ],
+  "jruby": [
+    "sharpstone/jruby_naether"
+  ],
   "rack": [
     "sharpstone/default_ruby",
     "sharpstone/mri_187_nokogiri",

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -610,7 +610,8 @@ WARNING
             "CPPATH"                        => noshellescape("#{yaml_include}:$CPPATH"),
             "LIBRARY_PATH"                  => noshellescape("#{yaml_lib}:$LIBRARY_PATH"),
             "RUBYOPT"                       => syck_hack,
-            "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true"
+            "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
+            "JAVA_HOME"                     => noshellescape("#{pwd}/$JAVA_HOME")
           }
           env_vars["BUNDLER_LIB_PATH"] = "#{pwd}/#{bundler_path}/lib" if ruby_version.ruby_version == "1.8.7"
           puts "Running: #{bundle_command}"

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -68,4 +68,13 @@ describe "Ruby Versions on cedar-14" do
       expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
     end
   end
+
+  it "should deploy jruby with the naether gem" do
+    app = Hatchet::Runner.new("jruby_naether")
+    app.setup!
+    app.deploy do |app|
+      expect(app.output).to match("Installing naether")
+      expect(app.output).not_to include("An error occurred while installing naether")
+    end
+  end
 end

--- a/spec/helpers/jvm_installer_spec.rb
+++ b/spec/helpers/jvm_installer_spec.rb
@@ -8,7 +8,7 @@ describe "JvmInstall" do
         begin
           ENV['JDK_URL_1_8'] = "http://lang-jvm.s3.amazonaws.com/jdk/openjdk1.8.0_51-cedar14.tar.gz"
 
-          jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "cedar-14")
+          jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "heroku-16")
           jvm_installer.install("9.0.1.0")
 
           expect(`ls bin`).to match("java")
@@ -25,7 +25,7 @@ describe "JvmInstall" do
       Dir.chdir(dir) do
         File.open('system.properties', 'w') { |f| f.write("java.runtime.version=1.7") }
 
-        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "heroku-16")
         jvm_installer.install("9.0.1.0")
 
         expect(`ls bin`).to match("java")
@@ -40,12 +40,12 @@ describe "JvmInstall" do
       Dir.chdir(dir) do
         File.open('system.properties', 'w') { |f| f.write("java.runtime.version=1.9") }
 
-        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "heroku-16")
         jvm_installer.install("9.0.1.0")
 
         expect(`ls bin`).to match("java")
         expect(`cat release 2>&1`).not_to match("1.8.0")
-        expect(`cat release 2>&1`).to match("9-internal")
+        expect(`cat release 2>&1`).to match("9")
       end
     end
   end
@@ -67,7 +67,7 @@ describe "JvmInstall" do
   it "downloads default JDK" do
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
-        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "heroku-16")
         jvm_installer.install("9.0.1.0")
 
         expect(`ls bin`).to match("java")
@@ -83,7 +83,7 @@ describe "JvmInstall" do
       Dir.chdir(dir) do
         File.open('system.properties', 'w') { |f| f.write("java.runtime.version=foobar") }
 
-        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "cedar-14")
+        jvm_installer = LanguagePack::Helpers::JvmInstaller.new(dir, "heroku-16")
 
         expect{ jvm_installer.install("9.0.1.0") }.to raise_error(BuildpackError)
       end


### PR DESCRIPTION
Using a relative path causes problems with some Gems that try to run the java command, such as the naether Gem. See ticket 523738. Added a spec for jruby with the naether Gem. This confirms the use of a full path for the jvm vendor directory.