### PR TITLE
Updated Ruby 2.5.0 Support

### DIFF
--- a/lib/language_pack/installers/ruby_installer.rb
+++ b/lib/language_pack/installers/ruby_installer.rb
@@ -24,6 +24,8 @@ module LanguagePack::Installers::RubyInstaller
     run("ln -s ruby #{install_dir}/bin/ruby.exe")
 
     Dir["#{install_dir}/bin/*"].each do |vendor_bin|
+      # for Ruby 2.5.0+ don't symlink the Bundler bin so our shim works
+      next if vendor_bin.include?("bundle")
       run("ln -s ../#{vendor_bin} #{DEFAULT_BIN_DIR}")
     end
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -540,10 +540,6 @@ WARNING
     "vendor/bundle/bin"
   end
 
-  def bundler_path
-    @bundler_path ||= "#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}"
-  end
-
   # runs bundler to install the dependencies
   def build_bundler(default_bundle_without)
     instrument 'ruby.build_bundler' do
@@ -580,15 +576,7 @@ WARNING
           bundle_command += " --deployment"
         end
 
-        # If Ruby's bundler is >= buildpack version, it will win. Get the
-        # version of bundler actually being used
-        bundler_version =
-          if ruby_version.ruby_version >= "2.5.0"
-            run!("#{bundler_path}/exe/#{bundle_bin} -v").downcase.chomp
-          else
-            "bundler #{bundler.version}"
-          end
-        topic("Installing dependencies using #{bundler_version}")
+        topic("Installing dependencies using bundler #{bundler.version}")
         load_bundler_cache
 
         bundler_output = ""
@@ -601,6 +589,7 @@ WARNING
           yaml_include   = File.expand_path("#{libyaml_dir}/include").shellescape
           yaml_lib       = File.expand_path("#{libyaml_dir}/lib").shellescape
           pwd            = Dir.pwd
+          bundler_path   = "#{pwd}/#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}/lib"
           # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
           # codon since it uses bundler.
           env_vars       = {
@@ -614,14 +603,8 @@ WARNING
             "JAVA_HOME"                     => noshellescape("#{pwd}/$JAVA_HOME"),
             "BUNDLE_DISABLE_VERSION_CHECK"  => "true"
           }
-          env_vars["BUNDLER_LIB_PATH"] = "#{pwd}/#{bundler_path}/lib" if ruby_version.ruby_version == "1.8.7"
+          env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
           puts "Running: #{bundle_command}"
-          # bundler binstub bug in Ruby 2.5.0-preview1
-          # https://bugs.ruby-lang.org/issues/13997
-          if ruby_version.ruby_version == "2.5.0"
-            bundle_command.prepend("#{bundler_path}/exe/")
-          end
-
           instrument "ruby.bundle_install" do
             bundle_time = Benchmark.realtime do
               bundler_output << pipe("#{bundle_command} --no-clean", out: "2>&1", env: env_vars, user_env: true)

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -91,6 +91,11 @@ module LanguagePack
       end
     end
 
+    # does this vendor bundler
+    def vendored_bundler?
+      Gem::Version.new(self.ruby_version) >= Gem::Version.new("2.5.0dev")
+    end
+
     private
 
     def none


### PR DESCRIPTION
This updates the buildpack to support Ruby 2.5.0's vendored bundler with Rails. Ruby 2.5.0 on trunk currently vendors the newly minted Bundler 1.16.1, but it breaks [the rails test suite](https://travis-ci.org/rails/rails/builds/319911098) and [rails binstubs](https://github.com/rails/webpacker/issues/998#issuecomment-353461343). Part of the buildpack's value is to alleviate users of this pain, so this patch creates a shim around Bundler so the buildpack can control the version of Bundler used. This patch lets users take advantage of Ruby 2.5.0 without the current problems with the vendored version of Bundler.

* reverts commit 26d0eddf7dcfc079e5604f0cfc07466e88a8fa49. This isn't needed anymore since https://bugs.ruby-lang.org/issues/13997 is now fixed.
* create a shim around Bundler, so every version of Ruby uses the same version of Bundler (`1.15.2`)