### PR TITLE
Ruby 2.5.0 will not vendor Bundler in the final release

### DIFF
--- a/lib/language_pack/installers/ruby_installer.rb
+++ b/lib/language_pack/installers/ruby_installer.rb
@@ -24,7 +24,7 @@ module LanguagePack::Installers::RubyInstaller
     run("ln -s ruby #{install_dir}/bin/ruby.exe")
 
     Dir["#{install_dir}/bin/*"].each do |vendor_bin|
-      # for Ruby 2.5.0+ don't symlink the Bundler bin so our shim works
+      # for Ruby 2.6.0+ don't symlink the Bundler bin so our shim works
       next if vendor_bin.include?("bundle")
       run("ln -s ../#{vendor_bin} #{DEFAULT_BIN_DIR}")
     end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -443,7 +443,7 @@ ERROR
       end
 
       # write bundler shim, so we can control the version bundler used
-      # Ruby 2.5.0 started vendoring bundler
+      # Ruby 2.6.0 started vendoring bundler
       write_bundler_shim("vendor/bundle/bin") if ruby_version.vendored_bundler?
     end
   end

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -93,7 +93,7 @@ module LanguagePack
 
     # does this vendor bundler
     def vendored_bundler?
-      Gem::Version.new(self.ruby_version) >= Gem::Version.new("2.5.0dev")
+      false
     end
 
     private


### PR DESCRIPTION
This removes the shim work to work around that.