### PR TITLE
Only set JAVA_HOME for Bundler when using JRuby

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,8 @@ machine:
 
 test:
   pre:
+    - wget -qO- https://cli-assets.heroku.com/install-ubuntu.sh | sh
+    - heroku --version
     - bundle exec rake hatchet:setup_travis
   override:
     - bundle exec parallel_rspec -n 11 spec/

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -638,9 +638,9 @@ WARNING
             "LIBRARY_PATH"                  => noshellescape("#{yaml_lib}:$LIBRARY_PATH"),
             "RUBYOPT"                       => syck_hack,
             "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
-            "JAVA_HOME"                     => noshellescape("#{pwd}/$JAVA_HOME"),
             "BUNDLE_DISABLE_VERSION_CHECK"  => "true"
           }
+          env_vars["JAVA_HOME"] = noshellescape("#{pwd}/$JAVA_HOME") if ruby_version.jruby?
           env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
           puts "Running: #{bundle_command}"
           instrument "ruby.bundle_install" do


### PR DESCRIPTION
The `JAVA_HOME` env var is absolute when using `heroku/jvm` buildpack, which causes this env var to be the invalid dir `/app/app/.jdk`.We should only set the env var when using JRuby.

A follow up to this PR should make the `@jvm_installer.java_home` absolute. But it's derived from `slug_vendor_jvm`, which is relative (along with all the other `vendor` references). I'm not sure if we want to make that one different.