### PR TITLE
Stop Bundler from using load to launch an executable in-process in `bundle exec`

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -639,7 +639,9 @@ WARNING
             "RUBYOPT"                       => syck_hack,
             "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
             "JAVA_HOME"                     => noshellescape("#{pwd}/$JAVA_HOME"),
-            "BUNDLE_DISABLE_VERSION_CHECK"  => "true"
+            "BUNDLE_DISABLE_VERSION_CHECK"  => "true",
+            # https://github.com/bundler/bundler/issues/6090
+            "BUNDLE_DISABLE_EXEC_LOAD"      => "true"
           }
           env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
           puts "Running: #{bundle_command}"


### PR DESCRIPTION
See https://github.com/bundler/bundler/issues/6090. This stops
SignalException from being handled by Bundler when using `bundle exec`
and instead by Ruby. As of Puma 3.10.0, Puma changed the SIGTERM
hanlding to be passed back to the parent process, `bundle exec` in this
case.