### PR TITLE
Execute Rake in context of current bundle

### DIFF
--- a/bin/support/ruby_test
+++ b/bin/support/ruby_test
@@ -53,9 +53,9 @@ execute_test(
   elsif File.exist?("bin/rails") && bundler.has_gem?("railties") && bundler.gem_version("railties") >= Gem::Version.new("5.x")
     "bin/rails test"
   elsif File.exist?("bin/rake")
-    "bin/rake test"
+    "bundle exec bin/rake test"
   else
-    "rake test"
+    "bundle exec rake test"
   end
 )
 


### PR DESCRIPTION
I have a Ruby 2.4.3 app that depends on Rake 10.4.2 and uses minitest.

Trying to use Heroku CI yields this error:

    -----> Running test: bin/rake test
           rake aborted!
           Gem::LoadError: You have already activated rake 12.0.0, but your Gemfile requires rake 10.4.2. Prepending `bundle exec` to your command may solve this.
           /app/vendor/bundle/ruby/2.4.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:317:in `check_for_activated_spec!'
           /app/vendor/bundle/ruby/2.4.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:32:in `block in setup'
           /app/vendor/bundle/ruby/2.4.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:27:in `map'
           /app/vendor/bundle/ruby/2.4.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:27:in `setup'
           /app/vendor/bundle/ruby/2.4.0/gems/bundler-1.15.2/lib/bundler.rb:101:in `setup'
           /app/vendor/bundle/ruby/2.4.0/gems/bundler-1.15.2/lib/bundler/setup.rb:19:in `<top (required)>'
           /app/Rakefile:1:in `<top (required)>'
           LoadError: cannot load such file -- bundler/setup
           /app/Rakefile:1:in `<top (required)>'
           (See full trace by running task with --trace)

This is due to Ruby 2.4.3 shipping with Rake 12.0.0.

The same error can be reproduced outside Heroku CI by running either `heroku run bin/rake --tasks` or `heroku run rake --tasks`. Inserting `bundle exec` resolves the issue.

(I wasn't sure whether to update both cases but it seems necessary as long as Ruby includes a Rake version.)