### PR TITLE
Upgrade node and yarn versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Node version upgraded to v8.9.4 (@josephpage)
-* Yarn version upgraded to v1.5.1 (@josephpage)
+* Node version upgraded to v8.10.0 (#714, @josephpage)
+* Yarn version upgraded to v1.5.1 (#714, @josephpage)
 
 ## v174 (02/13/2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Master
 
+## Unreleased
+
+* Node version upgraded to v8.9.4 (@josephpage)
+* Yarn version upgraded to v1.5.1 (@josephpage)
+
 ## v174 (02/13/2018)
 
 * Only set JAVA_HOME for Bundler when using JRuby (#649, @jkutner)

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -11,7 +11,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_node_lts
-    version = "6.11.1"
+    version = "8.9.4"
     {
       "number" => version,
       "url"    => "https://s3pository.heroku.com/node/v#{version}/node-v#{version}-linux-x64.tar.gz"
@@ -19,7 +19,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_yarn
-    version = "1.0.2"
+    version = "1.5.1"
     {
       "number" => version,
       "url"    => "https://yarnpkg.com/downloads/#{version}/yarn-v#{version}.tar.gz"

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -11,7 +11,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_node_lts
-    version = "8.9.4"
+    version = "8.10.0"
     {
       "number" => version,
       "url"    => "https://s3pository.heroku.com/node/v#{version}/node-v#{version}-linux-x64.tar.gz"


### PR DESCRIPTION
Node 8.10.0 is the latest LTS, since node 6.x is near end of its "active" life.
(https://github.com/nodejs/Release)

Yarn 1.5.1 is the latest stable release.
(https://github.com/yarnpkg/yarn/releases)

@hone @schneems @jkutner your reviews are eagerly awaited !

Thanks !

------
Edited since creation :
 - node from 8.9.4 to 8.10.0 (2018-03-15)