### PR TITLE
Fix buildpack logging with prefix

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -10,6 +10,7 @@ require "language_pack/fetcher"
 require "language_pack/instrument"
 
 Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
+ENV["BPLOG_PREFIX"] = "buildpack.ruby"
 
 # abstract class that all the Ruby based Language Packs inherit from
 class LanguagePack::Base

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -1,6 +1,5 @@
 require "shellwords"
 
-
 class BuildpackError < StandardError
 end
 
@@ -166,7 +165,11 @@ module LanguagePack
       def private_log(name, key_value_hash)
         File.open(ENV["BUILDPACK_LOG_FILE"] || "/dev/null", "a+") do |f|
           key_value_hash.each do |key, value|
-            f.puts "#{name}##{ENV["BPLOG_PREFIX"]}#{key}=#{value}"
+            metric = String.new("#{name}#")
+            metric << "#{ENV["BPLOG_PREFIX"]}"
+            metric << "." unless metric.end_with?('.')
+            metric << "#{key}=#{value}"
+            f.puts metric
           end
         end
       end

--- a/spec/helpers/shell_spec.rb
+++ b/spec/helpers/shell_spec.rb
@@ -21,7 +21,7 @@ describe "ShellHelpers" do
         Tempfile.open("logfile.log") do |f|
           ENV["BUILDPACK_LOG_FILE"] = f.path
           FakeShell.new.mcount "foo"
-          expect(File.read(f.path)).to match("count#foo=1")
+          expect(File.read(f.path)).to match("count#buildpack.ruby.foo=1")
         end
       ensure
         ENV["BUILDPACK_LOG_FILE"] = original


### PR DESCRIPTION
- Add prefix for Ruby buildpack
- Ensure log prefix ends with a dot.