### PR TITLE
[close #634] Allow Running Ruby outside of default directory

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -18,6 +18,7 @@
     "sharpstone/bundle-ruby-version-not-in-lockfile"
   ],
   "ruby": [
+    "sharpstone/cd_ruby",
     "sharpstone/mri_187",
     "sharpstone/mri_193_p547",
     "sharpstone/ruby_193_jruby_173",

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -97,6 +97,8 @@
   - 136e3e2627ed5e64e1491f9aff2b402462ce3d25
 - - "./repos/ruby/bad_ruby_version"
   - 7bf3470265a87ea6361640aa4bfce6ce3b743520
+- - "./repos/ruby/cd_ruby"
+  - 5d4139af87bbb941008ef945408eb8b6a5276369
 - - "./repos/ruby/empty-procfile"
   - 7cae0aae424c2028b81b5d37ee24d42db8e545b9
 - - "./repos/ruby/jruby-minimal"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -428,7 +428,7 @@ ERROR
   # setup the environment so we can use the vendored ruby
   def setup_ruby_install_env
     instrument 'ruby.setup_ruby_install_env' do
-      ENV["PATH"] = "#{ruby_install_binstub_path}:#{ENV["PATH"]}"
+      ENV["PATH"] = "#{File.expand_path(ruby_install_binstub_path)}:#{ENV["PATH"]}"
 
       if ruby_version.jruby?
         ENV['JAVA_OPTS']  = default_java_opts

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -1,6 +1,15 @@
 require_relative '../spec_helper'
 
 describe "Ruby apps" do
+
+  describe "running Ruby from outside the default dir" do
+    it "works" do
+      Hatchet::Runner.new('cd_ruby').deploy do |app|
+        expect(app.output).to match("2.3.5")
+      end
+    end
+  end
+
   describe "bundler ruby version matcher" do
     it "installs a version even when not present in the Gemfile.lock" do
       Hatchet::Runner.new('bundle-ruby-version-not-in-lockfile').deploy do |app|


### PR DESCRIPTION
Currently you cannot run `ruby` outside of your default directory because all paths to the user’s version of ruby are relative paths. This forces the relative path to be an absolute path so that Ruby commands are available from anywhere on the system.

Linking #634