### PR TITLE
Fix double newline printing

### DIFF
--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -133,7 +133,7 @@ module LanguagePack
     # @param [String] message to be displayed
     def puts(message)
       message.each_line do |line|
-        if line.end_with?('\n'.freeze)
+        if line.end_with?("\n".freeze)
           print "       #{line}"
         else
           print "       #{line}\n"

--- a/spec/helpers/shell_spec.rb
+++ b/spec/helpers/shell_spec.rb
@@ -19,6 +19,15 @@ describe "ShellHelpers" do
     include LanguagePack::ShellHelpers
   end
 
+  describe "pipe" do
+    it "does not double append newlines" do
+      sh = FakeShell.new
+      sh.pipe('bundle install')
+      first_line = sh.print_calls.first.first
+      expect(first_line.end_with?("\n\n")).to be(false)
+    end
+  end
+
   describe "mcount" do
     it "logs to a file" do
       begin


### PR DESCRIPTION
Introduced in #724 the `puts` method now uses `print` but appends a newline if it’s not already present. Unfortunately the string in the `end_with?` call is using single quotes instead of double quotes, so it is checking for a string that literally ends with a slash and an n rather than the newline character.

Switching to double quotes fixes the issue.

This bug manifested itself as showing bundle installs with two newlines instead of one. 

Before the output would look like this (with an extra newline):

```
       Using rake 12.0.0

       Using concurrent-ruby 1.0.5
```

After this PR it looks like this (matches bundle install output locally):

```
       Using rake 12.0.0
       Using concurrent-ruby 1.0.5
```