### PR TITLE
Bundler 1.16.1 support

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.15.2"
+  BUNDLER_VERSION      = "1.16.1"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
Fixes bundler/dep_proxy failure with Ruby 2.6.0preview1

```
Traceback (most recent call last):
        15: from /foo/bar.rb:10:in `<main>'
        14: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler.rb:108:in `require'
        13: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler.rb:103:in `setup'
        12: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:21:in `setup'
        11: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:218:in `specs_for'
        10: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:159:in `specs'
         9: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:228:in `resolve'
         8: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:779:in `converge_locked_specs'
         7: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:842:in `expand_dependencies'
         6: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:842:in `each'
         5: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:855:in `block in expand_dependencies'
         4: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:855:in `each'
         3: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/bundle/ruby/2.6.0/gems/bundler-1.15.2/lib/bundler/definition.rb:856:in `block (2 levels) in expand_dependencies'
         2: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:39:in `require'
         1: from /slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
/slugs/manager-1a3f59449e229e7a76dfc3dfb056ed6dec2db1a5/vendor/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:135:in `require': cannot load such file -- bundler/dep_proxy (LoadError)
```