### PR TITLE
Disable listing check for disabling cops

### DIFF
--- a/lib/language_pack/test/rails2.rb
+++ b/lib/language_pack/test/rails2.rb
@@ -36,6 +36,7 @@ class LanguagePack::Rails2
   def clear_db_test_tasks
     FileUtils::mkdir_p 'lib/tasks'
     File.open("lib/tasks/heroku_clear_tasks.rake", "w") do |file|
+      file.puts "# rubocop:disable Lint/UnneededDisable"
       file.puts "# rubocop:disable all"
       content = db_test_tasks_to_clear.map do |task_name|
         <<-FILE
@@ -47,6 +48,7 @@ end
 FILE
       end.join("\n")
       file.print content
+      file.puts "# rubocop:enable Lint/UnneededDisable"
       file.puts "# rubocop:enable all"
     end
   end


### PR DESCRIPTION
For a backstory see https://github.com/bbatsov/rubocop/issues/4459

You can configure rubocop to error out when anyone disables rubocop errors. Which is fine, except the Ruby buildpack needs to do that. We needed a way to disable that check, so this feature was added https://github.com/bbatsov/rubocop/pull/4938.

This PR is using that feature to hopefully allow anyone to deploy and not get errors from rubocop.