### PR TITLE
Provide explicit directory for file location

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -10,7 +10,7 @@ name = "Ruby"
   # get tokens for logging build tokens
   url = "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz"
   dir = "."
-  files = [".env"]
+  files = ["./.env"]
   [[publish.Vendor]]
   url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar-14/ruby-2.5.1.tgz"
   dir = "vendor/ruby/cedar-14"


### PR DESCRIPTION
The `.env` file is inside of the `./` directory.