### PR TITLE
Allow for Rails Runner timeout

### DIFF
--- a/lib/language_pack/helpers/rails_runner.rb
+++ b/lib/language_pack/helpers/rails_runner.rb
@@ -118,13 +118,17 @@ class LanguagePack::Helpers::RailsRunner
       @success = $?.success?
 
       unless @success
-        warn("Detecting rails configuration failed\nset HEROKU_DEBUG_RAILS_RUNNER=1 to debug")
+        message = String.new("Detecting rails configuration failed\n")
+        message << "set HEROKU_DEBUG_RAILS_RUNNER=1 to debug" unless @debug
+        warn(message)
         mcount("warn.rails.runner.fail")
       end
       return out
     rescue Timeout::Error
       @success = false
-      warn("Detecting rails configuration timeout\nset HEROKU_DEBUG_RAILS_RUNNER=1 to debug")
+      message = String.new("Detecting rails configuration timeout\n")
+      message << "set HEROKU_DEBUG_RAILS_RUNNER=1 to debug" unless @debug
+      warn(message)
       mcount("warn.rails.runner.timeout")
       return out
     end

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -108,12 +108,13 @@ module LanguagePack
     # run a shell command and stream the output
     # @param [String] command to be run
     def pipe(command, options = {})
-      output = ""
+      output = options[:buffer] || ""
+      silent = options[:silent]
       IO.popen(command_options_to_string(command, options)) do |io|
         until io.eof?
           buffer = io.gets
           output << buffer
-          puts buffer
+          puts buffer unless silent
         end
       end
 

--- a/spec/helpers/rails_runner_spec.rb
+++ b/spec/helpers/rails_runner_spec.rb
@@ -27,5 +27,83 @@ describe "Rails Runner" do
     local_storage.did_match?("foo")
     expect(rails_runner.called).to eq(1)
   end
+
+  it "calls a mock interface" do
+    Dir.mktmpdir do |tmpdir|
+      Dir.chdir(tmpdir) do
+        mock_rails_runner
+        expect(File.executable?("bin/rails")).to eq(true)
+
+        rails_runner  = LanguagePack::Helpers::RailsRunner.new
+        local_storage = rails_runner.detect("active_storage.service")
+
+        expect(rails_runner.output).to match("heroku.detecting.config.for.active_storage.service=active_storage.service")
+        expect(rails_runner.success?).to be(true)
+      end
+    end
+  end
+
+  it "timeout works as expected" do
+    Dir.mktmpdir do |tmpdir|
+      Dir.chdir(tmpdir) do
+        mock_rails_runner("sleep(0.05)")
+
+        rails_runner  = LanguagePack::Helpers::RailsRunner.new(false, 0.01)
+        local_storage = rails_runner.detect("active_storage.service")
+
+        expect(rails_runner.success?).to eq(false)
+      end
+    end
+  end
+
+  it "failure in one task does not cause another to fail" do
+    Dir.mktmpdir do |tmpdir|
+      Dir.chdir(tmpdir) do
+        mock_rails_runner('raise "bad" if value == :bad')
+
+        rails_runner  = LanguagePack::Helpers::RailsRunner.new(false, 1)
+        bad_value     = rails_runner.detect("bad.value")
+        local_storage = rails_runner.detect("active_storage.service")
+
+        expect(!!bad_value.success?).to     eq(false)
+        expect(!!local_storage.success?).to eq(true)
+      end
+    end
+  end
+
+  def mock_rails_runner(try_code = "")
+        executable_contents = <<-FILE
+#!/usr/bin/env ruby
+
+require 'ostruct'
+
+class Object
+  def try(value)
+    $tried ||= []
+    $tried << value
+    #{try_code}
+    $tried.join(".")
+  end
+end
+
+module Rails; end
+
+def Rails.application
+  OpenStruct.new(config: Object.new)
+end
+
+ARGV.shift # remove "runner"
+
+eval(ARGV.join(" "))
+FILE
+    FileUtils.mkdir("bin")
+    File.open("bin/rails", "w") { |f| f << executable_contents }
+    File.chmod(0777, "bin/rails")
+    ENV["PATH"] = "./bin/:#{ENV['PATH']}" unless ENV["PATH"].include?("./bin:")
+
+    # BUILDPACK_LOG_FILE support for logging
+    FileUtils.mkdir("tmp")
+    FileUtils.touch("buildpack.log")
+  end
 end
 


### PR DESCRIPTION
It is assumed that all Rails apps can boot within 60 seconds since this is the timeout for binding to a processes. While testing this feature to a subset of Heroku users (on master branch) an issue came up where it appeared that this call would “hang” and prevent the build from succeeding. This should never happen.

To prevent an indefinite hang, a timeout is added to the `rails runner call`. If it exceeds 65 seconds the task will fail.

When this happens a warning will be emitted along with steps on how to debug (by adding `HEROKU_DEBUG_RAILS_RUNNER=1`) to config.

Tests are added to this feature to simulate actually calling a `rails` executable.