### PR TITLE
Fix Rails Runner timeout

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -34,8 +34,6 @@ class LanguagePack::Base
       @metadata      = LanguagePack::Metadata.new(@cache)
       @bundler_cache = LanguagePack::BundlerCache.new(@cache, @stack)
       @id            = Digest::SHA1.hexdigest("#{Time.now.to_f}-#{rand(1000000)}")[0..10]
-      @warnings      = []
-      @deprecations  = []
       @fetchers      = {:buildpack => LanguagePack::Fetcher.new(VENDOR_URL) }
 
       Dir.chdir build_path
@@ -84,12 +82,12 @@ class LanguagePack::Base
     write_release_yaml
     instrument 'base.compile' do
       Kernel.puts ""
-      @warnings.each do |warning|
-        Kernel.puts "###### WARNING:"
+      warnings.each do |warning|
+        Kernel.puts "###### WARNING:\n"
         puts warning
         Kernel.puts ""
       end
-      if @deprecations.any?
+      if deprecations.any?
         topic "DEPRECATIONS:"
         puts @deprecations.join("\n")
       end

--- a/lib/language_pack/helpers/rails_runner.rb
+++ b/lib/language_pack/helpers/rails_runner.rb
@@ -40,6 +40,7 @@ class LanguagePack::Helpers::RailsRunner
       @debug        = options[:debug]
 
       @success      = nil
+      @did_time_out = false
       @heroku_key   = "heroku.detecting.config.for.#{config}"
 
       @rails_config = String.new('#{')
@@ -77,7 +78,7 @@ class LanguagePack::Helpers::RailsRunner
     @output        = nil
     @success       = false
     @debug         = debug
-    @timeout       = timeout # seconds
+    @timeout_val   = timeout # seconds
   end
 
   def detect(config_string)
@@ -98,38 +99,57 @@ class LanguagePack::Helpers::RailsRunner
     %Q{rails runner "#{@command_array.join(' ')}"}
   end
 
+  def timeout?
+    @did_time_out
+  end
+
   private
     def call
       topic("Detecting rails configuration")
+      puts "$ #{command}" if @debug
       out = execute_command!
-
-      if @debug
-        puts "$ #{command}"
-        puts out
-      end
+      puts out if @debug
       out
     end
 
-    def execute_command!
-      out = String.new
-      Timeout.timeout(@timeout) do
-        pipe(command, user_env: true, silent: true, buffer: out)
-      end
-      @success = $?.success?
+    def silent
+      return false if @debug
+      true
+    end
 
-      unless @success
+    def timeout
+      Timeout.timeout(@timeout_val) do
+        yield
+      end
+    rescue Timeout::Error
+      @success      = false
+      @did_time_out = true
+    end
+
+    def execute_command!
+      # Output is written to a file so if
+      # the process gets timed out, the contents of the file
+      # containing the partial output can be used for debugging
+      config_detect_file = Pathname.new(".heroku/ruby/config_detect/rails.txt")
+      config_detect_file.dirname.mkpath
+      timeout do
+        f = run(command, user_env: true, out: ">> #{config_detect_file} 2>&1") # Redirect stdout and stderr to file https://stackoverflow.com/questions/876239/how-can-i-redirect-and-append-both-stdout-and-stderr-to-a-file-with-bash
+        @success = $?.success?
+      end
+      out = config_detect_file.read
+
+      if timeout?
+        message = String.new("Detecting rails configuration timeout\n")
+        message << "set HEROKU_DEBUG_RAILS_RUNNER=1 to debug" unless @debug
+        warn(message)
+        mcount("warn.rails.runner.timeout")
+      elsif !@success
         message = String.new("Detecting rails configuration failed\n")
         message << "set HEROKU_DEBUG_RAILS_RUNNER=1 to debug" unless @debug
         warn(message)
         mcount("warn.rails.runner.fail")
       end
-      return out
-    rescue Timeout::Error
-      @success = false
-      message = String.new("Detecting rails configuration timeout\n")
-      message << "set HEROKU_DEBUG_RAILS_RUNNER=1 to debug" unless @debug
-      warn(message)
-      mcount("warn.rails.runner.timeout")
+
       return out
     end
 end

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -12,6 +12,16 @@ end
 module LanguagePack
   module ShellHelpers
     @@user_env_hash = {}
+    @@warnings      = []
+    @@deprecations  = []
+
+    def warnings
+      @@warnings
+    end
+
+    def deprecations
+      @@deprecations
+    end
 
     def mcount(key, value = 1)
       private_log("count", key => value)
@@ -157,8 +167,7 @@ module LanguagePack
         puts message
         Kernel.puts ""
       end
-      @warnings ||= []
-      @warnings << message
+      warnings << message
     end
 
     def error(message)
@@ -166,8 +175,7 @@ module LanguagePack
     end
 
     def deprecate(message)
-      @deprecations ||= []
-      @deprecations << message
+      deprecations << message
     end
 
     def noshellescape(string)


### PR DESCRIPTION
IO.popen cannot be timed out reliably: https://stackoverflow.com/questions/17237743/timeout-within-a-popen-works-but-popen-inside-a-timeout-doesnt

The issue is that the process can do something like `Process.spawn && wait` which defers control to a different process. Ruby cannot wake the process up in order to terminate it so when `io.close` is called (at the end of the block), the process deadlocks on the child process being terminated which may never happen.

The `run` command can reliably be killed because it does not depend on the child process successfully exiting to be terminated. However the whole reason I was using `pipe` is to provide debugging output for this feature. 

If we simply use `Timeout.timeout() { out = run }` and time out the call then we never get the output from the `run` command (because the execution fires before it can be set.

To meet our needs we need:

- To be able to reliably time out this command.
- To provide debugging output for when the command fails or times out.

The alternative that I came up with is to tell the `run` command to write to a file while it is running. If the command is killed via a timeout then the contents of the file are preserved and can be used for debugging. 
The updated timeout test fails on master, and passes on this branch.

Related support ticket number: 597095
