### PR TITLE
Allow warnings to work with multiple classes

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -34,8 +34,6 @@ class LanguagePack::Base
       @metadata      = LanguagePack::Metadata.new(@cache)
       @bundler_cache = LanguagePack::BundlerCache.new(@cache, @stack)
       @id            = Digest::SHA1.hexdigest("#{Time.now.to_f}-#{rand(1000000)}")[0..10]
-      @warnings      = []
-      @deprecations  = []
       @fetchers      = {:buildpack => LanguagePack::Fetcher.new(VENDOR_URL) }
 
       Dir.chdir build_path
@@ -84,12 +82,12 @@ class LanguagePack::Base
     write_release_yaml
     instrument 'base.compile' do
       Kernel.puts ""
-      @warnings.each do |warning|
-        Kernel.puts "###### WARNING:"
+      warnings.each do |warning|
+        Kernel.puts "###### WARNING:\n"
         puts warning
         Kernel.puts ""
       end
-      if @deprecations.any?
+      if deprecations.any?
         topic "DEPRECATIONS:"
         puts @deprecations.join("\n")
       end

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -12,6 +12,16 @@ end
 module LanguagePack
   module ShellHelpers
     @@user_env_hash = {}
+    @@warnings      = []
+    @@deprecations  = []
+
+    def warnings
+      @@warnings
+    end
+
+    def deprecations
+      @@deprecations
+    end
 
     def mcount(key, value = 1)
       private_log("count", key => value)
@@ -157,8 +167,7 @@ module LanguagePack
         puts message
         Kernel.puts ""
       end
-      @warnings ||= []
-      @warnings << message
+      warnings << message
     end
 
     def error(message)
@@ -166,8 +175,7 @@ module LanguagePack
     end
 
     def deprecate(message)
-      @deprecations ||= []
-      @deprecations << message
+      deprecations << message
     end
 
     def noshellescape(string)


### PR DESCRIPTION
As written warnings are expected to be directly on a buildpack class. This is not always the case, for example the `RailsRunner` object can warn.

To fix this we need shared mutable state between everything that inherits from shell helpers. Since both instances and classes use these methods they should be shared between the two via a class variable.