### PR TITLE
Colorize buildpack failures

### DIFF
--- a/bin/support/ruby_compile
+++ b/bin/support/ruby_compile
@@ -22,14 +22,5 @@ begin
     end
   end
 rescue Exception => e
-  Kernel.puts " !"
-  e.message.split("\n").each do |line|
-    Kernel.puts " !     #{line.strip}"
-  end
-  Kernel.puts " !"
-  if e.is_a?(BuildpackError)
-    exit 1
-  else
-    raise e
-  end
+  LanguagePack::ShellHelpers.display_error_and_exit(e)
 end

--- a/bin/support/ruby_test-compile
+++ b/bin/support/ruby_test-compile
@@ -16,6 +16,7 @@ $:.unshift File.expand_path("../../../lib", __FILE__)
 require "language_pack"
 require "language_pack/shell_helpers"
 require "language_pack/test"
+include LanguagePack::ShellHelpers
 
 begin
   LanguagePack::Instrument.trace 'test_compile', 'app.test_compile' do
@@ -28,14 +29,5 @@ begin
     end
   end
 rescue Exception => e
-  Kernel.puts " !"
-  e.message.split("\n").each do |line|
-    Kernel.puts " !     #{line.strip}"
-  end
-  Kernel.puts " !"
-  if e.is_a?(BuildpackError)
-    exit 1
-  else
-    raise e
-  end
+  LanguagePack::ShellHelpers.display_error_and_exit(e)
 end

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -81,7 +81,7 @@ class LanguagePack::Base
   def compile
     write_release_yaml
     instrument 'base.compile' do
-      Kernel.puts ""
+      Kernel.puts "\e[1m\e[33m" # Bold yellow
       warnings.each do |warning|
         Kernel.puts "###### WARNING:\n"
         puts warning
@@ -91,6 +91,7 @@ class LanguagePack::Base
         topic "DEPRECATIONS:"
         puts @deprecations.join("\n")
       end
+      Kernel.puts "\e[0m"
     end
     mcount "success"
   end

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -81,9 +81,10 @@ class LanguagePack::Base
   def compile
     write_release_yaml
     instrument 'base.compile' do
-      Kernel.puts "\e[1m\e[33m" # Bold yellow
+      Kernel.puts ""
       warnings.each do |warning|
-        Kernel.puts "###### WARNING:\n"
+        Kernel.puts "\e[1m\e[33m###### WARNING:\e[0m"# Bold yellow
+        Kernel.puts ""
         puts warning
         Kernel.puts ""
       end
@@ -91,7 +92,7 @@ class LanguagePack::Base
         topic "DEPRECATIONS:"
         puts @deprecations.join("\n")
       end
-      Kernel.puts "\e[0m"
+      Kernel.puts ""
     end
     mcount "success"
   end

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -62,6 +62,22 @@ module LanguagePack
       end
     end
 
+    # Should only be used once in the top level script
+    # for example $ bin/support/ruby_compile
+    def self.display_error_and_exit(e)
+      Kernel.puts "\e[1m\e[31m"
+      Kernel.puts " !"
+      e.message.split("\n").each do |line|
+        Kernel.puts " !     #{line.strip}"
+      end
+      Kernel.puts " !\e[0m"
+      if e.is_a?(BuildpackError)
+        exit 1
+      else
+        raise e
+      end
+    end
+
     # run a shell command (deferring to #run), and raise an error if it fails
     # @param [String] command to be run
     # @return [String] result of #run

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -259,9 +259,10 @@ module LanguagePack
 
     def warn(message, options = {})
       if options.key?(:inline) ? options[:inline] : false
-        Kernel.puts "###### WARNING:"
+        Kernel.puts "\e[1m\e[33m" # Bold yellow
+        Kernel.puts "###### WARNING:\n"
         puts message
-        Kernel.puts ""
+        Kernel.puts "\e[0m"
       end
       warnings << message
     end

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -65,7 +65,7 @@ module LanguagePack
     # Should only be used once in the top level script
     # for example $ bin/support/ruby_compile
     def self.display_error_and_exit(e)
-      Kernel.puts "\e[1m\e[31m"
+      Kernel.puts "\e[1m\e[31m" # Bold Red
       Kernel.puts " !"
       e.message.split("\n").each do |line|
         Kernel.puts " !     #{line.strip}"

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -259,10 +259,11 @@ module LanguagePack
 
     def warn(message, options = {})
       if options.key?(:inline) ? options[:inline] : false
-        Kernel.puts "\e[1m\e[33m" # Bold yellow
-        Kernel.puts "###### WARNING:\n"
+        Kernel.puts ""
+        Kernel.puts "\e[1m\e[33m###### WARNING:\e[0m" # Bold yellow
+        Kernel.puts ""
         puts message
-        Kernel.puts "\e[0m"
+        Kernel.puts ""
       end
       warnings << message
     end


### PR DESCRIPTION
Example output for Errors:

![](https://www.dropbox.com/s/5j2y7sszcea9huk/Screenshot%202018-07-02%2020.46.38.png?raw=1)

Example output for Warnings:

![](https://www.dropbox.com/s/1mhl4j6n106cx5d/Screenshot%202018-07-02%2020.52.26.png?raw=1&bust-cache=true)