### PR TITLE
Close #783 Warn on `action_dispatch.x_sendfile_header`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+## v190 (unreleased)
+
+* Warn when `config.action_dispatch.x_sendfile_header` is set but apache and nginx are not being used (https://github.com/heroku/heroku-buildpack-ruby/pull/795)
+
 ## v190 (7/24/2018)
 
 * Support TAP output for Heroku CI (https://github.com/heroku/heroku-buildpack-ruby/pull/790).

--- a/spec/hatchet/warnings_spec.rb
+++ b/spec/hatchet/warnings_spec.rb
@@ -1,0 +1,48 @@
+require_relative "../spec_helper"
+
+describe "Best practice warnings" do
+  it "should warn when using x_sendfile_header" do
+    app = Hatchet::Runner.new("rails5")
+    app.in_directory do
+      add_composer_json!
+      set_x_sendfile_config!
+
+      app.setup!
+      app.push_with_retry!
+    end
+
+    assert(app.output).to match(%r{you do not have `apache` installed on this app})
+  ensure
+    app.teardown! if app
+  end
+
+  it "should not warn when binary is present" do
+    buildpacks = [
+      "heroku/php", # used for adding apache
+      Hatchet::App.default_buildpack
+    ]
+    app = Hatchet::Runner.new("rails5", buildpacks: buildpacks)
+    app.in_directory do
+      add_composer_json!
+      set_x_sendfile_config!
+
+      app.setup!
+      app.push_with_retry!
+    end
+
+    assert(app.output).to_not match(%r{you do not have `apache` installed on this app})
+  ensure
+    app.teardown! if app
+  end
+
+  def set_x_sendfile_config!
+    run!(%Q{echo "config.action_dispatch.x_sendfile_header = 'X-Sendfile'" > config/initializers/sendfile.rb})
+    run!(%Q{git add -A; git commit -m 'changing config'})
+  end
+
+  # Puts apache on the path
+  def add_composer_json!
+    run!('echo {} > composer.json')
+    run!(%Q{git add -A; git commit -m 'Adding apache'})
+  end
+end


### PR DESCRIPTION
When serving files if the `action_dispatch.x_sendfile_header` is set then it is essentially saying “i don’t need to serve this asset, let nginx or apache do it for me”. The problem is…on heroku most people aren’t using apache or nginx so this causes a silent failure that is hard to debug.

This warning will hopefully help people identify their mistake earlier.