### PR TITLE
Ignore bundler warning

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -54,7 +54,6 @@
     "sharpstone/rails3_runtime_assets",
     "sharpstone/rails3-fail-assets-compile",
     "sharpstone/rails3-fail-rakefile"
-
   ],
   "rails4": [
     "sharpstone/rails4-manifest",

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -652,8 +652,10 @@ WARNING
             "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
             "BUNDLE_DISABLE_VERSION_CHECK"  => "true"
           }
-          env_vars["JAVA_HOME"] = noshellescape("#{pwd}/$JAVA_HOME") if ruby_version.jruby?
-          env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
+          env_vars["JAVA_HOME"]                    = noshellescape("#{pwd}/$JAVA_HOME") if ruby_version.jruby?
+          env_vars["BUNDLER_LIB_PATH"]             = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
+          env_vars["BUNDLE_DISABLE_VERSION_CHECK"] = "true"
+
           puts "Running: #{bundle_command}"
           instrument "ruby.bundle_install" do
             bundle_time = Benchmark.realtime do

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -4,6 +4,9 @@ describe "Rails 5" do
   it "works" do
     Hatchet::Runner.new("rails5").deploy do |app, heroku|
       expect(app.run("rails -v")).to match("")
+
+      # Test BUNDLE_DISABLE_VERSION_CHECK works
+      expect(app.output).not_to include("The latest bundler is")
     end
   end
 

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -71,7 +71,7 @@ describe "Ruby apps" do
     context "no active record" do
       it "writes a heroku specific database.yml" do
         Hatchet::Runner.new("default_ruby").deploy do |app, heroku|
-          expect(app.output).to include("Writing config/database.yml to read from DATABASE_URL")
+          expect(app.output).to     include("Writing config/database.yml to read from DATABASE_URL")
           expect(app.output).not_to include("Your app was upgraded to bundler")
         end
       end


### PR DESCRIPTION
Close #772, get rid of this annoying warning:

```
       Warning: the running version of Bundler (1.15.2) is older than the version that created the lockfile (1.16.1). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.

       The latest bundler is 1.16.3, but you are currently running 1.15.2.
```