### PR TITLE
Cache Webpacker builds between deploys

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -66,6 +66,14 @@ WARNING
     "tmp/cache/assets"
   end
 
+  def public_packs_folder
+    "public/packs"
+  end
+
+  def default_webpacker_cache
+    "tmp/cache/webpacker"
+  end
+
   def run_assets_precompile_rake_task
     instrument "rails4.run_assets_precompile_rake_task" do
       log("assets_precompile") do
@@ -80,7 +88,9 @@ WARNING
         topic("Preparing app for Rails asset pipeline")
 
         @cache.load_without_overwrite public_assets_folder
+        @cache.load_without_overwrite public_packs_folder
         @cache.load default_assets_cache
+        @cache.load default_webpacker_cache
 
         precompile.invoke(env: rake_env)
 
@@ -93,7 +103,9 @@ WARNING
 
           cleanup_assets_cache
           @cache.store public_assets_folder
+          @cache.store public_packs_folder
           @cache.store default_assets_cache
+          @cache.store default_webpacker_cache
         else
           precompile_fail(precompile.output)
         end


### PR DESCRIPTION
 ## Goal
Save 5-10 minutes per deploy by using Webpacker's existing caching to skip running Webpack on builds where no changes are made.

 ## Approach
Use Heroku's deploy cache to cache Webpacker's default **public output** and **cache** paths.

 ## Context
Currently all deploys using Webpacker, unless very specifically configured, will do a full recompile on every deploy even if there are no files changed. This is because the digest file and packs directory is not cached between deploys.

[By default](https://github.com/rails/webpacker/blob/3-x-stable/lib/install/config/webpacker.yml#L6-L7), Webpacker stores [a compilation digest](https://github.com/rails/webpacker/blob/3-x-stable/lib/webpacker/compiler.rb#L88) in `tmp/cache/webpacker` and its packs in `public/packs`. [Webpacker iterates](https://github.com/rails/webpacker/blob/3-x-stable/lib/webpacker/compiler.rb#L50) over the watched paths to compute the digest based on the mtime of the files. If none of the files have changed and the packs directory is in place, running Webpack is skipped, saving a lot of time (e.g. my company's Rails app takes 8 minutes to run webpack).

 ## ~~Caveats~~
~~The environment variable `CI` needs to be set as the mtime does not seem to be preserved correctly across deploys. If `ENV['CI']` is set, Webpacker will use the file contents to compute the cache digest file instead of the files' mtimes.~~

~~I'm not familiar enough with the Heroku infrastructure to understand why the mtime isn't being preserved. [I did notice](https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/cache.rb#L53) that `cp`ing is done via `-a` which [preserves timestamps](http://www.man7.org/linux/man-pages/man1/cp.1.html) via `--preserve=all` but that doesn't seem to be enough. Perhaps there is an issue with the way Webpacker is computing the mtime digest.~~

~~I believe this is a tangential issue that should be resolved independently.~~

The CI environment variable issue has been resolved with https://github.com/rails/webpacker/commit/95c00e23b98397706bece763b3f45421821efcb7. (Thanks to @grk for pointing this out.)

 ## Further Notes
* This could technically be solved without modifying either Webpacker or the Heroku build pack (by changing the pack output and cache paths) but I thought this would be the best solution as it fixes all existing configurations provided they used the default settings. This would also make the default "just work" instead of requiring end-users to read documentation and configure their Rails apps specifically for Heroku.

* I've also tested this works correctly with version 4.0.0.pre.pre.2 of Webpacker. (Since the name of the digest file changed, it will require two deploys to realize its effect.)

* I don't mean for this pull request to be the canonical place to fix this issue but merely an issue report with a solution attached.

 ## Related
* https://github.com/rails/webpacker/issues/1347
* https://github.com/rails/webpacker/issues/1439#issuecomment-417713222
* https://github.com/rails/webpacker/issues/1611