### PR TITLE
[close #797] Do not carry asset pipeline fragment cache into runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Delete the sprockets temp directory for a smaller runtime slug if they are not building assets at runtime (https://github.com/heroku/heroku-buildpack-ruby/pull/812)
+
 ## v195 (10/18/2018)
 
 * Default Ruby version is now 2.4.5 (https://github.com/heroku/heroku-buildpack-ruby/pull/821)

--- a/hatchet.json
+++ b/hatchet.json
@@ -79,6 +79,9 @@
     "sharpstone/active_storage_local",
     "sharpstone/sprockets_asset_compile_true"
   ],
+  "heroku": [
+    "heroku/ruby-getting-started"
+  ],
   "multibuildpack": [
     "sharpstone/node_multi"
   ],

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -27,6 +27,8 @@
   - 540ec776eff3111ad9bb01af204c62725c94a11d
 - - "./repos/ci/ruby_no_rails_test"
   - 3916137106d59b008b67d738abe6a1438f8fbde6
+- - "./repos/heroku/ruby-getting-started"
+  - 7abd8af85c7ba6486bb03a4964da9cea98766b06
 - - "./repos/jruby/jruby_naether"
   - c5081c07de64dcd4b480923e4b7e2a98a9b4a431
 - - "./repos/multibuildpack/node_multi"

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -66,6 +66,11 @@ WARNING
     "tmp/cache/assets"
   end
 
+  def cleanup
+    super
+    FileUtils.remove_dir(default_assets_cache) unless assets_compile_enabled?
+  end
+
   def run_assets_precompile_rake_task
     instrument "rails4.run_assets_precompile_rake_task" do
       log("assets_precompile") do

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -68,7 +68,9 @@ WARNING
 
   def cleanup
     super
-    FileUtils.remove_dir(default_assets_cache) unless assets_compile_enabled?
+    return unless assets_compile_enabled?
+    return unless Dir.exist?(default_assets_cache)
+    FileUtils.remove_dir(default_assets_cache)
   end
 
   def run_assets_precompile_rake_task

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -68,7 +68,7 @@ WARNING
 
   def cleanup
     super
-    return unless assets_compile_enabled?
+    return if assets_compile_enabled?
     return unless Dir.exist?(default_assets_cache)
     FileUtils.remove_dir(default_assets_cache)
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -110,8 +110,12 @@ WARNING
       end
       config_detect
       best_practice_warnings
+      cleanup
       super
     end
+  end
+
+  def cleanup
   end
 
   def config_detect

--- a/spec/hatchet/getting_started_spec.rb
+++ b/spec/hatchet/getting_started_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../spec_helper'
+
+describe "Heroku ruby getting started" do
+  it "clears runtime cache" do
+    Hatchet::Runner.new("ruby-getting-started").deploy do |app|
+      expect(app.run("ls tmp/cache/assets")).to_not match("sprockets")
+    end
+  end
+end


### PR DESCRIPTION
When someone is using the asset pipeline, and they've disabled the config that allows them to build assets in production.

So when

```
config.assets.compile = false
```

Then the `tmp/cache/assets/sprockets/` folder is not needed at runtime and should be safe to delete, which will lower the overall slug size.

Do not merge until after Dreamforce.