### PR TITLE
Close #84 Allow apps to enable `RUBYOPT=--jit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Allow apps to enable `RUBYOPT=--jit` (https://github.com/heroku/heroku-buildpack-ruby/pull/848)
+
 ## v197 (12/18/2018)
 
 * Upgrade node version (https://github.com/heroku/heroku-buildpack-ruby/pull/831)

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -48,7 +48,7 @@ module LanguagePack
     end
 
     def self.blacklist?(key)
-      %w(PATH GEM_PATH GEM_HOME GIT_DIR JRUBY_OPTS JAVA_OPTS JAVA_TOOL_OPTIONS).include?(key)
+      %w(PATH GEM_PATH GEM_HOME GIT_DIR JRUBY_OPTS JAVA_OPTS JAVA_TOOL_OPTIONS RUBYOPT).include?(key)
     end
 
     def self.initialize_env(path)


### PR DESCRIPTION
If you set:

```
$ heroku config:set RUBYOT=--jit
```

Then this will be a global value so when the buildpack attempts to detect ruby version by running:

```
$ bundle platform --ruby
```

It is executed with the RUBYOPT set. Since the version of Ruby the buildpack executes does not have `--jit` it fails:

```
-----> Ruby app detected
-----> Compiling Ruby/Rails
 !
 !     There was an error parsing your Gemfile, we cannot continue
 !     ruby: invalid option --jit  (-h will show valid options) (RuntimeError)
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```