### PR TITLE
Bundler 2 support

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -1,16 +1,56 @@
+# frozen_string_literal: true
+
 require 'language_pack/fetcher'
 
 # This class is responsible for installing and maintaining a
 # reference to bundler. It contains access to bundler internals
 # that are used to introspect a project such as detecting presence
 # of gems and their versions.
+#
+# Example:
+#
+#   bundler = LanguagePack::Helpers::BundlerWrapper.new
+#   bundler.install
+#   bundler.version                 => "1.15.2"
+#   bundler.dir_name                => "bundler-1.15.2"
+#   bundler.has_gem?("railties")    => true
+#   bundler.gem_version("railties") => "5.2.2"
+#
+# Also used to determine the version of Ruby that a project is using
+# based on `bundle platform --ruby`
+#
+#   bundler.ruby_version # => "ruby-2.5.1"
+#
 class LanguagePack::Helpers::BundlerWrapper
   include LanguagePack::ShellHelpers
 
+  BLESSED_BUNDLER_VERSIONS = {}
+  BLESSED_BUNDLER_VERSIONS["1"] = "1.15.2"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.0.1"
+  private_constant :BLESSED_BUNDLER_VERSIONS
+
   class GemfileParseError < BuildpackError
     def initialize(error)
-      msg = "There was an error parsing your Gemfile, we cannot continue\n"
+      msg = String.new("There was an error parsing your Gemfile, we cannot continue\n")
       msg << error
+      super msg
+    end
+  end
+
+  class UnsupportedBundlerVersion < BuildpackError
+    def initialize(version_hash, major)
+      msg = String.new("Your Gemfile.lock indicates you need bundler `#{major}.x`\n")
+      msg << "which is not currently supported. You can deploy with bundler version:\n"
+      version_hash.keys.each do |v|
+        msg << "  - `#{v}.x`\n"
+      end
+      msg << "\nTo use another version of bundler, update your `Gemfile.lock` to poin\n"
+      msg << "to as supported version. For example:\n"
+      msg << "\n"
+      msg << "```\n"
+      msg << "BUNDLED WITH\n"
+      msg << "   #{version_hash["1"]}"
+      msg << "```"
       super msg
     end
   end
@@ -18,17 +58,17 @@ class LanguagePack::Helpers::BundlerWrapper
   attr_reader :bundler_path
 
   def initialize(options = {})
-    @version              = "1.15.2"
-    @bundler_tmp          = Dir.mktmpdir
+    @bundler_tmp          = Pathname.new(Dir.mktmpdir)
     @fetcher              = options[:fetcher]      || LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL) # coupling
-    @bundler_path         = options[:bundler_path] || File.join(@bundler_tmp, "#{dir_name}")
     @gemfile_path         = options[:gemfile_path] || Pathname.new("./Gemfile")
-    @bundler_tar          = options[:bundler_tar]  || "#{dir_name}.tgz"
+    @gemfile_lock_path    = Pathname.new("#{@gemfile_path}.lock")
+    detect_bundler_version_and_dir_name!
 
-    @gemfile_lock_path    = "#{@gemfile_path}.lock"
+    @bundler_path         = options[:bundler_path] || @bundler_tmp.join(dir_name)
+    @bundler_tar          = options[:bundler_tar]  || "bundler/#{dir_name}.tgz"
     @orig_bundle_gemfile  = ENV['BUNDLE_GEMFILE']
     ENV['BUNDLE_GEMFILE'] = @gemfile_path.to_s
-    @path                 = Pathname.new "#{@bundler_path}/gems/#{dir_name}/lib"
+    @path                 = Pathname.new("#{@bundler_path}/gems/#{dir_name}/lib")
   end
 
   def install
@@ -40,7 +80,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   def clean
     ENV['BUNDLE_GEMFILE'] = @orig_bundle_gemfile
-    FileUtils.remove_entry_secure(@bundler_tmp) if Dir.exist?(@bundler_tmp)
+    @bundler_tmp.rmtree if @bundler_tmp.directory?
 
     if version  == "1.7.12"
       # Hack to cleanup after pre 1.8 versions of bundler. See https://github.com/bundler/bundler/pull/3277/
@@ -132,6 +172,29 @@ class LanguagePack::Helpers::BundlerWrapper
     instrument 'parse_bundle' do
       gemfile_contents = File.read(@gemfile_lock_path)
       Bundler::LockfileParser.new(gemfile_contents)
+    end
+  end
+
+  def major_bundler_version
+    # https://rubular.com/r/uuRpai9IheL68d
+    bundler_version_match = @gemfile_lock_path.read.match(/^BUNDLED WITH$(\r?\n)   (?<major>\d*)\.\d*\.\d*/m)
+
+    if bundler_version_match
+      bundler_version_match[:major]
+    else
+      "1"
+    end
+  end
+
+  # You cannot use Bundler 2.x with a Gemfile.lock that points to a 1.x bundler
+  # version. The solution here is to read in the value set in the Gemfile.lock
+  # and download the "blessed" version with the same major version.
+  def detect_bundler_version_and_dir_name!
+    major = major_bundler_version
+    if BLESSED_BUNDLER_VERSIONS.key?(major)
+      @version = BLESSED_BUNDLER_VERSIONS[major]
+    else
+      raise UnsupportedBundlerVersion.new(BLESSED_BUNDLER_VERSIONS, major)
     end
   end
 end

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -93,13 +93,6 @@ class LanguagePack::Helpers::BundlerWrapper
   def clean
     ENV['BUNDLE_GEMFILE'] = @orig_bundle_gemfile
     @bundler_tmp.rmtree if @bundler_tmp.directory?
-
-    if version  == "1.7.12"
-      # Hack to cleanup after pre 1.8 versions of bundler. See https://github.com/bundler/bundler/pull/3277/
-      Dir["#{Dir.tmpdir}/bundler*"].each do |dir|
-        FileUtils.remove_entry_secure(dir) if Dir.exist?(dir) && File.stat(dir).writable?
-      end
-    end
   end
 
   def has_gem?(name)

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -188,8 +188,8 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def major_bundler_version
-    # https://rubular.com/r/uuRpai9IheL68d
-    bundler_version_match = @gemfile_lock_path.read.match(/^BUNDLED WITH$(\r?\n)   (?<major>\d*)\.\d*\.\d*/m)
+    # https://rubular.com/r/jt9yj0aY7fU3hD
+    bundler_version_match = @gemfile_lock_path.read.match(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m)
 
     if bundler_version_match
       bundler_version_match[:major]

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,8 +16,6 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.15.2"
-  BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"
 
@@ -126,9 +124,9 @@ private
   def warn_bundler_upgrade
     old_bundler_version  = @metadata.read("bundler_version").chomp if @metadata.exists?("bundler_version")
 
-    if old_bundler_version && old_bundler_version != BUNDLER_VERSION
+    if old_bundler_version && old_bundler_version != bundler.version
       puts(<<-WARNING)
-Your app was upgraded to bundler #{ BUNDLER_VERSION }.
+Your app was upgraded to bundler #{ bundler.version }.
 Previously you had a successful deploy with bundler #{ old_bundler_version }.
 
 If you see problems related to the bundler version please refer to:
@@ -596,7 +594,7 @@ WARNING
   end
 
   def bundler_path
-    @bundler_path ||= "#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}"
+    @bundler_path ||= "#{slug_vendor_base}/gems/#{bundler.dir_name}"
   end
 
   def write_bundler_shim(path)
@@ -607,7 +605,7 @@ WARNING
 #!/usr/bin/env ruby
 require 'rubygems'
 
-version = "#{BUNDLER_VERSION}"
+version = "#{bundler.version}"
 
 if ARGV.first
   str = ARGV.first
@@ -678,7 +676,7 @@ WARNING
           yaml_include   = File.expand_path("#{libyaml_dir}/include").shellescape
           yaml_lib       = File.expand_path("#{libyaml_dir}/lib").shellescape
           pwd            = Dir.pwd
-          bundler_path   = "#{pwd}/#{slug_vendor_base}/gems/#{BUNDLER_GEM_PATH}/lib"
+          bundler_path   = "#{pwd}/#{slug_vendor_base}/gems/#{bundler.dir_name}/lib"
           # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
           # codon since it uses bundler.
           env_vars       = {
@@ -1081,7 +1079,7 @@ params = CGI.parse(uri.query || "")
       FileUtils.mkdir_p(heroku_metadata)
       @metadata.write(ruby_version_cache, full_ruby_version, false)
       @metadata.write(buildpack_version_cache, BUILDPACK_VERSION, false)
-      @metadata.write(bundler_version_cache, BUNDLER_VERSION, false)
+      @metadata.write(bundler_version_cache, bundler.version, false)
       @metadata.write(rubygems_version_cache, rubygems_version, false)
       @metadata.write(stack_cache, @stack, false)
       @metadata.save

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe "Bundler" do
+  it "deploys with version 2.x" do
+    before_deploy = -> { run!(%Q{printf "\nBUNDLED WITH\n   2.0.1\n" >> Gemfile.lock}) }
+
+    Hatchet::Runner.new("default_ruby", before_deploy: before_deploy).deploy do |app|
+      expect(app.output).to match("Installing dependencies using bundler 2.")
+    end
+  end
+end

--- a/spec/helpers/fetcher_spec.rb
+++ b/spec/helpers/fetcher_spec.rb
@@ -4,6 +4,7 @@ describe "Fetches" do
   it "bundler" do
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
+        FileUtils.touch("Gemfile.lock")
 
         fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
         fetcher.fetch_untar("#{LanguagePack::Helpers::BundlerWrapper.new.dir_name}.tgz")

--- a/spec/helpers/fetcher_spec.rb
+++ b/spec/helpers/fetcher_spec.rb
@@ -1,15 +1,14 @@
 require 'spec_helper'
 
 describe "Fetches" do
-
   it "bundler" do
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
+
         fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
-        fetcher.fetch_untar("#{LanguagePack::Ruby::BUNDLER_GEM_PATH}.tgz")
+        fetcher.fetch_untar("#{LanguagePack::Helpers::BundlerWrapper.new.dir_name}.tgz")
         expect(`ls bin`).to match("bundle")
       end
     end
   end
 end
-

--- a/spec/helpers/rails_runner_spec.rb
+++ b/spec/helpers/rails_runner_spec.rb
@@ -2,12 +2,16 @@ require 'spec_helper'
 
 describe "Rails Runner" do
   around(:each) do |test|
+    original_path = ENV["PATH"]
+    ENV["PATH"] = "./bin/:#{ENV['PATH']}"
+
     Dir.mktmpdir do |tmpdir|
-      @tmpdir = tmpdir
       Dir.chdir(tmpdir) do
         test.run
       end
     end
+  ensure
+    ENV["PATH"] = original_path if original_path
   end
 
   it "config objects build propperly formatted commands" do
@@ -119,7 +123,6 @@ FILE
     FileUtils.mkdir("bin")
     File.open("bin/rails", "w") { |f| f << executable_contents }
     File.chmod(0777, "bin/rails")
-    ENV["PATH"] = "./bin/:#{ENV['PATH']}" unless ENV["PATH"].include?("./bin:")
 
     # BUILDPACK_LOG_FILE support for logging
     FileUtils.mkdir("tmp")


### PR DESCRIPTION
Detect bundler version

## Problem 1

Bundler 2.x cannot be used with a Gemfile.lock that specifies bundler 1.x:

```
BUNDLED WITH
   1.16.4
```

If you try, then Bundler 2.x will look for an installed bundler 1.x version and try to use it. If no such version exists on the system then an error is thrown:


```
can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```


- https://github.com/rubygems/rubygems/pull/2426
- https://github.com/rubygems/rubygems/pull/2515


## Problem 2

Likewise a version of bundler 1.x cannot be used on a project where a `BUNDLED WITH` specifies 2.x:


```
$ bundle -v
1.17.3
$ cat Gemfile.lock | grep -A 1 BUNDLED WITH
BUNDLED WITH
  2.0.1
$ bundle
Traceback (most recent call last):
        2: from /Users/rschneeman/.gem/ruby/2.6.0/bin/bundle:23:in `<main>'
        1: from /Users/rschneeman/.rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'
/Users/rschneeman/.rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': Could not find 'bundler' (2.0.0) required by your /private/tmp/default_ruby/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.0.0`
```

This is due to a bug in Rubygems 3.x https://github.com/rubygems/rubygems/issues/2592


## Proposed Solution

This PR implements a solution where we have a different "blessed" version of bundler for each major version.

The way this is implemented is to read in a Gemfile.lock and to read in the `BUNDLED WITH` value. Then the major version is pulled out and converted into a "blessed" version.

This allows for multiple major versions of bundler to be used on Heroku without sacrificing stability.