### PR TITLE
Attempt to make rails runner tests less flappy

### DIFF
--- a/spec/helpers/node_installer_spec.rb
+++ b/spec/helpers/node_installer_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe LanguagePack::Helpers::NodeInstaller do
   describe "#install" do
     it "should extract a node binary" do
-      installer = LanguagePack::Helpers::NodeInstaller.new
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
+          installer = LanguagePack::Helpers::NodeInstaller.new
           installer.install
 
           expect(File.exist?("node")).to be(true)

--- a/spec/helpers/yarn_installer_spec.rb
+++ b/spec/helpers/yarn_installer_spec.rb
@@ -4,10 +4,9 @@ describe LanguagePack::Helpers::YarnInstaller do
   describe "#install" do
 
     it "should extract the yarn package" do
-      installer = LanguagePack::Helpers::YarnInstaller.new
-
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
+          installer = LanguagePack::Helpers::YarnInstaller.new
           installer.install
 
           # webpacker gem checks for yarnpkg


### PR DESCRIPTION
Not sure why they flap, but this makes sure all examples are running in their own dir.