### PR TITLE
Ignore invalid byte encodings when detecting rails config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Master
 
 
+* Ignore invalid byte encodings when detecting rails config (https://github.com/heroku/heroku-buildpack-ruby/pull/854)
+
 ## v199 (2/19/2019)
 
 * Add support for arbitrary Bundler major versions, most notably bundler 2 (https://github.com/heroku/heroku-buildpack-ruby/pull/850)

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -177,7 +177,7 @@ module LanguagePack
       def output
         raise "no file name given" if @file.nil?
         exec_once
-        @file.read
+        @file.read.encode('UTF-8', invalid: :replace)
       end
 
       def timeout?

--- a/spec/helpers/rails_runner_spec.rb
+++ b/spec/helpers/rails_runner_spec.rb
@@ -78,6 +78,15 @@ describe "Rails Runner" do
     expect(!!local_storage.success?).to eq(true)
   end
 
+  it "does not fail when there is an invalid byte sequence" do
+    mock_rails_runner('puts "hi \255"')
+
+    rails_runner  = LanguagePack::Helpers::RailsRunner.new
+    local_storage = rails_runner.detect("active_storage.service")
+
+    expect(local_storage.success?).to be_truthy
+  end
+
   def time_it
     start = Time.now
     yield


### PR DESCRIPTION
Previously if a customer had an invalid byte sequence emitted during boot up, it would raise an error:

```
invalid byte sequence in UTF-8
```

Which would prevent configuration detection from functioning correctly. 

When detecting rails configuration, we know that the input we are trying to detect for success will be UTF-8. As a result, we can ignore any other encoded characters.

This PR prevents an invalid byte sequence from blocking rails configuration detection.

Reference internal support ticket number: 681812

Here's a blog post on invalid byte sequences if you're interested https://thoughtbot.com/blog/fight-back-utf-8-invalid-byte-sequences.