### PR TITLE
Build an export file in CI, too

### DIFF
--- a/lib/language_pack/test/ruby.rb
+++ b/lib/language_pack/test/ruby.rb
@@ -8,6 +8,7 @@ class LanguagePack::Ruby
       install_ruby
       install_jvm
       setup_language_pack_environment
+      setup_export
       setup_profiled
       allow_git do
         install_bundler_in_app


### PR DESCRIPTION
Without an export file, subsequent testpacks can't use Ruby. 

This [example repo](https://github.com/joshwlewis/heroku-ruby-then-node-build-script) will not compile on CI or pass tests when using the `heroku/ruby` buildpack. The example repo expects `bundle` and `ruby` to be available on the `$PATH` during the node buildpack `bin/test-compile` and `bin/test` stages. With this change, the example repo builds and passes tests on CI.