### PR TITLE
Handle Rails 4 apps without sprockets-rails

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -73,6 +73,12 @@ WARNING
     FileUtils.remove_dir(default_assets_cache)
   end
 
+  def assets_compile_enabled?
+    return false unless bundler.has_gem?('sprockets-rails')
+
+    super
+  end
+
   def run_assets_precompile_rake_task
     instrument "rails4.run_assets_precompile_rake_task" do
       log("assets_precompile") do


### PR DESCRIPTION
When building a Rails 4 without `sprockets-rails`, asset compilation is assumed to always be enabled, which would then cause an exception to be raised when trying to determine whether the `sprockets` version is vulnerable to CVE-2018-3760.

This PR ensures that Asset Compilation is properly detected as being disabled when the `sprockets-rails` Gem is absent.

Closes #866.