### PR TITLE
Set JRUBY max heap similarly to JVM common buildpack logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,5 +84,8 @@ DEPENDENCIES
   rspec-expectations
   rspec-retry
 
+RUBY VERSION
+   ruby 2.5.5p157
+
 BUNDLED WITH
    1.16.4


### PR DESCRIPTION
A rather simple calculation, but better than the current method, because it takes in consideration the total memory rather than putting a random value per `ulimit -a`.

 Most notably this should fix mem issues with people using P-M dynos, and improve ram util for P-L.

Tested command on a P-L one-off instance.