### PR TITLE
Use last line of bundler platform --ruby

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -145,7 +145,7 @@ class LanguagePack::Helpers::BundlerWrapper
       command = "bundle platform --ruby"
 
       # Silently check for ruby version
-      output  = run_stdout(command, user_env: true, env: env)
+      output  = run_stdout(command, user_env: true, env: env).strip.lines.last
 
       # If there's a gem in the Gemfile (i.e. syntax error) emit error
       raise GemfileParseError.new(run("bundle check", user_env: true, env: env)) unless $?.success?

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -50,5 +50,12 @@ describe "BundlerWrapper" do
         expect(@bundler.ruby_version).to eq("ruby-1.9.3-p547")
       end
     end
+
+    it "handles app with output in their Gemfile" do
+      Hatchet::App.new("problem_gemfile_version").in_directory do |dir|
+        run!(%{echo '\nputs "some output"\n' >> Gemfile})
+        expect(@bundler.ruby_version).to eq("ruby-2.5.1-p0")
+      end
+    end
   end
 end


### PR DESCRIPTION
For determining the ruby version when `bundler platform --ruby` is used,
no longer take into account all output from the command. Instead use the
final line which should container the ruby version.

This addresses issues where Gemfiles may contain debugging information
or processes that produce output on STDOUT, and are then unable to to
build due to using an inccrect ruby version name.