### PR TITLE
Cache Webpacker builds between deploys, redux

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -66,6 +66,14 @@ WARNING
     "tmp/cache/assets"
   end
 
+  def public_packs_folder
+    "public/packs"
+  end
+
+  def default_webpacker_cache
+    "tmp/cache/webpacker"
+  end
+
   def cleanup
     super
     return if assets_compile_enabled?
@@ -87,7 +95,9 @@ WARNING
         topic("Preparing app for Rails asset pipeline")
 
         @cache.load_without_overwrite public_assets_folder
+        @cache.load_without_overwrite public_packs_folder
         @cache.load default_assets_cache
+        @cache.load default_webpacker_cache
 
         precompile.invoke(env: rake_env)
 
@@ -100,7 +110,9 @@ WARNING
 
           cleanup_assets_cache
           @cache.store public_assets_folder
+          @cache.store public_packs_folder
           @cache.store default_assets_cache
+          @cache.store default_webpacker_cache
         else
           precompile_fail(precompile.output)
         end


### PR DESCRIPTION
Continuing from #803. I was seeing very slow builds on our Webpack/er 4 setup:

`remote:        Asset precompilation completed (362.53s)`

Now with @ericboehs's patch:

`remote:        Asset precompilation completed (96.99s)`

I'll take that speedup over nothing!

💥 ⚡️ 