### PR TITLE
debug

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -184,6 +184,8 @@ class LanguagePack::Helpers::BundlerWrapper
     # https://rubular.com/r/jt9yj0aY7fU3hD
     bundler_version_match = @gemfile_lock_path.read.match(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m)
 
+    puts "======================="
+    puts bundler_version_match.inspect
     if bundler_version_match
       bundler_version_match[:major]
     else


### PR DESCRIPTION

  remoto:  https: / /rubygems.org/
  especificaciones:
    activesupport ( 4.0 . 0 )
    activesupport ( 4.0 . 2 )
      i18n ( ~ >  0.6 , > =  0.6 . 4 )
      minitest ( ~ >  4.2 )
      multi_json ( ~ >  1.3 )
@@ -20,21 +20,22 @@ GEM
      thor ( ~ >  0.15 . 2 )
    atómico ( 1.1 . 14 )
    diferencias - lcs ( 1.1 . 3 )
    excon ( 0.25 . 3 )
    heroku - api ( 0.3 . 15 )
      excon ( ~ >  0.25 . 1 )
    heroku_hatchet ( 1.1 . 6 )
    excon ( 0.31 . 0 )
    heroku - api ( 0.3 . 16 )
      excon ( ~ >  0.27 )
      multi_json ( ~ >  1.8 . 2 )
    heroku_hatchet ( 1.1 . 7 )
      ayuda activa
      yunque - cli
      excon
      heroku - api
      repl_runner
      rrrretry
      tor
    i18n ( 0.6 . 5 )
    mime - tipos ( 1.25 )
    i18n ( 0.6 . 9 )
    mime - tipos ( 2.0 )
    minitest ( 4.7 . 5 )
    multi_json ( 1.8 . 2 )
    multi_json ( 1.8 . 4 )
    netrc ( 0.7 . 7 )
    paralelo ( 0.6 . 5 )
    Pruebas paralelas ( 0.13 . 1 )
@@ -45,7 +46,7 @@ GEM
      ayuda activa
    resto - cliente ( 1.6 . 7 )
      mime - tipos ( > =  1.16 )
    rrrretry ( 0 .0 . 1 )
    rrrretry ( 1 .0 . 0 )
    rspec ( 2.2 . 0 )
      rspec - core ( ~ >  2.2 )
      rspec - expectativas ( ~ >  2.2 )
  3  hatchet.json 
@@ -26,7 +26,8 @@
    " sharpstone / mri_187_nokogiri " ,
    " sharpstone / mri_192 " ,
    " sharpstone / mri_193 " ,
    " sharpstone / mri_200 "
    " sharpstone / mri_200 " ,
    " sharpstone / mri_210 "
  ]
  " rails2 " : [
    " sharpstone / rails23_mri_187 "
  3  lib / language_pack / ruby.rb 
@@ -141,7 +141,8 @@ def slug_vendor_base
      elsif ruby_version.ruby_version ==  " 1.8.7 "
        @slug_vendor_base  =  " vendor / bundle / 1.8 "
      más
        @slug_vendor_base  = run ( % q ( ruby -e "require 'rbconfig'; pone \" vendedor / paquete / # {RUBY_ENGINE} / # {RbConfig :: CONFIG ['ruby_version']} \ "" ) ). chomp
        @slug_vendor_base  = run_no_pipe ( % q ( ruby -e "require 'rbconfig'; pone \" vendedor / paquete / # {RUBY_ENGINE} / # {RbConfig :: CONFIG ['ruby_version']} \ "" ) ). chomp
        error " Problema al detectar el directorio del proveedor del bundler: # { @slug_vendor_base } " a  menos que  $? .¿éxito?
      fin
    fin
  fin
  7  lib / language_pack / shell_helpers.rb 
@@ -27,6 +27,13 @@ def run! (Comando)
      resultado de retorno
    fin

    # no hace ninguna tubería especial. stderr no será redirigido
    #  @ param [ String ] comando a ejecutar 
    #  @ return [ String ] salida de stdout 
    def  run_no_pipe ( comando )
      % x { bash -c # { command.shellescape }  }
    fin

    # ejecuta un comando de shell y canaliza stderr a / dev / null
    #  @ param [ String ] comando a ejecutar 
    #  @ return [ String ] salida de stdout 
  12  spec / user_env_compile_edge_case_spec.rb 
@@ -0,0 +1,12 @@
requiere  ' spec_helper '

Describe " Usuario comp compilar "  hacer
  que " no debería causar problemas con las advertencias de "  hacer
    app =  Hatchet :: Runner . nuevo ( " mri_210 " , labs:  " user-env-compile " )
    app.setup!
    app.set_config ( " RUBY_HEAP_MIN_SLOTS " => " 1000000 " )
    app.deploy do | aplicación |
      expect (app.run ( " bundle version " )) para coincidir ( LanguagePack :: Ruby :: BUNDLER_VERSION )
    fin
  fin
fin