### PR TITLE
fix vendored ruby is not in PATH for CNB v3

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -9,7 +9,7 @@ BIN_DIR=$(cd $(dirname $0); pwd)
 BUILDPACK_DIR=$(dirname $BIN_DIR)
 
 # legacy buildpack uses $STACK 
-STACK=$PACK_STACK_ID
+STACK=$CNB_STACK_ID
 
 source "$BIN_DIR/support/bash_functions.sh"
 heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+LAYERS_DIR=$1
+PLATFORM_DIR=$2
+ENV_DIR="$PLATFORM_DIR/env"
+PLAN=$3
+APP_DIR=$(pwd)
+BIN_DIR=$(cd $(dirname $0); pwd)
+BUILDPACK_DIR=$(dirname $BIN_DIR)
+
+# legacy buildpack uses $STACK 
+STACK=$PACK_STACK_ID
+
+source "$BIN_DIR/support/bash_functions.sh"
+heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
+
+$heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_build $APP_DIR $LAYERS_DIR $PLATFORM_DIR $PLAN

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-
-if [ -z "$PACK_STACK_ID" ]; then
+if [ -z "$CNB_STACK_ID" ]; then
   # v2 API
   APP_DIR=$1
 else

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,18 @@
 #!/bin/sh
 
-if [ -f "$1/Gemfile" ]; then
+
+if [ -z "$PACK_STACK_ID" ]; then
+  # v2 API
+  APP_DIR=$1
+else
+  PLATFORM_DIR=$1
+  PLAN=$2
+  # working is the cwd now
+  # v3 API
+  APP_DIR=$(pwd)
+fi
+
+if [ -f "$APP_DIR/Gemfile" ]; then
   echo "Ruby"
   exit 0
 else

--- a/bin/support/ruby_build
+++ b/bin/support/ruby_build
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+# This script compiles an application so it can run on Heroku.
+# It will install the application's specified version of Ruby, it's dependencies
+# and certain framework specific requirements (such as calling `rake assets:precompile`
+# for rails apps). You can see all features described in the devcenter
+# https://devcenter.heroku.com/articles/ruby-support
+$stdout.sync = true
+
+$:.unshift File.expand_path("../../../lib", __FILE__)
+require "language_pack"
+require "language_pack/shell_helpers"
+
+APP_DIR=ARGV[0]
+LAYER_DIR=ARGV[1]
+PLATFORM_DIR=ARGV[2]
+ENV_DIR="#{PLATFORM_DIR}/env"
+PLAN=ARGV[3]
+
+begin
+  LanguagePack::Instrument.trace 'compile', 'app.compile' do
+    LanguagePack::ShellHelpers.initialize_env(ENV_DIR)
+    if pack = LanguagePack.detect(ARGV[0], nil, LAYER_DIR)
+      pack.topic("Compiling #{pack.name}")
+      pack.log("compile") do
+        pack.build
+      end
+    end
+  end
+rescue Exception => e
+  LanguagePack::ShellHelpers.display_error_and_exit(e)
+end
+

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,6 @@
 [buildpack]
+id = "heroku/ruby"
+version = "0.0.1"
 name = "Ruby"
 ruby_version = "2.5.5"
 
@@ -21,3 +23,6 @@ ruby_version = "2.5.5"
   [[publish.Vendor]]
   url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.5.5.tgz"
   dir = "vendor/ruby/heroku-18"
+
+[[stacks]]
+id = "heroku-18"

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -133,7 +133,7 @@ class LanguagePack::Base
     layer = LanguagePack::Helpers::Layer.new(@layer_dir, "env", launch: true)
     FileUtils.mkdir_p("#{layer.path}/env.launch")
     release["config_vars"].each do |key, value|
-      File.open("#{layer.path}/env.launch/#{key.upcase}", 'w') do |f|
+      File.open("#{layer.path}/env.launch/#{key.upcase}.override", 'w') do |f|
         f.write(value)
       end
     end

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -5,12 +5,18 @@ require "language_pack"
 class LanguagePack::Cache
   # @param [String] path to the cache store
   def initialize(cache_path)
-    @cache_base = Pathname.new(cache_path)
+    if cache_path
+      @cache_base = Pathname.new(cache_path)
+    else
+      @cache_base = nil
+    end
   end
 
   # removes the the specified path from the cache
   # @param [String] relative path from the cache_base
   def clear(path)
+    return unless @cache_base
+
     target = (@cache_base + path)
     target.exist? && target.rmtree
   end
@@ -22,6 +28,8 @@ class LanguagePack::Cache
   # @param [String] path of contents to store. it will be stored using this a relative path from the cache_base.
   # @param [String] relative path to store the cache contents, if nil it will assume the from path
   def store(from, path = nil)
+    return unless @cache_base
+
     path ||= from
     clear path
     copy from, (@cache_base + path)
@@ -30,6 +38,8 @@ class LanguagePack::Cache
   # Adds file to cache without clearing the destination
   # Use LanguagePack::Cache#store to avoid accidental cache bloat
   def add(from, path = nil)
+    return unless @cache_base
+
     path ||= from
     copy from, (@cache_base + path)
   end
@@ -38,11 +48,15 @@ class LanguagePack::Cache
   # @param [String] relative path of the cache contents
   # @param [String] path of where to store it locally, if nil, assume same relative path as the cache contents
   def load(path, dest = nil)
+    return unless @cache_base
+
     dest ||= path
     copy (@cache_base + path), dest
   end
 
   def load_without_overwrite(path, dest=nil)
+    return unless @cache_base
+
     dest ||= path
     copy (@cache_base + path), dest, '-a -n'
   end
@@ -51,6 +65,8 @@ class LanguagePack::Cache
   # @param [String] source directory
   # @param [String] destination directory
   def copy(from, to, options='-a')
+    return unless @cache_base
+
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
     system("cp #{options} #{from}/. #{to}")
@@ -60,6 +76,8 @@ class LanguagePack::Cache
   # @param [String] source cache directory
   # @param [String] destination directory
   def cache_copy(from,to)
+    return unless @cache_base
+
     copy(@cache_base + from, @cache_base + to)
   end
 
@@ -67,6 +85,8 @@ class LanguagePack::Cache
   # @param [String] relative path of the cache contents
   # @param [Boolean] true if the path exists in the cache and false if otherwise
   def exists?(path)
+    return unless @cache_base
+
     File.exists?(@cache_base + path)
   end
 end

--- a/lib/language_pack/helpers/layer.rb
+++ b/lib/language_pack/helpers/layer.rb
@@ -1,0 +1,60 @@
+require 'fileutils'
+require 'toml'
+
+class LanguagePack::Helpers::Layer
+  attr_reader :path
+
+  def initialize(layer_dir, name, launch: false, build: false, cache: false)
+    @layer_dir = layer_dir
+    @name = name
+    @path = "#{@layer_dir}/#{@name}"
+    @toml = if File.exist?(toml_file)
+              TOML.load(File.read(toml_file))
+            else
+              Hash.new
+            end
+
+    @toml[:launch] = launch.to_s
+    @toml[:build] = build.to_s
+    @toml[:cache] = cache.to_s
+    @toml[:metadata] = Hash.new
+
+    puts "Creating Layer: #{@path}"
+    FileUtils.mkdir_p(@path)
+    puts "Writing: #{toml_file}"
+    File.open(toml_file, "w") do |file|
+      file.write <<TOML
+launch = #{launch}
+build = #{build}
+cache = #{cache}
+TOML
+    end
+  end
+
+  def metadata
+    @toml[:metadata]
+  end
+
+  def toml_file
+    @toml_file ||= "#{@layer_dir}/#{@name}.toml"
+  end
+
+  def write
+    metadata_string = metadata.inject([]) do |acc, (key, value)|
+      acc << "#{key} = '#{value}'"
+    end
+
+    unless metadata_string.empty?
+      File.open(toml_file, "w") do |file|
+        file.write <<TOML
+launch = #{@toml[:launch]}
+build = #{@toml[:build]}
+cache = #{@toml[:cache]}
+
+[metadata]
+#{metadata_string.join("\n")}
+TOML
+      end
+    end
+  end
+end

--- a/lib/language_pack/installers/ruby_installer.rb
+++ b/lib/language_pack/installers/ruby_installer.rb
@@ -23,10 +23,15 @@ module LanguagePack::Installers::RubyInstaller
     FileUtils.mkdir_p DEFAULT_BIN_DIR
     run("ln -s ruby #{install_dir}/bin/ruby.exe")
 
+    install_pathname = Pathname.new(install_dir)
     Dir["#{install_dir}/bin/*"].each do |vendor_bin|
       # for Ruby 2.6.0+ don't symlink the Bundler bin so our shim works
       next if vendor_bin.include?("bundle")
-      run("ln -s ../#{vendor_bin} #{DEFAULT_BIN_DIR}")
+      if install_pathname.absolute?
+        run("ln -s #{vendor_bin} #{DEFAULT_BIN_DIR}")
+      else
+        run("ln -s ../#{vendor_bin} #{DEFAULT_BIN_DIR}")
+      end
     end
   end
 end

--- a/lib/language_pack/metadata.rb
+++ b/lib/language_pack/metadata.rb
@@ -11,15 +11,24 @@ class LanguagePack::Metadata
     end
   end
 
+  def [](key)
+    read(key)
+  end
+
+  def []=(key, value)
+    write(key, value)
+  end
+
   def read(key)
     full_key = "#{FOLDER}/#{key}"
-    File.read(full_key) if exists?(key)
+    File.read(full_key).chomp if exists?(key)
   end
 
   def exists?(key)
     full_key = "#{FOLDER}/#{key}"
     File.exists?(full_key) && !Dir.exists?(full_key)
   end
+  alias_method :include?, :exists?
 
   def write(key, value, isave = true)
     FileUtils.mkdir_p(FOLDER)
@@ -29,7 +38,7 @@ class LanguagePack::Metadata
     save if isave
   end
 
-  def save
-    @cache ? @cache.add(FOLDER) : false
+  def save(file = FOLDER)
+    @cache ? @cache.add(file) : false
   end
 end

--- a/lib/language_pack/rack.rb
+++ b/lib/language_pack/rack.rb
@@ -40,8 +40,8 @@ class LanguagePack::Rack < LanguagePack::Ruby
 private
 
   # sets up the profile.d script for this buildpack
-  def setup_profiled
-    super
+  def setup_profiled(*args)
+    super(*args)
     set_env_default "RACK_ENV", "production"
   end
 

--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -63,6 +63,12 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
     end
   end
 
+  def build
+    # TODO install plugins into separate layer
+    #install_plugins
+    super
+  end
+
   def best_practice_warnings
     if env("RAILS_ENV") != "production"
       warn(<<-WARNING)

--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -16,7 +16,7 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
     end
   end
 
-  def initialize(build_path, cache_path=nil)
+  def initialize(build_path, cache_path=nil, layer_dir=nil)
     super(build_path, cache_path)
     @rails_runner = LanguagePack::Helpers::RailsRunner.new
   end

--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -16,8 +16,8 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
     end
   end
 
-  def initialize(build_path, cache_path=nil, layer_dir=nil)
-    super(build_path, cache_path)
+  def initialize(*args)
+    super(*args)
     @rails_runner = LanguagePack::Helpers::RailsRunner.new
   end
 
@@ -93,8 +93,8 @@ private
   end
 
   # sets up the profile.d script for this buildpack
-  def setup_profiled
-    super
+  def setup_profiled(*args)
+    super(*args)
     default_env_vars.each do |key, value|
       set_env_default key, value
     end

--- a/lib/language_pack/rails41.rb
+++ b/lib/language_pack/rails41.rb
@@ -15,9 +15,9 @@ class LanguagePack::Rails41 < LanguagePack::Rails4
     end
   end
 
-  def setup_profiled
+  def setup_profiled(*args)
     instrument 'setup_profiled' do
-      super
+      super(*args)
       set_env_default "SECRET_KEY_BASE", app_secret
     end
   end

--- a/lib/language_pack/rails42.rb
+++ b/lib/language_pack/rails42.rb
@@ -14,9 +14,9 @@ class LanguagePack::Rails42 < LanguagePack::Rails41
     end
   end
 
-  def setup_profiled
+  def setup_profiled(*args)
     instrument 'setup_profiled' do
-      super
+      super(*args)
       set_env_default "RAILS_SERVE_STATIC_FILES", "enabled"
     end
   end

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -14,9 +14,9 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
     end
   end
 
-  def setup_profiled
+  def setup_profiled(*args)
     instrument 'setup_profiled' do
-      super
+      super(*args)
       set_env_default "RAILS_LOG_TO_STDOUT", "enabled"
     end
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -118,6 +118,7 @@ WARNING
   end
 
   def build
+    new_app?
     remove_vendor_bundle
 
     ruby_layer = Layer.new(@layer_dir, "ruby", launch: true)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -343,12 +343,13 @@ SHELL
   # sets up the profile.d script for this buildpack
   def setup_profiled
     instrument 'setup_profiled' do
-      profiled_path = [binstubs_relative_paths.map {|path| "$HOME/#{path}" }.join(":")]
+      profiled_path_prefix = @layer_dir ? @build_path : "$HOME"
+      profiled_path = [binstubs_relative_paths.map {|path| "#{profiled_path_prefix}/#{path}" }.join(":")]
       profiled_path << "vendor/#{@yarn_installer.binary_path}" if has_yarn_binary?
       profiled_path << "$PATH"
 
       set_env_default  "LANG",     "en_US.UTF-8"
-      set_env_override "GEM_PATH", "$HOME/#{slug_vendor_base}:$GEM_PATH"
+      set_env_override "GEM_PATH", "#{profiled_path_prefix}/#{slug_vendor_base}:$GEM_PATH"
       set_env_override "PATH",      profiled_path.join(":")
 
       add_to_profiled set_default_web_concurrency if env("SENSIBLE_DEFAULTS")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -404,6 +404,7 @@ SHELL
   def setup_profiled(ruby_layer_path = "$HOME", gem_layer_path = "$HOME")
     instrument 'setup_profiled' do
       profiled_path = binstubs_relative_paths(gem_layer_path)
+      profiled_path << File.expand_path(ruby_install_binstub_path(ruby_layer_path))
       profiled_path << "vendor/#{@yarn_installer.binary_path}" if has_yarn_binary?
       profiled_path << "$PATH"
 

--- a/vendor/toml.rb
+++ b/vendor/toml.rb
@@ -1,0 +1,49 @@
+require "ostruct"
+require "date"
+
+module TOML
+  def self.safe_load
+    raise NotImplementedError, "whoops"
+  end
+
+  def self.load(__toml)
+    __b = binding
+    __b.eval(to_ruby(__toml))
+    hashize(binding_vars(__b))
+  end
+
+  class << self
+  private
+    def _section(mergee)
+      b = nil
+      c = Object.new
+      c.singleton_class.send(:define_method, :[]) { |b_| b = b_ }
+      yield c
+      mergee.merge! binding_vars(b)
+    end
+
+    def binding_vars(b)
+      Hash[b.eval("local_variables").reject{|v|v[0,2]=="__"}.map{|l| [l, b.eval("#{l}")] }]
+    end
+
+    def hashize(obj, seen = {}.compare_by_identity)
+      return if seen[obj]
+      seen[obj] = true
+      case obj
+      when OpenStruct; hashize(obj.instance_variable_get(:@table), seen)
+      when Hash; Hash[obj.reject{|k,_|k[0, 2] == "__"}.map { |k,v| v = hashize(v, seen); v.nil? ? nil : [k, v] }.compact]
+      when Array; obj.map { |v| hashize(v, seen) }.compact
+      when Fixnum, Float, true, false, nil; seen[obj] = false; obj
+      else obj
+      end
+    end
+
+    def to_ruby(toml)
+      "if true\n#{toml.gsub(/^\s*\[([a-z0-9_.]+)\]\s*$/i){|sec|" end; #{1.
+      upto($1.split(".").length-1).map { |i| "#{$1.split(".")[0...i].join(
+      ".")}||=OpenStruct.new"}.join";"}; #{$1} = OpenStruct.new; _section(
+      #{$1}.instance_variable_get(:@table)) do |__| __[binding]; " }.gsub(
+      /\d{4}(-\d{2}){2}T(\d{2}:){2}\d{2}Z/){|x|"Date.parse(%{#{x}})"}}end"
+    end
+  end
+end

--- a/vendor/toml.rb
+++ b/vendor/toml.rb
@@ -33,7 +33,7 @@ module TOML
       when OpenStruct; hashize(obj.instance_variable_get(:@table), seen)
       when Hash; Hash[obj.reject{|k,_|k[0, 2] == "__"}.map { |k,v| v = hashize(v, seen); v.nil? ? nil : [k, v] }.compact]
       when Array; obj.map { |v| hashize(v, seen) }.compact
-      when Fixnum, Float, true, false, nil; seen[obj] = false; obj
+      when Integer, Float, true, false, nil; seen[obj] = false; obj
       else obj
       end
     end
@@ -44,6 +44,111 @@ module TOML
       ".")}||=OpenStruct.new"}.join";"}; #{$1} = OpenStruct.new; _section(
       #{$1}.instance_variable_get(:@table)) do |__| __[binding]; " }.gsub(
       /\d{4}(-\d{2}){2}T(\d{2}:){2}\d{2}Z/){|x|"Date.parse(%{#{x}})"}}end"
+    end
+  end
+
+  # pulled from https://github.com/emancu/toml-rb/blob/master/lib/toml-rb/dumper.rb
+  class Dumper
+    def initialize(hash)
+      @toml_str = ''
+
+      visit(hash, [])
+    end
+
+    def to_s
+      @toml_str
+    end
+
+    private
+
+    def visit(hash, prefix, extra_brackets = false)
+      simple_pairs, nested_pairs, table_array_pairs = sort_pairs hash
+
+      if prefix.any? && (simple_pairs.any? || hash.empty?)
+        print_prefix prefix, extra_brackets
+      end
+
+      dump_pairs simple_pairs, nested_pairs, table_array_pairs, prefix
+    end
+
+    def sort_pairs(hash)
+      nested_pairs = []
+      simple_pairs = []
+      table_array_pairs = []
+
+      hash.keys.sort.each do |key|
+        val = hash[key]
+        element = [key, val]
+
+        if val.is_a? Hash
+          nested_pairs << element
+        elsif val.is_a?(Array) && val.first.is_a?(Hash)
+          table_array_pairs << element
+        else
+          simple_pairs << element
+        end
+      end
+
+      [simple_pairs, nested_pairs, table_array_pairs]
+    end
+
+    def dump_pairs(simple, nested, table_array, prefix = [])
+      # First add simple pairs, under the prefix
+      dump_simple_pairs simple
+      dump_nested_pairs nested, prefix
+      dump_table_array_pairs table_array, prefix
+    end
+
+    def dump_simple_pairs(simple_pairs)
+      simple_pairs.each do |key, val|
+        key = quote_key(key) unless bare_key? key
+        @toml_str << "#{key} = #{to_toml(val)}\n"
+      end
+    end
+
+    def dump_nested_pairs(nested_pairs, prefix)
+      nested_pairs.each do |key, val|
+        key = quote_key(key) unless bare_key? key
+
+        visit val, prefix + [key], false
+      end
+    end
+
+    def dump_table_array_pairs(table_array_pairs, prefix)
+      table_array_pairs.each do |key, val|
+        key = quote_key(key) unless bare_key? key
+        aux_prefix = prefix + [key]
+
+        val.each do |child|
+          print_prefix aux_prefix, true
+          args = sort_pairs(child) << aux_prefix
+
+          dump_pairs(*args)
+        end
+      end
+    end
+
+    def print_prefix(prefix, extra_brackets = false)
+      new_prefix = prefix.join('.')
+      new_prefix = '[' + new_prefix + ']' if extra_brackets
+
+      @toml_str += "[" + new_prefix + "]\n"
+    end
+
+    def to_toml(obj)
+      if obj.is_a? Time
+        obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+      else
+        obj.inspect
+      end
+    end
+
+    def bare_key?(key)
+      !!key.to_s.match(/^[a-zA-Z0-9_-]*$/)
+    end
+
+    def quote_key(key)
+      '"' + key.gsub('"', '\\"') + '"'
     end
   end
 end


### PR DESCRIPTION
This fixes a problem where the `ruby` binary that is vendored in the `heroku_ruby` layer is not used by default.
This causes many native gems to fail with `"incompatible library version"` error.
Tto reproduce the problem run `pack build` in a ruby project that has `mysql2` gem in it's Gemfile. Then run `docker run --rm my-built-image bundle exec ruby -e "require 'mysql2'"`

The reason for this error is that ruby's [`dln_incompatible_library_p`](https://github.com/ruby/ruby/blob/d48783bb0236db505fe1205d1d9822309de53a36/dln.c#L1252-L1256) ensures that the MRI binary used and the dynamic library loaded have the exact same `ruby_xmalloc`.

~The solution implemented here "exports" the relevant parts of the `PATH` (those starting with `<layer-dir>`) to the `env.launch/PATH` file so it is appended properly as specific by the [CNB spec](https://github.com/buildpack/spec/blob/37ba4d9/buildpack.md#provided-by-the-buildpacks)~

The change adds the same path that is used during install (in `#setup_ruby_install_env`) to the `PATH` written to `profile.d`