### PR TITLE
Bootstrap Ruby version of buildpack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.5'
 
 group :development, :test do
+  gem "toml-rb"
   gem "heroku_hatchet"
   gem "rspec-core"
   gem "rspec-expectations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     ansi (1.5.0)
     ci-queue (0.13.6)
       ansi
+    citrus (3.0.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
@@ -64,6 +65,8 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     threaded (0.0.4)
+    toml-rb (1.1.2)
+      citrus (~> 3.0, > 3.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
@@ -83,6 +86,10 @@ DEPENDENCIES
   rspec-core
   rspec-expectations
   rspec-retry
+  toml-rb
+
+RUBY VERSION
+   ruby 2.5.5p157
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -32,7 +32,7 @@ heroku_buildpack_ruby_install_ruby()
   if [ ! -d "$heroku_buildpack_ruby_dir" ]; then
     heroku_buildpack_ruby_dir=$(mktemp -d)
     # bootstrap ruby
-    $bin_dir/support/download_ruby $heroku_buildpack_ruby_dir
+    $bin_dir/support/download_ruby "$BIN_DIR" "$heroku_buildpack_ruby_dir"
     function atexit {
       rm -rf $heroku_buildpack_ruby_dir
     }

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -1,14 +1,48 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-# This script will download a version of Ruby for the buildpack to use
-# and put it in the `ARGV.first` location.
-$stdout.sync = true
+# Downloads a bootstrap copy of Ruby for execution of the buildpack
+# this is needed so we can totally control the Ruby version and are
+# not dependant on the Ruby version of the stack image
 
-$:.unshift File.expand_path("../../../lib", __FILE__)
-require "language_pack"
+# fail hard
+set -o pipefail
+# fail harder
+set -eu
 
-DEFAULT_STACK = "cedar-14"
+BIN_DIR=$1
+RUBY_BOOTSTRAP_DIR=$2
 
-installer    = LanguagePack::Installers::HerokuRubyInstaller.new(ENV['STACK'] || DEFAULT_STACK)
-ruby_version = LanguagePack::RubyVersion.new("ruby-#{LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER}")
-installer.fetch_unpack(ruby_version, ARGV[0])
+curl_retry_on_18() {
+  local ec=18;
+  local attempts=0;
+  while (( ec == 18 && attempts++ < 3 )); do
+    curl "$@" # -C - would return code 33 if unsupported by server
+    ec=$?
+  done
+  return $ec
+}
+
+# Pull ruby version out of buildpack.toml to be used with bootstrapping
+regex=".*ruby_version = [\'\"]([0-9]+\.[0-9]+\.[0-9]+)[\'\"].*"
+if [[ $(cat "$BIN_DIR/../buildpack.toml") =~ $regex ]]
+  then
+    heroku_buildpack_ruby_url="https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
+  else
+    echo "Could not detect ruby version to bootstrap"
+    exit 1
+fi
+
+mkdir -p "$RUBY_BOOTSTRAP_DIR"
+
+curl_retry_on_18 --fail --silent --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url" || {
+cat<<EOF
+  Failed to download a Ruby executable for bootstrapping!
+
+  This is most likely a temporary internal error. If the problem
+  persists, make sure that you are not running a custom or forked
+  version of the Heroku Ruby buildpack which may need updating.
+EOF
+  exit 1
+}
+
+tar xzf "$RUBY_BOOTSTRAP_DIR/ruby.tgz" -C "$RUBY_BOOTSTRAP_DIR"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,5 +1,6 @@
 [buildpack]
 name = "Ruby"
+ruby_version = "2.5.5"
 
   [publish.Ignore]
   files = [

--- a/spec/helpers/config_spec.rb
+++ b/spec/helpers/config_spec.rb
@@ -6,5 +6,10 @@ describe "Boot Strap Config" do
     config = TomlRB.load_file("buildpack.toml")
     bootstrap_version = config["buildpack"]["ruby_version"]
     expect(bootstrap_version).to eq(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+
+    urls = config["publish"]["Vendor"].map {|h| h["url"] if h["dir"] != "." }.compact
+    urls.each do |url|
+      expect(url.include?(bootstrap_version)).to be_truthy, "expected #{url.inspect} to include #{bootstrap_version.inspect} but it did not"
+    end
   end
 end

--- a/spec/helpers/config_spec.rb
+++ b/spec/helpers/config_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe "Boot Strap Config" do
+  it "matches the default ruby version" do
+    require 'toml-rb'
+    config = TomlRB.load_file("buildpack.toml")
+    bootstrap_version = config["buildpack"]["ruby_version"]
+    expect(bootstrap_version).to eq(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+  end
+end


### PR DESCRIPTION
Previously the ruby buildpack used itself to bootstrap a version of Ruby to run on. This technique works fine, but means that it must be able to load the HerokuRubyInstaller which requires shell helpers and lots of other code to be able to bootstrap. This means that these classes cannot use any syntax unless it is valid in all versions of system Ruby present. Currently that includes 1.9.3.

By moving the bootstrap download code to bash we can target our syntax to use any version of Ruby that the buildpack bootstraps.

In an attempt to keep things dry-ish the bash bootstrap code pulls the ruby version from the `buildpack.toml` file. This file also contains the vendor declarations that are used when the buildpack is published. Having all the versions in the same file should encourage keeping all versions up to date.