### PR TITLE
Log test order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ group :development, :test do
   gem "netrc"
   gem "git", github: "hone/ruby-git", branch: "master"
   gem 'json', '~> 2.0.2'
-  gem 'ci-queue'
+  gem 'ci-queue', github: 'shopify/ci-queue', branch: 'rspec-log-order'
   gem 'redis'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
   specs:
     git (1.2.6)
 
+GIT
+  remote: https://github.com/shopify/ci-queue.git
+  revision: 0713fe26a8b0be6290ad109a651b7cf5b242930a
+  branch: rspec-log-order
+  specs:
+    ci-queue (0.16.0)
+      ansi
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -14,8 +22,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ansi (1.5.0)
-    ci-queue (0.16.0)
-      ansi
     citrus (3.0.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
@@ -74,7 +80,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ci-queue
+  ci-queue!
   excon
   git!
   heroku_hatchet

--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
       },
       "scripts": {
         "test-setup": "bundle exec rake hatchet:setup_ci",
-        "test":       "bundle exec rspec-queue --max-requeues=3 --timeout 180 --queue $REDIS_URL"
+        "test":       "bundle exec rspec-queue --max-requeues=3 --timeout 180 --queue $REDIS_URL || { cat log/test_order.log;  $(exit 1); }"
       },
       "buildpacks": [
         { "url": "https://github.com/heroku/heroku-buildpack-apt" },


### PR DESCRIPTION
Feature introduced in https://github.com/Shopify/ci-queue/pull/99

This will output a failing test order if the suite fails.