### PR TITLE
Bump buildpack ruby version to 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Master
 
 * Set memory default for Node builds (https://github.com/heroku/heroku-buildpack-ruby/pull/861)
-* Default Ruby version is now 2.5.5, was previously 2.5.3 (https://github.com/heroku/heroku-buildpack-ruby/pull/863)
+* Default Ruby version is now 2.6.3, was previously 2.5.3 (https://github.com/heroku/heroku-buildpack-ruby/pull/863)
 * Default Node version is now 10.15.3 and default Yarn version is now 1.16.0 (https://github.com/heroku/heroku-buildpack-ruby/pull/884)
 
 ## v200 (3/7/2019)

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.5'
+ruby '2.6.3'
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 2.5.5p157
+   ruby 2.6.3p62
 
 BUNDLED WITH
    2.0.1

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "2.5.5"
+ruby_version = "2.6.3"
 
   [publish.Ignore]
   files = [
@@ -13,11 +13,11 @@ ruby_version = "2.5.5"
   dir = "."
   files = ["./.env"]
   [[publish.Vendor]]
-  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar-14/ruby-2.5.5.tgz"
+  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar-14/ruby-2.6.3.tgz"
   dir = "vendor/ruby/cedar-14"
   [[publish.Vendor]]
-  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-16/ruby-2.5.5.tgz"
+  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-16/ruby-2.6.3.tgz"
   dir = "vendor/ruby/heroku-16"
   [[publish.Vendor]]
-  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.5.5.tgz"
+  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.6.3.tgz"
   dir = "vendor/ruby/heroku-18"

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,7 +12,7 @@ module LanguagePack
       end
     end
 
-    DEFAULT_VERSION_NUMBER = "2.5.5"
+    DEFAULT_VERSION_NUMBER = "2.6.3"
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}"
     LEGACY_VERSION_NUMBER  = "1.9.2"
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}"

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -8,4 +8,15 @@ describe "Bundler" do
       expect(app.output).to match("Installing dependencies using bundler 2.")
     end
   end
+
+  it "deploys with version 2.0.2 and Ruby 2.5.5" do
+    before_deploy = -> {
+      run!(%Q{printf "ruby '2.5.5'" >> Gemfile})
+      run!(%Q{printf "\nBUNDLED WITH\n   2.0.2\n" >> Gemfile.lock})
+    }
+
+    Hatchet::Runner.new("default_ruby", before_deploy: before_deploy).deploy do |app|
+      expect(app.output).to match("Installing dependencies using bundler 2.")
+    end
+  end
 end


### PR DESCRIPTION
Due to bundler/bundler#7205. When the buildpack tries to detect the version of Ruby used by the app it gets an error if they are using bundler 2.0.2 and bundler on the system is 2.0.1:

```
remote: !
remote: ! There was an error parsing your Gemfile, we cannot continue
remote: ! /app/tmp/buildpacks/b7af5642714be4eddaa5f35e2b4c36176b839b4abcd9bfe57ee71c358d71152b4fd2cf925c5b6e6816adee359c4f0f966b663a7f8649b0729509d510091abc07/vendor/ruby/heroku-18/lib/ruby/2.5.0/rubygems.rb:289:in find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException) remote: ! from /app/tmp/buildpacks/b7af5642714be4eddaa5f35e2b4c36176b839b4abcd9bfe57ee71c358d71152b4fd2cf925c5b6e6816adee359c4f0f966b663a7f8649b0729509d510091abc07/vendor/ruby/heroku-18/lib/ruby/2.5.0/rubygems.rb:308:inactivate_bin_path'
remote: ! from /tmp/d20190618-115-la0wgl/bundler-2.0.1/bin/bundle:23:in `'
remote: !
```

Ruby 2.6.3 has a more recent version of RubyGems that should not trigger this failing logic.