### PR TITLE
Add support to Rails 6 by adding a new Language Pack

### DIFF
--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -13,7 +13,7 @@ module LanguagePack
     Instrument.instrument 'detect' do
       Dir.chdir(args.first)
 
-      pack = [ NoLockfile, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
+      pack = [ NoLockfile, Rails6, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
         klass.use?
       end
 
@@ -47,4 +47,5 @@ require "language_pack/rails4"
 require "language_pack/rails41"
 require "language_pack/rails42"
 require "language_pack/rails5"
+require "language_pack/rails6"
 require "language_pack/no_lockfile"

--- a/lib/language_pack/rails6.rb
+++ b/lib/language_pack/rails6.rb
@@ -1,0 +1,16 @@
+require 'securerandom'
+require "language_pack"
+require "language_pack/rails5"
+
+class LanguagePack::Rails6 < LanguagePack::Rails5
+  # @return [Boolean] true if it's a Rails 6.x app
+  def self.use?
+    instrument "rails6.use" do
+      rails_version = bundler.gem_version('railties')
+      return false unless rails_version
+      is_rails = rails_version >= Gem::Version.new('6.x') &&
+        rails_version < Gem::Version.new('7.0.0')
+      return is_rails
+    end
+  end
+end


### PR DESCRIPTION
The current Rails 5 language pack work for Rails 6 applications but it could not be used because of the version constraints. This was making Rails 6 apps to be handled as generic rack apps and causing problems at deploy if no SECRET_KEY_BASE was set.

By adding a new class we can update the constraint so new Rails 6 apps can work as in the pre-releases.

@hone @schneems 