### PR TITLE
Rails 6 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+## v202 (8/20/2019)
+
+* Add support class for Rails 6 (https://github.com/heroku/heroku-buildpack-ruby/pull/908)
+
 ## v201 (6/23/2019)
 
 * Set memory default for Node builds (https://github.com/heroku/heroku-buildpack-ruby/pull/861)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,4 +92,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/hatchet.json
+++ b/hatchet.json
@@ -79,6 +79,9 @@
     "sharpstone/active_storage_local",
     "sharpstone/sprockets_asset_compile_true"
   ],
+  "rails6": [
+    "sharpstone/rails6-basic"
+  ],
   "heroku": [
     "heroku/ruby-getting-started"
   ],

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -13,7 +13,7 @@ module LanguagePack
     Instrument.instrument 'detect' do
       Dir.chdir(args.first)
 
-      pack = [ NoLockfile, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
+      pack = [ NoLockfile, Rails6, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
         klass.use?
       end
 
@@ -47,4 +47,5 @@ require "language_pack/rails4"
 require "language_pack/rails41"
 require "language_pack/rails42"
 require "language_pack/rails5"
+require "language_pack/rails6"
 require "language_pack/no_lockfile"

--- a/lib/language_pack/rails6.rb
+++ b/lib/language_pack/rails6.rb
@@ -1,0 +1,16 @@
+require 'securerandom'
+require "language_pack"
+require "language_pack/rails5"
+
+class LanguagePack::Rails6 < LanguagePack::Rails5
+  # @return [Boolean] true if it's a Rails 6.x app
+  def self.use?
+    instrument "rails6.use" do
+      rails_version = bundler.gem_version('railties')
+      return false unless rails_version
+      is_rails = rails_version >= Gem::Version.new('6.x') &&
+        rails_version < Gem::Version.new('7.0.0')
+      return is_rails
+    end
+  end
+end

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v201"
+    BUILDPACK_VERSION = "v202"
   end
 end

--- a/spec/hatchet/rails6_spec.rb
+++ b/spec/hatchet/rails6_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../spec_helper'
+
+describe "Rails 6" do
+  it "should detect successfully" do
+    Hatchet::App.new('rails6-basic').in_directory do
+      expect(LanguagePack::Rails5.use?).to eq(false)
+    end
+    Hatchet::App.new('rails6-basic').in_directory do
+      expect(LanguagePack::Rails6.use?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
From @rafaelfranca on #907:

> The current Rails 5 language pack work for Rails 6 applications but it could not be used because of the version constraints. This was making Rails 6 apps to be handled as generic rack apps and causing problems at deploy if no SECRET_KEY_BASE was set.
>
> By adding a new class we can update the constraint so new Rails 6 apps can work as in the pre-releases.

In addition this adds a test.