### PR TITLE
Avoid empty error message when assets:precompile fail

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -981,17 +981,17 @@ params = CGI.parse(uri.query || "")
     mcount "fail.assets_precompile"
     log "assets_precompile", :status => "failure"
     msg = "Precompiling assets failed.\n"
+    sprockets_version = bundler.gem_version('sprockets')
     if output.match(/(127\.0\.0\.1)|(org\.postgresql\.util)/)
       msg << "Attempted to access a nonexistent database:\n"
       msg << "https://devcenter.heroku.com/articles/pre-provision-database\n"
-    end
-
-    sprockets_version = bundler.gem_version('sprockets')
-    if output.match(/Sprockets::FileNotFound/) && (sprockets_version < Gem::Version.new('4.0.0.beta7') && sprockets_version > Gem::Version.new('4.0.0.beta4'))
+    elsif output.match(/Sprockets::FileNotFound/) && (sprockets_version < Gem::Version.new('4.0.0.beta7') && sprockets_version > Gem::Version.new('4.0.0.beta4'))
       mcount "fail.assets_precompile.file_not_found_beta"
       msg << "If you have this file in your project\n"
       msg << "try upgrading to Sprockets 4.0.0.beta7 or later:\n"
       msg << "https://github.com/rails/sprockets/pull/547\n"
+    else
+      msg << output
     end
 
     error msg


### PR DESCRIPTION
Currently when a build fail at `assets:precompile`，error message is not visible unless matching the 2 [specified][1] [cases][2].

For example, in following log only 'Precompiling assets failed.' was output.

```
-----> Ruby app detected
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-2.6.3
-----> Installing dependencies using bundler 1.15.2
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x64-mingw32, x86-mswin32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x64-mingw32 x86-mswin32 java`.
       Using rake 12.3.2
       Using concurrent-ruby 1.1.5
       Using i18n 1.6.0
       ...
       Using title 0.0.7
       Using uglifier 4.1.20
       Using webpacker 4.0.7
       Bundle complete! 63 Gemfile dependencies, 143 gems now installed.
       Gems in the groups development and test were not installed.
       Bundled gems are installed into `./vendor/bundle`
       Removing bundler (1.15.2)
       Bundle completed (0.64s)
       Cleaning up the bundler cache.
       The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x64-mingw32, x86-mswin32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x64-mingw32 x86-mswin32 java`.
-----> Installing node-v10.15.3-linux-x64
-----> Installing yarn-v1.16.0
-----> Detecting rake tasks
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       W, [2019-08-29T05:45:20.284064 #274]  WARN -- sentry: ** [Raven] You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`
       I, [2019-08-29T05:45:20.284182 #274]  INFO -- sentry: ** [Raven] Raven 2.11.0 configured not to capture errors: DSN not set
       Note: Google::Cloud::Logging is disabled because it failed to authorize with the service. (Could not load the default credentials. Browse to
       https://developers.google.com/accounts/docs/application-default-credentials
       for more information
       ) Falling back to the default Rails logger.
       yarn install v1.16.0
       [1/4] Resolving packages...
       [2/4] Fetching packages...
       info fsevents@1.2.9: The platform "linux" is incompatible with this module.
       info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
       [3/4] Linking dependencies...
       warning "@hahow/hh-classroom > react-moment@0.9.2" has unmet peer dependency "moment@^2.24.0".
       warning " > styled-components@5.0.0-beta.6-ej4" has unmet peer dependency "react-is@>= 16.8.0".
       warning "@hahow/hh-classroom > styled-components > stylis-rule-sheet@0.0.10" has unmet peer dependency "stylis@^3.5.0".
       ...
       warning " > eslint-config-react-app@4.0.1" has unmet peer dependency "@typescript-eslint/parser@1.x".
       warning " > eslint-config-react-app@4.0.1" has incorrect peer dependency "babel-eslint@10.x".
       warning " > webpack-dev-server@3.8.0" has unmet peer dependency "webpack@^4.0.0".
       [4/4] Building fresh packages...
       Done in 55.27s.
       I, [2019-08-29T05:46:28.779511 #274]  INFO -- : Writing /tmp/build_cd15716fd0cc5207a3b863fd43cdf76e/public/assets/rails_admin/rails_admin-946c0320e5428d853d62d7ce91c9359a3a8813b61315f0189f4e45347de08c59.js
       I, [2019-08-29T05:46:28.779986 #274]  INFO -- : Writing /tmp/build_cd15716fd0cc5207a3b863fd43cdf76e/public/assets/rails_admin/rails_admin-946c0320e5428d853d62d7ce91c9359a3a8813b61315f0189f4e45347de08c59.js.gz
       I, [2019-08-29T05:46:31.189711 #274]  INFO -- : Writing /tmp/build_cd15716fd0cc5207a3b863fd43cdf76e/public/assets/rails_admin/rails_admin-a5ac3667cda05bcd6fd057c32fa37efbf745b1eddf48577d63afe229cfa43355.css
       ...
       I, [2019-08-29T05:46:36.410783 #274]  INFO -- : Writing /tmp/build_cd15716fd0cc5207a3b863fd43cdf76e/public/assets/actiontext/test/dummy/app/assets/stylesheets/application-5012ecb04079eb015f5aeb648c58f5e6f44dda7226233def08ceae9a8f806be9.css.gz
       I, [2019-08-29T05:46:36.569473 #274]  INFO -- : Writing /tmp/build_cd15716fd0cc5207a3b863fd43cdf76e/public/assets/actiontext/test/dummy/app/javascript/packs/application-1616dbf6c074462ce21c21b4df6b5871ef31f6224e2b4eb647713d06e8c746f2.js
       I, [2019-08-29T05:46:36.570112 #274]  INFO -- : Writing /tmp/build_cd15716fd0cc5207a3b863fd43cdf76e/public/assets/actiontext/test/dummy/app/javascript/packs/application-1616dbf6c074462ce21c21b4df6b5871ef31f6224e2b4eb647713d06e8c746f2.js.gz
       Compiling…
       Compilation failed:
       
 !
 !     Precompiling assets failed.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```

I think it would be helpful for debugging if a fail task fallbacks to print its full error message, when none of the 2 pre-defined error patterns is matched.

[1]: https://github.com/heroku/heroku-buildpack-ruby/pull/911/files#diff-3fc66e13e389ff4d15c7ca3ddb86464eR985
[2]: https://github.com/heroku/heroku-buildpack-ruby/pull/911/files#diff-3fc66e13e389ff4d15c7ca3ddb86464eR988