### PR TITLE
clean old bundler binstubs on load

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -1015,6 +1015,9 @@ params = CGI.parse(uri.query || "")
       rubygems_version_cache  = "rubygems_version"
       stack_cache             = "stack"
 
+      # bundle clean does not remove binstubs
+      FileUtils.rm_rf("vendor/bundler/bin")
+
       old_rubygems_version = @metadata.read(ruby_version_cache).chomp if @metadata.exists?(ruby_version_cache)
       old_stack = @metadata.read(stack_cache).chomp if @metadata.exists?(stack_cache)
       old_stack ||= DEFAULT_LEGACY_STACK


### PR DESCRIPTION
It looks like there's a bug with `bundle clean`, where it doesn't clean up binstubs that aren't used. This patch removes the `vendor/bundle/bin` directory on cache load. Bundler will regenerate the binstubs even if no new gems need to be installed.