### PR TITLE
Revert "Merge pull request #755 from heroku/schneems/fix-rubocop-ci-e…

### DIFF
--- a/lib/language_pack/test/rails2.rb
+++ b/lib/language_pack/test/rails2.rb
@@ -36,7 +36,6 @@ class LanguagePack::Rails2
   def clear_db_test_tasks
     FileUtils::mkdir_p 'lib/tasks'
     File.open("lib/tasks/heroku_clear_tasks.rake", "w") do |file|
-      file.puts "# rubocop:disable Lint/UnneededCopDisableDirective"
       file.puts "# rubocop:disable all"
       content = db_test_tasks_to_clear.map do |task_name|
         <<-FILE
@@ -49,7 +48,6 @@ FILE
       end.join("\n")
       file.print content
       file.puts "# rubocop:enable all"
-      file.puts "# rubocop:enable Lint/UnneededCopDisableDirective"
     end
   end
 


### PR DESCRIPTION
…rror"

This reverts commit 6d41fb17d60f5f1162aeee871c488dd8a46b1f33, reversing
changes made to 5fda279a095f91f62d02f89f0bc5aac49a67d9cf.

The purpose of this PR was to reduce errors in the CI environment
However, it was reported in https://github.com/heroku/heroku-buildpack-ruby/commit/1dc39bb0ca86bb5e3dd3287609e471f639952f95
that the commit itself actually causes a break.