### PR TITLE
[changelog skip] Fix logic for Outdated check

### DIFF
--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -71,7 +71,6 @@ class LanguagePack::Helpers::OutdatedRubyVersion
       .sort_by { |v| Gem::Version.new(v) }
       .last(3)
       .first
-      .sub(/0$/, 'x')
 
     @already_joined = true
   end
@@ -102,6 +101,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
   def suggest_ruby_eol_version
     return false unless maybe_eol?
     @suggested_eol_version
+      .sub(/0$/, 'x')
   end
 
   # Checks for a range of "tiny" versions in parallel

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -93,5 +93,23 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     expect(outdated.eol?).to be_falsey
     expect(outdated.maybe_eol?).to be_falsey
   end
+
+  it "can call eol? on the latest Ruby version" do
+    ruby_version = LanguagePack::RubyVersion.new("ruby-2.6.0")
+
+    new_fetcher = fetcher.dup
+    def new_fetcher.exists?(value); false; end
+
+    outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
+      current_ruby_version: ruby_version,
+      fetcher: new_fetcher
+    )
+
+    outdated.call
+
+    expect(outdated.eol?).to be_falsey
+    expect(outdated.maybe_eol?).to be_falsey
+  end
+
 end
 


### PR DESCRIPTION
Previously when calling this logic on a Ruby version that is truly the last in line, then we would end up with an empty array that we then call `first` on and then expect it to be a string. That string we then call `sub` on. This fails when nil is returned from the array.

Instead of doing this logic inside of the join method, we can put it directly in the suggest_ruby_eol_version method which runs after a guard statement so it will never run unless the array provided a value.

We can test this in a way that does not depend on external existence of the files by stubbing out the fetcher to always return false when it checks for another ruby version.