### PR TITLE
Fix missing constant

### DIFF
--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -176,7 +176,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
       next if !@fetcher.exists?("#{version}.tgz")
 
       check_eol_versions_minor(
-        base_version: RubyVersion.new(version)
+        base_version: LanguagePack::RubyVersion.new(version)
       )
 
       version


### PR DESCRIPTION
Was getting this error, following Ruby's own suggestion fixes it:

```
uninitialized constant LanguagePack::Helpers::OutdatedRubyVersion::RubyVersion (NameError)
Did you mean?  LanguagePack::RubyVersion
        RUBY_VERSION
```