### PR TITLE
[changelog skip] Fix missing constant && rev version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v206 (unreleased)
+## v206 (10/15/2019)
 
 * Default Ruby version for new apps is now 2.5.7 (https://github.com/heroku/heroku-buildpack-ruby/pull/926)
 * Using old and EOL versions of Ruby now generate warnings (https://github.com/heroku/heroku-buildpack-ruby/pull/864)

--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -176,7 +176,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
       next if !@fetcher.exists?("#{version}.tgz")
 
       check_eol_versions_minor(
-        base_version: RubyVersion.new(version)
+        base_version: LanguagePack::RubyVersion.new(version)
       )
 
       version

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v205"
+    BUILDPACK_VERSION = "v206"
   end
 end


### PR DESCRIPTION
- cherry-picking https://github.com/heroku/heroku-buildpack-ruby/pull/930 for tests
- bump version, ready to release tomorrow.