### PR TITLE
Vendor libpq5.12.1 into Slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v207 (unreleased)
 
+* Vendor in libpq 5.12.1 (https://github.com/heroku/heroku-buildpack-ruby/pull/935)
 * Remove possibilities of false exceptions being raised by removing `BUNDLED WITH` from the `Gemfile.lock` (https://github.com/heroku/heroku-buildpack-ruby/pull/928)
 
 ## v206 (10/15/2019)

--- a/changelogs/v207/vendor_libpq.md
+++ b/changelogs/v207/vendor_libpq.md
@@ -1,0 +1,15 @@
+## Postgresql client library libpq version 5.12.1 now vendored into Ruby applications
+
+Ruby applications will get a vendored version of the libpq client library version 5.12.1 starting today. For more information about the reasons for this change and the possible effects see:
+
+<url>
+
+If your application breaks due to this change you can rollback to your last build. You can also temporarially opt out of this behavior by setting:
+
+```
+$ heroku config:set HEROKU_SKIP_LIBPQ12=1
+```
+
+In the future libpq 5.12 will be the default on the platform and you will not be able to opt-out of the library. For more information see:
+
+<url>

--- a/changelogs/v207/vendor_libpq.md
+++ b/changelogs/v207/vendor_libpq.md
@@ -2,7 +2,7 @@
 
 Ruby applications will get a vendored version of the libpq client library version 5.12.1 starting today. For more information about the reasons for this change and the possible effects see:
 
-<url>
+https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
 
 If your application breaks due to this change you can rollback to your last build. You can also temporarially opt out of this behavior by setting:
 
@@ -12,4 +12,4 @@ $ heroku config:set HEROKU_SKIP_LIBPQ12=1
 
 In the future libpq 5.12 will be the default on the platform and you will not be able to opt-out of the library. For more information see:
 
-<url>
+https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior

--- a/hatchet.json
+++ b/hatchet.json
@@ -30,7 +30,8 @@
     "sharpstone/jruby-minimal",
     "sharpstone/empty-procfile",
     "sharpstone/bad_ruby_version",
-    "sharpstone/activerecord41_scaffold"
+    "sharpstone/activerecord41_scaffold",
+    "sharpstone/libpq_connection_error"
   ],
   "jruby": [
     "sharpstone/jruby_naether"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -164,7 +164,7 @@ WARNING
     EOF
 
     Dir.chdir("vendor") do
-      run!("curl --remote-name-all http://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-12/#{pkg}")
+      run!("curl --remote-name-all https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-12/#{pkg}")
       run!("dpkg -x #{pkg} .")
 
       load_libpq_12_unless_env_var = <<~EOF

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -147,7 +147,8 @@ WARNING
       This version includes a bug fix that can cause an exception
       on boot for applications with incorrectly configured connection
       values. For more information see:
-        <url>
+
+        https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
 
       If your application breaks you can rollback to your last build.
       You can also temporarially opt out of this behavior by setting:
@@ -158,7 +159,8 @@ WARNING
 
       In the future libpq 5.12 will be the default on the platform and
       you will not be able to opt-out of the library. For more information see:
-        <url>
+
+        https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
     EOF
 
     Dir.chdir("vendor") do

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -121,7 +121,6 @@ WARNING
   def patch_libpq
     # Check for existing libraries
     out = run!("ls /usr/lib/x86_64-linux-gnu/ | grep libpq")
-    puts out
     out.each_line do |line|
       version = line.sub(/libpq\.so\./, '')
       next unless version.match?(/\Ad/) # avoid libpq.so.libpq.a

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -121,8 +121,10 @@ WARNING
   def patch_libpq
     # Check for existing libraries
     out = run!("ls /usr/lib/x86_64-linux-gnu/ | grep libpq")
+    puts out
     out.each_line do |line|
       version = line.sub(/libpq\.so\./, '')
+      next unless version.match?(/\Ad/) # avoid libpq.so.libpq.a
       return if Gem::Version.new(version) >= Gem::Version("5.12")
     end
 

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -1,6 +1,22 @@
 require_relative '../spec_helper'
 
 describe "Ruby apps" do
+  describe "vendoring libpq" do
+    it "works on heroku-16" do
+      Hatchet::Runner.new("libpq_connection_error", stack: "heroku-16").deploy do |app|
+        out = app.run("ruby reproduce_error.rb")
+        expect(out).to match(%Q{invalid integer value "15s"})
+      end
+    end
+
+    it "works on heroku-18" do
+      Hatchet::Runner.new("libpq_connection_error", stack: "heroku-18").deploy do |app|
+        out = app.run("ruby reproduce_error.rb")
+        expect(out).to match(%Q{invalid integer value "15s"})
+      end
+    end
+  end
+
   describe "running Ruby from outside the default dir" do
     it "works" do
       Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK).deploy do |app|


### PR DESCRIPTION
Libpq is the client library used to communicate to postgresql. There was a bug in libpq 5.11 that essentially said if there is a problem with a configuration value, for example if you tried to set `pool` (which should be an integer) to a string, then the value would be silently ignored. In libpq 5.12 this behavior was "fixed" so that if you try to set a value to an incorrect type it will raise an error:

```
PG::UnableToSend: no connection to the server
```

Or 

```
CONNECTION_BAD
```

Here is the commit that changed the behavior https://github.com/postgres/postgres/commit/e7a2217978d9cbb2149bfcb4ef1e45716cfcbefb

The largest failure mode is when someone accidentally forgets to put a space after their ERB tag in `database.yml` but before their comment. For example:


```
connect_timeout: <%= ENV['DB_CONNECT_TIMEOUT'] || 5 %># seconds
```

Would be evaluated to a string of "5# seconds". This will work in libpq5.11 but fail in libpq5.12. This can be fixed by adding a space between `%>` and `# seconds`.

This change was rolled out on our stack image, but then rolled back to customers getting failures in the middle of the night when they had seemingly changed nothing. 

By vendoring this library in the slug, we have more control around when the update will happen. Rather than breaking changes when the stack image rolls out which might happen in the middle of the night for some developers, this change will only be applied as customers are deploying their apps. If they have a release phase then the error will likely be caught there and prevented from going into production.

This behavior introduces a helpful warning message along with URLs for getting more information around this issue.

We do not anticipate that a majority of applications will be affected by this change, however those that are affected experience large problems. The intent of rolling this change out in a buildpack is to minimize the exposure of apps that will trigger this failing condition.

Eventually libpq5.12.1 will be the default version on the stack. This change works to prepare developers for that change.

## TODO

- [x] Changelog
- [ ] Devcenter article explaining the problem