### PR TITLE
Vendor libpq5.12.1 into Slugs - Heroku 18 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v207 (unreleased)
 
-* Vendor in libpq 5.12.1 (https://github.com/heroku/heroku-buildpack-ruby/pull/935)
+* Vendor in libpq 5.12.1 for Heroku-18 (https://github.com/heroku/heroku-buildpack-ruby/pull/936)
 * Remove possibilities of false exceptions being raised by removing `BUNDLED WITH` from the `Gemfile.lock` (https://github.com/heroku/heroku-buildpack-ruby/pull/928)
 
 ## v206 (10/15/2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v207 (unreleased)
 
+* Vendor in libpq 5.12.1 (https://github.com/heroku/heroku-buildpack-ruby/pull/935)
 * Remove possibilities of false exceptions being raised by removing `BUNDLED WITH` from the `Gemfile.lock` (https://github.com/heroku/heroku-buildpack-ruby/pull/928)
 
 ## v206 (10/15/2019)

--- a/changelogs/v207/vendor_libpq.md
+++ b/changelogs/v207/vendor_libpq.md
@@ -1,0 +1,15 @@
+## Postgresql client library libpq version 5.12.1 now vendored into Ruby applications
+
+Ruby applications will get a vendored version of the libpq client library version 5.12.1 starting today. For more information about the reasons for this change and the possible effects see:
+
+<url>
+
+If your application breaks due to this change you can rollback to your last build. You can also temporarially opt out of this behavior by setting:
+
+```
+$ heroku config:set HEROKU_SKIP_LIBPQ12=1
+```
+
+In the future libpq 5.12 will be the default on the platform and you will not be able to opt-out of the library. For more information see:
+
+<url>

--- a/changelogs/v207/vendor_libpq.md
+++ b/changelogs/v207/vendor_libpq.md
@@ -2,7 +2,7 @@
 
 Ruby applications will get a vendored version of the libpq client library version 5.12.1 starting today. For more information about the reasons for this change and the possible effects see:
 
-<url>
+https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
 
 If your application breaks due to this change you can rollback to your last build. You can also temporarially opt out of this behavior by setting:
 
@@ -12,4 +12,4 @@ $ heroku config:set HEROKU_SKIP_LIBPQ12=1
 
 In the future libpq 5.12 will be the default on the platform and you will not be able to opt-out of the library. For more information see:
 
-<url>
+https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior

--- a/changelogs/v207/vendor_libpq.md
+++ b/changelogs/v207/vendor_libpq.md
@@ -1,6 +1,6 @@
-## Postgresql client library libpq version 5.12.1 now vendored into Ruby applications
+## Postgresql client library libpq version 5.12.1 now vendored into Ruby applications on Heroku-18
 
-Ruby applications will get a vendored version of the libpq client library version 5.12.1 starting today. For more information about the reasons for this change and the possible effects see:
+Ruby applications deploying to Heroku-18 will get a vendored version of the libpq client library version 5.12.1 starting today. For more information about the reasons for this change and the possible effects see:
 
 https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
 

--- a/hatchet.json
+++ b/hatchet.json
@@ -30,7 +30,8 @@
     "sharpstone/jruby-minimal",
     "sharpstone/empty-procfile",
     "sharpstone/bad_ruby_version",
-    "sharpstone/activerecord41_scaffold"
+    "sharpstone/activerecord41_scaffold",
+    "sharpstone/libpq_connection_error"
   ],
   "jruby": [
     "sharpstone/jruby_naether"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -111,6 +111,8 @@
   - 7cae0aae424c2028b81b5d37ee24d42db8e545b9
 - - "./repos/ruby/jruby-minimal"
   - f79860bc2866449fe065484f1542aaadd3f7cfd2
+- - "./repos/ruby/libpq_connection_error"
+  - c211c245f09d8335a520cd7a0b5360897d4988eb
 - - "./repos/ruby/mri_187"
   - 43cecfacbedda64f09310a4408ce73c5dc3a9c44
 - - "./repos/ruby/mri_193_p547"

--- a/lib/language_pack/metadata.rb
+++ b/lib/language_pack/metadata.rb
@@ -35,6 +35,15 @@ class LanguagePack::Metadata
     write(key, "true")
   end
 
+  def fetch(key)
+    return read(key) if exists?(key)
+
+    value = yield
+
+    write(key, value.to_s)
+    return value
+  end
+
   def save
     @cache ? @cache.add(FOLDER) : false
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -164,7 +164,7 @@ WARNING
     EOF
 
     Dir.chdir("vendor") do
-      run!("curl --remote-name-all http://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-12/#{pkg}")
+      run!("curl --remote-name-all https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-12/#{pkg}")
       run!("dpkg -x #{pkg} .")
 
       load_libpq_12_unless_env_var = <<~EOF

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -147,7 +147,8 @@ WARNING
       This version includes a bug fix that can cause an exception
       on boot for applications with incorrectly configured connection
       values. For more information see:
-        <url>
+
+        https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
 
       If your application breaks you can rollback to your last build.
       You can also temporarially opt out of this behavior by setting:
@@ -158,7 +159,8 @@ WARNING
 
       In the future libpq 5.12 will be the default on the platform and
       you will not be able to opt-out of the library. For more information see:
-        <url>
+
+        https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
     EOF
 
     Dir.chdir("vendor") do

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -120,23 +120,8 @@ WARNING
 
   def vendor_libpq
     # Check for existing libraries
-    out = run!("ls /usr/lib/x86_64-linux-gnu/ | grep libpq")
-    out.each_line do |line|
-      version = line.sub(/libpq\.so\./, '')
-      next unless version.match?(/\Ad/) # avoid libpq.so.libpq.a
-      return if Gem::Version.new(version) >= Gem::Version("5.12")
-    end
-
-    case ENV['STACK']
-    when 'heroku-16'
-      pkg = "libpq5_12.1-1.pgdg16.04+1_amd64.deb"
-    when 'heroku-18'
-      pkg = "libpq5_12.1-1.pgdg18.04+1_amd64.deb"
-    when 'cedar-14'
-      return
-    else
-      return
-    end
+    return unless File.exist?("/usr/lib/x86_64-linux-gnu/libpq.so.5.11")
+    return unless ENV['STACK'] == 'heroku-18'
 
     @metadata.touch("patched_libpq12")
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -99,7 +99,7 @@ WARNING
       setup_export
       setup_profiled
       allow_git do
-        patch_libpq
+        vendor_libpq
         install_bundler_in_app
         build_bundler("development:test")
         post_bundler
@@ -118,7 +118,7 @@ WARNING
     raise e
   end
 
-  def patch_libpq
+  def vendor_libpq
     # Check for existing libraries
     out = run!("ls /usr/lib/x86_64-linux-gnu/ | grep libpq")
     out.each_line do |line|

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -149,8 +149,9 @@ WARNING
     EOF
 
     Dir.chdir("vendor") do
-      run!("curl --remote-name-all https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-12/#{pkg}")
-      run!("dpkg -x #{pkg} .")
+      @fetchers[:mri].fetch_untar("libpq5_12.1-1.deb.tgz")
+      run!("dpkg -x libpq5_12.1-1.deb .")
+      run!("rm libpq5_12.1-1.deb")
 
       load_libpq_12_unless_env_var = <<~EOF
         if [ "$HEROKU_SKIP_LIBPQ12" == "" ]; then

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -121,7 +121,6 @@ WARNING
   def patch_libpq
     # Check for existing libraries
     out = run!("ls /usr/lib/x86_64-linux-gnu/ | grep libpq")
-    puts out
     out.each_line do |line|
       version = line.sub(/libpq\.so\./, '')
       next unless version.match?(/\Ad/) # avoid libpq.so.libpq.a

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -149,7 +149,7 @@ WARNING
     EOF
 
     Dir.chdir("vendor") do
-      @fetchers[:mri].fetch_untar("libpq5_12.1-1.deb.tgz")
+      @fetchers[:mri].fetch("libpq5_12.1-1.deb")
       run!("dpkg -x libpq5_12.1-1.deb .")
       run!("rm libpq5_12.1-1.deb")
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -123,30 +123,33 @@ WARNING
     return unless File.exist?("/usr/lib/x86_64-linux-gnu/libpq.so.5.11")
     return unless ENV['STACK'] == 'heroku-18'
 
-    @metadata.touch("patched_libpq12")
-
     topic("Vendoring libpq 5.12.1")
-    warn(<<~EOF)
-      Replacing libpq with version libpq 5.12.1
 
-      This version includes a bug fix that can cause an exception
-      on boot for applications with incorrectly configured connection
-      values. For more information see:
+    @metadata.fetch("vendor_libpq12") do
+      warn(<<~EOF)
+        Replacing libpq with version libpq 5.12.1
 
-        https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
+        This version includes a bug fix that can cause an exception
+        on boot for applications with incorrectly configured connection
+        values. For more information see:
 
-      If your application breaks you can rollback to your last build.
-      You can also temporarially opt out of this behavior by setting:
+          https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
 
-      ```
-      $ heroku config:set HEROKU_SKIP_LIBPQ12=1
-      ```
+        If your application breaks you can rollback to your last build.
+        You can also temporarially opt out of this behavior by setting:
 
-      In the future libpq 5.12 will be the default on the platform and
-      you will not be able to opt-out of the library. For more information see:
+        ```
+        $ heroku config:set HEROKU_SKIP_LIBPQ12=1
+        ```
 
-        https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
-    EOF
+        In the future libpq 5.12 will be the default on the platform and
+        you will not be able to opt-out of the library. For more information see:
+
+          https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
+      EOF
+
+      "true" # Set future cache value
+    end
 
     Dir.chdir("vendor") do
       @fetchers[:mri].fetch("libpq5_12.1-1.deb")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -121,8 +121,10 @@ WARNING
   def patch_libpq
     # Check for existing libraries
     out = run!("ls /usr/lib/x86_64-linux-gnu/ | grep libpq")
+    puts out
     out.each_line do |line|
       version = line.sub(/libpq\.so\./, '')
+      next unless version.match?(/\Ad/) # avoid libpq.so.libpq.a
       return if Gem::Version.new(version) >= Gem::Version("5.12")
     end
 

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -1,6 +1,22 @@
 require_relative '../spec_helper'
 
 describe "Ruby apps" do
+  describe "vendoring libpq" do
+    it "works on heroku-16" do
+      Hatchet::Runner.new("libpq_connection_error", stack: "heroku-16").deploy do |app|
+        out = app.run("ruby reproduce_error.rb")
+        expect(out).to match(%Q{invalid integer value "15s"})
+      end
+    end
+
+    it "works on heroku-18" do
+      Hatchet::Runner.new("libpq_connection_error", stack: "heroku-18").deploy do |app|
+        out = app.run("ruby reproduce_error.rb")
+        expect(out).to match(%Q{invalid integer value "15s"})
+      end
+    end
+  end
+
   describe "running Ruby from outside the default dir" do
     it "works" do
       Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK).deploy do |app|

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -3,6 +3,8 @@ require_relative '../spec_helper'
 describe "Ruby apps" do
   describe "vendoring libpq" do
     it "works on heroku-16" do
+      skip "Blocked on getting heroku-16 docker example to work https://github.com/schneems/libpq_heroku_16_reproduction/tree/schneems/manually-download-install"
+
       Hatchet::Runner.new("libpq_connection_error", stack: "heroku-16").deploy do |app|
         out = app.run("ruby reproduce_error.rb")
         expect(out).to match(%Q{invalid integer value "15s"})


### PR DESCRIPTION
Pick up from the work in https://github.com/heroku/heroku-buildpack-ruby/pull/935 but removing Heroku-16 support until we can get that working in Docker locally 

https://github.com/schneems/libpq_heroku_16_reproduction/tree/schneems/manually-download-install

(Note it's a branch)