### PR TITLE
Default WEB_CONCURRENCY and RAILS_MAX_THREADS for new apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v207 (unreleased)
+## Master (unreleased)
+
+* Set default values for WEB_CONCURRENCY for new applications based on dyno type and size (https://github.com/heroku/heroku-buildpack-ruby/pull/946)
+
+## v207 (12/16/2019)
 
 * Vendor in libpq 5.12.1 for Heroku-18 (https://github.com/heroku/heroku-buildpack-ruby/pull/936)
 * Remove possibilities of false exceptions being raised by removing `BUNDLED WITH` from the `Gemfile.lock` (https://github.com/heroku/heroku-buildpack-ruby/pull/928)

--- a/changelogs/v208/WEB_CONCURRENCY.md
+++ b/changelogs/v208/WEB_CONCURRENCY.md
@@ -1,0 +1,34 @@
+## New Ruby applications now have a set default value WEB_CONCURRENCY based on dyno type and size
+
+The values for WEB_CONCURRENCY and RAILS_MAX_THREADS are now set for new applications based on the dyno size and type. This will allow a developer upgrading to a performance-l dyno to take advantage of additional physical CPU cores without having to modify environment variables.
+
+Existing applications that want to opt-into having these values set to defaults can do so by setting this configuration value:
+
+```
+$ heroku config:set SENSIBLE_DEFAULTS=1
+```
+
+For more information see the [Ruby Support documentation](https://devcenter.heroku.com/articles/ruby-support#default-web_concurrency)
+
+
+----
+
+## Default WEB_CONCURRENCY
+
+For new applications, the values for WEB_CONCURRENCY and RAILS_MAX_THREADS are set by default according to our [recommended Puma configuration](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration).
+
+You can see if your application has this set by running `heroku run bash` and then this command:
+
+```
+$ cat .profile.d/WEB_CONCURRENCY.sh | grep RAILS_MAX_THREADS
+export RAILS_MAX_THREADS=${RAILS_MAX_THREADS:-5}
+```
+
+If you see a blank output then this feature is not enabled. To enable this feature for an existing application you can set:
+
+```
+$ heroku config:set SENSIBLE_DEFAULTS=1
+```
+
+If you still do not see the expected output, it may be due to use of multiple buildpacks and the order they are being invoked. Multiple buildpacks such as the `heroku/nodejs` buildpack also set a default value for `WEB_CONCURRENCY`. When multiple buildpacks set this value, the last one to execute will "win" and those settings will take precedence. To avoid this complication place the `heroku/ruby` buildpack after other buildpacks or manually manage your environment variable values.
+

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -43,7 +43,18 @@ describe "Ruby Versions on cedar-14" do
     end
   end
 
-  it "should deploy jdk 8 on cedar-14 by default" do
+  it "should deploy jruby 1.7.16.1 (jdk 7) properly on cedar-14 with sys props file" do
+    app = Hatchet::Runner.new("ruby_193_jruby_17161_jdk7", stack: "cedar-14")
+    app.setup!
+    app.deploy do |app|
+      expect(app.output).to match("Installing JVM: openjdk-7")
+      expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
+    end
+  end
+end
+
+describe "Ruby versions" do
+  it "should deploy jdk 8 on heroku-18  by default" do
     app = Hatchet::Runner.new("ruby_193_jruby_1_7_27", stack: "heroku-18")
     app.setup!
     app.deploy do |app|
@@ -60,23 +71,14 @@ describe "Ruby Versions on cedar-14" do
     end
   end
 
-  it "should deploy jruby 1.7.16.1 (jdk 7) properly on cedar-14 with sys props file" do
-    app = Hatchet::Runner.new("ruby_193_jruby_17161_jdk7", stack: "cedar-14")
-    app.setup!
-    app.deploy do |app|
-      expect(app.output).to match("Installing JVM: openjdk-7")
-      expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
-    end
-  end
-
-  it "should deploy jruby with the naether gem" do
-    app = Hatchet::Runner.new("jruby_naether", stack: DEFAULT_STACK)
-    app.setup!
-    app.deploy do |app|
-      expect(app.output).to match("Installing naether")
-      expect(app.output).not_to include("An error occurred while installing naether")
-    end
-  end
+  # it "should deploy jruby with the naether gem" do
+  #   app = Hatchet::Runner.new("jruby_naether", stack: DEFAULT_STACK)
+  #   app.setup!
+  #   app.deploy do |app|
+  #     expect(app.output).to match("Installing naether")
+  #     expect(app.output).not_to include("An error occurred while installing naether")
+  #   end
+  # end
 end
 
 

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -50,21 +50,6 @@ describe "Ruby apps" do
     end
   end
 
-  # describe "default WEB_CONCURRENCY" do
-  #   it "auto scales WEB_CONCURRENCY" do
-  #     pending("https://github.com/heroku/api/issues/4426")
-  #     app = Hatchet::Runner.new("default_ruby")
-  #     app.setup!
-  #     app.set_config("SENSIBLE_DEFAULTS" => "enabled")
-  #     app.deploy do |app|
-  #       app.run('echo "loaded"')
-  #       expect(app.run(:bash, 'echo "value: $WEB_CONCURRENCY"', heroku: { size: "1X" } )).to match("value: 2")
-  #       expect(app.run(:bash, 'echo "value: $WEB_CONCURRENCY"', heroku: { size: "2X" } )).to match("value: 4")
-  #       expect(app.run(:bash, 'echo "value: $WEB_CONCURRENCY"', heroku: { size: "PX" } )).to match("value: 16")
-  #     end
-  #   end
-  # end
-
   describe "Rake detection" do
     context "default" do
       # it "adds default process types" do
@@ -137,6 +122,9 @@ describe "Rack" do
 
     app.deploy do |app|
       expect(app.run("env")).to match(custom_env)
+
+      # Testing default WEB_CONCURRENCY value
+      expect(app.run('env | grep WEB_CONCURRENCY')).to match("WEB_CONCURRENCY=1")
     end
   end
 end


### PR DESCRIPTION
These values are set based on recommendations from https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration

These new settings only take effect if the user is deploying a new application or is using the `SENSIBLE_DEFAULTS` environment variable (legacy).

The reason we cannot make this the default for all applications is some people use the lack of an environment variable to set their application values. For example their `config/puma.rb` might look like this:

```
workers ENV.fetch("WEB_CONCURRENCY") { 2 }
```

In this scenario if they've purposefully unset the `WEB_CONCURRENCY` env-var then they would expect it to use a value of `2`. This expectation is not as strong for new applications and will minimize breaking behavior.

In addition to setting this default value it also utilizes the semi-standard `.profile.d/WEB_CONCURRENCY.sh` file so that the last buildpack in the list will be the one that "wins" at setting the value for WEB_CONCURRENCY.

Here is a copy of the current recommendations and the rationale behind the selected settings:

## Recommended default Puma process and thread configuration

Here are our default recommended values for Puma processes and threads:

<table>
<thead>
  <tr style="width: 100%">
    <th style="text-align: left; white-space: nowrap;">Dyno Type</th>
    <th style="text-align: left;">Recommended web process count (WEB_CONCURRENCY)</th>
    <th style="text-align: left;">Recommended web thread count (RAILS_MAX_THREADS)</th>
    <th style="text-align: left;">Dedicated cores</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td style="text-align: left; white-space: nowrap;">free</td>
    <td style="text-align: left; ">1 (2 if enough memory)</td>
    <td style="text-align: left; ">5</td>
    <td style="text-align: left; ">n/a</td>
</tr>
  <tr>
    <td style="text-align: left; white-space: nowrap;">hobby</td>
    <td style="text-align: left; ">1 (2 if enough memory)</td>
    <td style="text-align: left; ">5</td>
    <td style="text-align: left; ">n/a</td>
  </tr>
  <tr>
    <td style="text-align: left; white-space: nowrap;">standard-1x</td>
    <td style="text-align: left; ">1 (2 if enough memory)</td>
    <td style="text-align: left; ">5</td>
    <td style="text-align: left; ">n/a</td>
  </tr>
  <tr>
    <td style="text-align: left; white-space: nowrap;">standard-2x</td>
    <td style="text-align: left; ">2</td>
    <td style="text-align: left; ">5</td>
    <td style="text-align: left; ">n/a</td>
  </tr>
  <tr>
    <td style="text-align: left; white-space: nowrap;">performance-m</td>
    <td style="text-align: left; ">2</td>
    <td style="text-align: left; ">5</td>
    <td style="text-align: left; ">1</td>
  </tr>
  <tr>
    <td style="text-align: left; white-space: nowrap;">performance-l</td>
    <td style="text-align: left; ">4</td>
    <td style="text-align: left; ">5</td>
    <td style="text-align: left; ">4</td>
  </tr>
</tbody>
</table>

>warning
>Regardless of what we recommend here, you must tune the values to your application. If your application encounters [R14 - Memory Quota Exceeded errors](https://devcenter.heroku.com/articles/ruby-memory-use), you should consider reducing your process count.

>note
>The following material is not comprehensive and is subject to change. For a full understanding of tuning your application's performance, we recommend [The Complete Guide to Rails Performance](https://www.railsspeed.com/).

## Process count value

Increasing process count increases RAM utilization, which can be a limiting factor. Another factor for setting this value is the number of physical cores on the system. Due to the [GVL](https://en.wikipedia.org/wiki/Global_interpreter_lock), the Ruby interpreter (MRI) can only run one thread executing Ruby code at a time. Due to this limitation, to fully make use of multiple cores, your application should have a process count that matches the number of physical cores on the system.

If you go above the physical core count, then the processes will contend for limited resources. Due to this contention, they will spend extra time context switching that could have been spent executing code.

You can find the number of physical cores by running `nproc` on a system via `heroku run bash`. For example:

```term
$ heroku run bash --size=performance-l
$ nproc
8
```

The value returned by `nproc` includes "hyperthreads" in addition to physical cores. All physical cores used on Heroku have a hyperthread so to gain the "true" number of physical cores divide by two. For example, with performance-l dynos, there are four physical cores and four hyperthreads. This dyno can only physically execute instructions from four processes at a time.

>note
>The value for `nproc` from free, hobby, standard-1x, and standard-2x dynos are correct, but these cores are shared between multiple applications running in containers. While `nproc` for these dynos will all return `8`, it is best to assume only one process can execute at a time.

While the number of physical cores dictates the maximum number of processes that can execute at a given time, there are cases you want to tune process count above physical core count. Multiple processes can provide redundancy in case one process crashes. When a Puma worker process crashes, it will be restarted, but this process is not instantaneous. While the master process is replacing a worker process, having redundancy can mean that the second process can still process requests. For this reason, we typically recommend a minimum of `2` processes, if possible.

The other reason to have multiple processes that exceed physical core count is if your application is not thread-safe and cannot run multiple threads. If you are only running one process in this scenario, then your core will be idle while your application makes IO calls, such as network requests or database queries. In this scenario, having an extra process would allow it to work on another request while waiting on IO.

The final consideration when setting process type is memory use. Scaling out through processes typically uses more memory than using more threads. For more information on this, see: [what is a thread](https://www.schneems.com/2017/10/23/wtf-is-a-thread/). If your application is using so much memory that it starts to swap to disk, this will dramatically reduce the performance of your application. We highly recommend tuning your process count so that your application does not encounter a [R14 - Memory Quota Exceeded error](https://devcenter.heroku.com/articles/ruby-memory-use).

## Thread count value

Once you've found an optimal value for your process count, you can further tune the system's thread count. Threads in a Ruby (MRI) process allow your app to work on multiple requests at a time when there is IO involved (database calls, network calls, etc.). It is "cheaper" for an operating system to context switch between threads, and they also generally consume less memory overall than processes since they share memory. Adding more threads to a system will [increase the overall memory use of the Ruby app over time](https://schneems.com/2019/11/07/why-does-my-apps-memory-usage-grow-asymptotically-over-time/), but it's not usually the main concern for tuning the thread number.

We recommend the same number of threads for each process type. We picked five in part because it is the default value for the Active Record connection pool, but also in part because research has shown the value to be "good enough":

> What you're seeing there, with 5-10 threads being optimal for an I/O-heavy workload, is pretty typical of CRuby. [Appfolio: Threads, Processes, and Fibers](https://engineering.appfolio.com/appfolio-engineering/2019/9/4/benchmark-results-threads-processes-and-fibers)

**Dyno load to tune thread counts (on Performance dynos)** - Heroku does provide a [Dyno Load metric](https://devcenter.heroku.com/articles/metrics#dyno-load
) to understand CPU utilization. Ideally, when tuning overall thread count (number of processes multiplied by the number of threads), you want to consume all CPU time available to your application. The load value in this metric represents the number of tasks/threads that are waiting or currently executing at a given time. If this number is high, it indicates there are too many threads spawned and that your application may be suffering from contention. If the number very infrequently rises above your physical core count, then your application may benefit from additional threads.

For more information see [What is an acceptable amount of Dyno load?](https://help.heroku.com/88G3XLA6/what-is-an-acceptable-amount-of-dyno-load)