### PR TITLE
Fix RubyVersion#vendored_bundler?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,76 @@
+version: 2
+
+references:
+  default_docker_ruby_executor: &default_docker_ruby_executor
+    image: circleci/ruby:2.5.7-stretch
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      GEM_HOME: vendor/bundle
+      HATCHET_APP_LIMIT: 80
+      HATCHET_DEPLOY_STRATEGY: git
+      HATCHET_RETRIES: 3
+      HATCHET_BUILDPACK_BASE: https://github.com/Kajabi/heroku-buildpack-ruby.git
+jobs:
+  build:
+    docker:
+      - *default_docker_ruby_executor
+    steps:
+      - checkout
+      - run: echo "export PATH=\"$(pwd)/vendor/bundle/bin:$PATH\"" >> $BASH_ENV
+      - restore_cache:
+          keys:
+            - kajabi-buildpack-ruby-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install correct bundler version
+          command: gem install --conservative --install-dir vendor/bundle bundler:2.0.2
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      - save_cache:
+          key: kajabi-buildpack-ruby-bundle-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      # hatchet ci:setup installs apt packages (mostly the heroku CLI) and
+      # downloads `repos` from `hatchet.json`.
+      - run:
+          name: Setup Hatchet
+          command: bundle exec hatchet ci:setup
+      - save_cache:
+          key: kajabi-buildpack-ruby-hatchet-{{ checksum "hatchet.lock" }}
+          paths:
+            - repos
+  test:
+    parallelism: 10
+    docker:
+      - *default_docker_ruby_executor
+    steps:
+      - checkout
+      - run: echo "export PATH=\"$(pwd)/vendor/bundle/bin:$PATH\"" >> $BASH_ENV
+      - restore_cache:
+          keys:
+            - kajabi-buildpack-ruby-bundle-{{ checksum "Gemfile.lock" }}
+            - kajabi-buildpack-ruby-hatchet-{{ checksum "hatchet.lock" }}
+      - run:
+          name: Install correct bundler version
+          command: gem install --conservative --install-dir vendor/bundle bundler:2.0.2
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      - run:
+          name: Setup Hatchet
+          command: bundle exec hatchet ci:setup
+      - run:
+          command: |
+            mkdir /tmp/test-results
+            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            bundle exec rspec $TESTFILES --format progress
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -93,7 +93,7 @@ module LanguagePack
 
     # does this vendor bundler
     def vendored_bundler?
-      false
+      Gem::Version.new(self.ruby_version) >= Gem::Version.new("2.6.0-dev")
     end
 
     # Returns the next logical version in the minor series

--- a/spec/helpers/rails_runner_spec.rb
+++ b/spec/helpers/rails_runner_spec.rb
@@ -4,6 +4,9 @@ describe "Rails Runner" do
   around(:each) do |test|
     original_path = ENV["PATH"]
     ENV["PATH"] = "./bin/:#{ENV['PATH']}"
+    # bash subprocesses (e.g. as set by CircleCI) will source $BASH_ENV, which
+    # could clobber our change to $PATH
+    ENV["BASH_ENV"] = nil
 
     Dir.mktmpdir do |tmpdir|
       Dir.chdir(tmpdir) do

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -131,4 +131,12 @@ describe "RubyVersion" do
       expect { LanguagePack::RubyVersion.new(@bundler.ruby_version) }.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
     end
   end
+
+  it "detects vendored bundler" do
+    ruby_version = LanguagePack::RubyVersion.new("ruby-2.5.7-p-206")
+    expect(ruby_version.vendored_bundler?).to be false
+
+    ruby_version = LanguagePack::RubyVersion.new("ruby-2.6.5-p-114")
+    expect(ruby_version.vendored_bundler?).to be true
+  end
 end


### PR DESCRIPTION
Ruby 2.6 started vendoring bundler, so this returns the correct value from `RubyVersion#vendored_bundler?`