### PR TITLE
Make version warnings more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master (unreleased)
 
+## v209 (3/5/2020)
+
+* Fix bug in version download error message logic (https://github.com/heroku/heroku-buildpack-ruby/pull/957)
+
 ## v208 (3/4/2020)
 
 * Improve Ruby version download error messages (https://github.com/heroku/heroku-buildpack-ruby/pull/953)

--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -28,14 +28,14 @@ class LanguagePack::Helpers::DownloadPresence
     end
   end
 
-  def next_stack(stack)
-    next_index = @stacks.index(stack) + 1
+  def next_stack(current_stack: )
+    next_index = @stacks.index(current_stack) + 1
 
     @stacks[next_index]
   end
 
-  def exists_on_next_stack?(stack)
-    next_index = @stacks.index(stack) + 1
+  def exists_on_next_stack?(current_stack: )
+    next_index = @stacks.index(current_stack) + 1
     @threads[next_index]
   end
 
@@ -60,7 +60,7 @@ class LanguagePack::Helpers::DownloadPresence
   def call
     @fetchers.map do |fetcher|
       @threads << Thread.new do
-        fetcher.exists?(@path)
+        fetcher.exists?(@path, 3)
       end
     end
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -449,14 +449,14 @@ SHELL
 
   def warn_stack_upgrade
     return unless defined?(@ruby_download_check)
-    return unless @ruby_download_check.next_stack(stack)
-    return unless @ruby_download_check.exists_on_next_stack?(stack)
+    return unless @ruby_download_check.next_stack(current_stack: stack)
+    return unless @ruby_download_check.exists_on_next_stack?(current_stack: stack)
 
     warn(<<~WARNING)
       Your Ruby version is not present on the next stack
 
       You are currently using #{ruby_version.version_for_download} on #{stack} stack.
-      This version does not exist on #{@ruby_download_check.next_stack(stack)}. In order to upgrade your stack you will
+      This version does not exist on #{@ruby_download_check.next_stack(current_stack: stack)}. In order to upgrade your stack you will
       need to upgrade to a supported Ruby version.
 
       For a list of supported Ruby versions see:

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v208"
+    BUILDPACK_VERSION = "v209"
   end
 end

--- a/spec/helpers/download_presence_spec.rb
+++ b/spec/helpers/download_presence_spec.rb
@@ -9,13 +9,27 @@ describe LanguagePack::Helpers::DownloadPresence do
 
     download.call
 
-    expect(download.next_stack("cedar-14")).to eq("heroku-16")
-    expect(download.next_stack("heroku-16")).to eq("heroku-18")
-    expect(download.next_stack("heroku-18")).to be_falsey
+    expect(download.next_stack(current_stack: "cedar-14")).to eq("heroku-16")
+    expect(download.next_stack(current_stack: "heroku-16")).to eq("heroku-18")
+    expect(download.next_stack(current_stack: "heroku-18")).to be_falsey
 
-    expect(download.exists_on_next_stack?("cedar-14")).to be_truthy
+    expect(download.exists_on_next_stack?(current_stack:"cedar-14")).to be_truthy
   end
 
+  it "detects when a package is present on higher stacks" do
+    download = LanguagePack::Helpers::DownloadPresence.new(
+      'ruby-2.6.5.tgz',
+      stacks: ['cedar-14', 'heroku-16', 'heroku-18']
+    )
+
+    download.call
+
+    expect(download.exists?).to eq(true)
+    expect(download.valid_stack_list).to eq(['cedar-14', 'heroku-16', 'heroku-18'])
+
+    expect(download.exists_on_next_stack?(current_stack: "heroku-16")).to be_truthy
+    expect(download.next_stack(current_stack: "heroku-16")).to eq("heroku-18")
+  end
 
   it "detects when a package is not present on higher stacks" do
     download = LanguagePack::Helpers::DownloadPresence.new(


### PR DESCRIPTION
Users are mistakenly getting this warning when building apps:

```
       Your Ruby version is not present on the next stack
       You are currently using ruby-2.6.5 on heroku-16 stack.
       This version does not exist on heroku-18. In order to upgrade your stack you will
       need to upgrade to a supported Ruby version.
       For a list of supported Ruby versions see:
         https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
       For a list of the oldest Ruby versions present on a given stack see:
         https://devcenter.heroku.com/articles/ruby-support#oldest-available-runtimes
```

I believe this is a result of network glitches. We should be cautious about warning about issues that don't actually exist.