### PR TITLE
Fix version download warning logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Master (unreleased)
 
+
+## v210 (3/6/2020)
+
+* Fix version download error warning inversion logic (https://github.com/heroku/heroku-buildpack-ruby/pull/958)
+
 ## v209 (3/5/2020)
 
 * Fix bug in version download error message logic (https://github.com/heroku/heroku-buildpack-ruby/pull/957)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -450,7 +450,7 @@ SHELL
   def warn_stack_upgrade
     return unless defined?(@ruby_download_check)
     return unless @ruby_download_check.next_stack(current_stack: stack)
-    return unless @ruby_download_check.exists_on_next_stack?(current_stack: stack)
+    return if @ruby_download_check.exists_on_next_stack?(current_stack: stack)
 
     warn(<<~WARNING)
       Your Ruby version is not present on the next stack

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v209"
+    BUILDPACK_VERSION = "v210"
   end
 end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -100,6 +100,7 @@ describe "Ruby apps" do
         Hatchet::Runner.new("default_ruby").deploy do |app, heroku|
           expect(app.output).to     include("Writing config/database.yml to read from DATABASE_URL")
           expect(app.output).not_to include("Your app was upgraded to bundler")
+          expect(app.output).not_to include("Your Ruby version is not present on the next stack")
         end
       end
     end


### PR DESCRIPTION
The logic was inverted so that versions that exist get a warning but not versions that do not exist.