### PR TITLE
Remove libpq vendoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master (unreleased)
 
+* Remove libpq external dependency (https://github.com/heroku/heroku-buildpack-ruby/pull/959)
 
 ## v210 (3/6/2020)
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -99,7 +99,6 @@ WARNING
       setup_export
       setup_profiled
       allow_git do
-        vendor_libpq
         install_bundler_in_app
         build_bundler("development:test")
         post_bundler
@@ -116,55 +115,6 @@ WARNING
   rescue => e
     warn_outdated_ruby
     raise e
-  end
-
-  def vendor_libpq
-    # Check for existing libraries
-    return unless File.exist?("/usr/lib/x86_64-linux-gnu/libpq.so.5.11")
-    return unless ENV['STACK'] == 'heroku-18'
-
-    topic("Vendoring libpq 5.12.1")
-
-    @metadata.fetch("vendor_libpq12") do
-      warn(<<~EOF)
-        Replacing libpq with version libpq 5.12.1
-
-        This version includes a bug fix that can cause an exception
-        on boot for applications with incorrectly configured connection
-        values. For more information see:
-
-          https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
-
-        If your application breaks you can rollback to your last build.
-        You can also temporarially opt out of this behavior by setting:
-
-        ```
-        $ heroku config:set HEROKU_SKIP_LIBPQ12=1
-        ```
-
-        In the future libpq 5.12 will be the default on the platform and
-        you will not be able to opt-out of the library. For more information see:
-
-          https://devcenter.heroku.com/articles/libpq-5-12-1-breaking-connection-behavior
-      EOF
-
-      "true" # Set future cache value
-    end
-
-    Dir.chdir("vendor") do
-      @fetchers[:mri].fetch("libpq5_12.1-1.deb")
-      run!("dpkg -x libpq5_12.1-1.deb .")
-      run!("rm libpq5_12.1-1.deb")
-
-      load_libpq_12_unless_env_var = <<~EOF
-        if [ "$HEROKU_SKIP_LIBPQ12" == "" ]; then
-          export LD_LIBRARY_PATH="$HOME/vendor/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
-        fi
-      EOF
-      add_to_export load_libpq_12_unless_env_var
-      add_to_profiled load_libpq_12_unless_env_var
-      ENV["LD_LIBRARY_PATH"] = Dir.pwd + "/usr/lib/x86_64-linux-gnu:#{ENV["LD_LIBRARY_PATH"]}"
-    end
   end
 
   def cleanup


### PR DESCRIPTION
As an effort to slow roll out libpq client it was vendored into the dyno. This PR removes this vendoring to use the version available on the stack.