### PR TITLE
CI fails with with different bundler execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master (unreleased)
 
+* Fix issue where the wrong version of bundler is used on CI apps (https://github.com/heroku/heroku-buildpack-ruby/pull/961)
 * Remove libpq external dependency (https://github.com/heroku/heroku-buildpack-ruby/pull/959)
 
 ## v210 (3/6/2020)

--- a/bin/support/ruby_test
+++ b/bin/support/ruby_test
@@ -30,19 +30,20 @@ def execute_command(command)
 end
 
 # $ bin/test BUILD_DIR ENV_DIR ARTIFACT_DIR
-build_dir, env_dir, artifact_dir = ARGV
+build_dir, env_dir, _ = ARGV
 LanguagePack::ShellHelpers.initialize_env(env_dir)
+
+bundler = LanguagePack::Helpers::BundlerWrapper.new(
+  gemfile_path: "#{build_dir}/Gemfile"
+)
 
 # The `ruby_test-compile` program installs a version of Ruby for the
 # user's application. It needs the propper `PATH`, where ever Ruby is installed
 # we always add a symlink to the `bin/ruby` file so that is always valid.
 # We calculate the gem path the same way we do when compiling.
-LanguagePack::ShellHelpers.user_env_hash["PATH"] = "#{build_dir}/bin:#{ENV["PATH"]}"
+LanguagePack::ShellHelpers.user_env_hash["PATH"] = "#{build_dir}/bin:#{bundler.bundler_path}/bin:#{ENV["PATH"]}"
 LanguagePack::ShellHelpers.user_env_hash["GEM_PATH"] = LanguagePack::Ruby.slug_vendor_base
 
-bundler = LanguagePack::Helpers::BundlerWrapper.new(
-  gemfile_path: "#{build_dir}/Gemfile"
-)
 # load bundler
 bundler.install
 

--- a/hatchet.json
+++ b/hatchet.json
@@ -99,6 +99,7 @@
     "sharpstone/rails_31_ruby_schema_format",
     "sharpstone/rails_31_sql_schema_format",
     "sharpstone/ruby_no_rails_test",
-    "sharpstone/activerecord_rake_tasks_does_not_exist"
+    "sharpstone/activerecord_rake_tasks_does_not_exist",
+    "sharpstone/ci_fails_ruby_default_bundler"
   ]
 }

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -15,6 +15,8 @@
   - 116db685f54dae18f703b3beb90e64fdbddb048d
 - - "./repos/ci/activerecord_rake_tasks_does_not_exist"
   - a6b711be6921cf7a0aa4e31269c37965799ea110
+- - "./repos/ci/ci_fails_ruby_default_bundler"
+  - 43cbf196245957be6242b1e1bc56b8f1bfa00004
 - - "./repos/ci/heroku-ci-json-example"
   - 4e5410a7381f486ba3df7739e02e52f32fdd4dda
 - - "./repos/ci/rails5_ruby_schema_format"

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -38,4 +38,10 @@ describe "CI" do
       expect(test_run.output).to_not match("db:migrate")
     end
   end
+
+  it "works when using a Ruby version different from default with an older version of bundler and not declaring a test script" do
+    Hatchet::Runner.new("ci_fails_ruby_default_bundler").run_ci do |test_run|
+      expect(test_run.output).to match("rspec")
+    end
+  end
 end


### PR DESCRIPTION
I'm not 100% sure why this failure mode happens, but it looks like for some reason even though the path is set correctly bundler incorrectly uses the wrong path to load the wrong version of Ruby (the buildpack Ruby version instead of the Ruby version the customer's app wants/needs).


This is what the failure mode looks like:

```
# test setup
-----> Fetching heroku/ruby buildpack...
       buildpack downloaded
-----> Ruby app detected
-----> Installing bundler 2.0.2
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Setting up Test for Ruby/Rack
-----> Using Ruby version: ruby-2.7.0
-----> Installing dependencies using bundler 2.0.2
```

```
# test actual

-----> Running Ruby buildpack tests...
-----> Installing bundler 1.17.3
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Running test: bundle exec rspec
bundler: failed to load command: rspec (/app/vendor/bundle/bin/rspec)
Bundler::RubyVersionMismatch: Your Ruby version is 2.6.5, but your Gemfile specified 2.7.0
```

From inside of a `bin/support/test_ruby` modified run:

```
$ which bundle 25c5b6e6816adee359c4f0f966b663a7f8649b0729509d510091abc07/vendor/ruby/heroku-16/bin//bundle
$ bundle -v Bundler version 2.0.2
```

It appears that the `test/support/test_ruby` script is invoking bundler and in these cases the system `bundle` is being invoked instead of the customer's bundler version. This then causes the wrong version of Ruby to be loaded, presumably due to some coupling in the default Bundler ruby gem.

Internal tickets:

- https://heroku.support/834258
- https://heroku.support/834446