### PR TITLE
[changelog skip] Fix `\n` in export path

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -1099,7 +1099,7 @@ params = CGI.parse(uri.query || "")
     return @node_preinstall_bin_path if defined?(@node_preinstall_bin_path)
 
     legacy_path = "#{Dir.pwd}/#{NODE_BP_PATH}"
-    path        = run("which node")
+    path        = run("which node").chomp
     if path && $?.success?
       @node_preinstall_bin_path = path
     elsif run("#{legacy_path}/node -v") && $?.success?
@@ -1117,7 +1117,7 @@ params = CGI.parse(uri.query || "")
   def yarn_preinstall_bin_path
     return @yarn_preinstall_bin_path if defined?(@yarn_preinstall_bin_path)
 
-    path = run("which yarn")
+    path = run("which yarn").chomp
     if path && $?.success?
       @yarn_preinstall_bin_path = path
     else

--- a/spec/hatchet/node_spec.rb
+++ b/spec/hatchet/node_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 
 describe "Node" do
   it "works with node buildpack" do
-    Hatchet::Runner.new("node_multi", buildpack_url: "https://github.com/heroku/heroku-buildpack-multi.git").deploy do |app|
+    before_deploy = Proc.new do
+      run!("rm .buildpacks")
+      run!("echo https://github.com/heroku/heroku-buildpack-nodejs.git >> .buildpacks")
+      run!("echo #{Hatchet::App.default_buildpack} >> .buildpacks")
+    end
+
+    Hatchet::Runner.new(
+      "node_multi",
+      before_deploy: before_deploy,
+      buildpack_url: "https://github.com/heroku/heroku-buildpack-multi.git"
+    ).deploy do |app|
       expect(app.output).to match("Node Version in Ruby buildpack is: v4.1.2")
       expect(app.run("node -v")).to match("v4.1.2")
     end


### PR DESCRIPTION
The command `which` returns a newline which was being put in the PATH and then exported to the export file:

```
which node: "/tmp/build_d21ec1d0a2e7e9466b95cd2f7f79b41a/.heroku/node/bin/node\n"
```

Would cause this to be in the PATH:

```
remote: export PATH=/tmp/build_449e75fdca9780bfa7f33fac3b86065e/./vendor/bundle/bin:/tmp/build_449e75fdca9780bfa7f33fac3b86065e/./vendor/bundle/ruby/2.6.0/bin:/tmp/build_449e75fdca9780bfa7f33fac3b86065e/vendor/ruby-2.6.2/bin:/tmp/tmp.ly4bnGG8nm/bin/:/tmp/build_449e75fdca9780bfa7f33fac3b86065e/.heroku/node/bin:/tmp/build_449e75fdca9780bfa7f33fac3b86065e/.heroku/yarn/bin:/usr/local/bin:/usr/bin:/bin:/tmp/codon/vendor/bin:/tmp/build_449e75fdca9780bfa7f33fac3b86065e/node_modules/.bin:/tmp/build_449e75fdca9780bfa7f33fac3b86065e/.heroku/node/bin/node
remote: :/tmp/build_449e75fdca9780bfa7f33fac3b86065e/bin:/usr/local/bin:/usr/bin:/bin:$PATH
```

This causes the multi buildpack to fail https://github.com/heroku/heroku-buildpack-ruby/issues/963, but only the multi buildpack. Error is:

```
remote: /tmp/buildpackYYwZE/export: line 2: :/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/bin:/usr/local/bin:/usr/bin:/bin:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/./vendor/bundle/bin:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/./vendor/bundle/ruby/2.6.0/bin:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/vendor/ruby-2.6.5/bin:/tmp/tmp.behzAImwsj/bin/:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/.heroku/node/bin:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/.heroku/yarn/bin:/usr/local/bin:/usr/bin:/bin:/tmp/codon/vendor/bin:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/node_modules/.bin:/tmp/build_71238ae8789a5e65c5afca4e8abc6c3a/.heroku/node/bin/node: No such file or directory
```

Even though this is the bug, it has been in the ruby buildpack for some time. Something in #888 introduced a failure mode.

Since multi-buildpack is deprecated and unmaintained I don't want to add an automated test here. You can manually reproduce the failure by running:

```
cd /tmp
dir_name=$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
mkdir $dir_name
cd $dir_name
echo "source 'https://rubygems.org'" > Gemfile
bundle install
git init .
git add .
git commit -m first
echo '{ "engines" : { "node": "8.9.4" } }' > package.json
heroku create
heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
echo "https://github.com/heroku/heroku-buildpack-nodejs.git" >> .buildpacks
echo "https://github.com/heroku/heroku-buildpack-ruby" >> .buildpacks
git add . ; git commit -m next
git push heroku master
```

You can get it to pass by running

```
rm .buildpacks
echo "https://github.com/heroku/heroku-buildpack-nodejs.git" >> .buildpacks
echo "https://github.com/heroku/heroku-buildpack-ruby#schneems/fix-node-which" >> .buildpacks
```

Which points the app at this PR.