### PR TITLE
Fix absolute path bug in .profile.d/ruby.sh $PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master (unreleased)
 
+## v213 (4/1/2020)
+
+* Fix regression. PATH value at runtime was relative instead of absolute (https://github.com/heroku/heroku-buildpack-ruby/pull/973)
+
 ## v212 (3/26/2020)
 
 * Cloud Native Buildpack support (https://github.com/heroku/heroku-buildpack-ruby/pull/888)

--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
       "buildpacks": [
         { "url": "https://github.com/heroku/heroku-buildpack-apt" },
         { "url": "https://github.com/heroku/heroku-buildpack-cli.git" },
-        { "url": "heroku/ruby" }
+        { "url": "https://github.com/heroku/heroku-buildpack-ruby#v211" }
       ]
     }
   }

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -429,13 +429,14 @@ SHELL
   # sets up the profile.d script for this buildpack
   def setup_profiled(ruby_layer_path = "$HOME", gem_layer_path = "$HOME")
     instrument 'setup_profiled' do
-      profiled_path = binstubs_relative_paths(gem_layer_path)
+      profiled_path = ["$HOME/bin"]
+      profiled_path << binstubs_relative_paths(gem_layer_path)
       profiled_path << "vendor/#{@yarn_installer.binary_path}" if has_yarn_binary?
       profiled_path << "$PATH"
 
       set_env_default  "LANG",     "en_US.UTF-8"
       set_env_override "GEM_PATH", "#{gem_layer_path}/#{slug_vendor_base}:$GEM_PATH"
-      set_env_override "PATH",      profiled_path.join(":")
+      set_env_override "PATH",      profiled_path.uniq.join(":")
 
       set_env_default "MALLOC_ARENA_MAX", "2"     if default_malloc_arena_max?
       add_to_profiled set_default_web_concurrency if env("SENSIBLE_DEFAULTS")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -211,7 +211,7 @@ WARNING
     # need to remove bin/ folder since it links
     # to the wrong --prefix ruby binstubs
     # breaking require. This only applies to Ruby 1.9.2 and 1.8.7.
-    safe_binstubs = binstubs_relative_paths(gem_layer_path) - ["bin"]
+    safe_binstubs = binstubs_relative_paths(gem_layer_path) - ["bin", "#{gem_layer_path}/bin"]
     paths         = [
       ENV["PATH"],
       "bin",
@@ -225,7 +225,7 @@ WARNING
 
   def binstubs_relative_paths(gem_layer_path = ".")
     [
-      "bin",
+      "#{gem_layer_path}/bin",
       "#{gem_layer_path}/#{bundler_binstubs_path}",
       "#{gem_layer_path}/#{slug_vendor_base}/bin"
     ]

--- a/spec/cnb/basic_local_pack_spec.rb
+++ b/spec/cnb/basic_local_pack_spec.rb
@@ -1,21 +1,61 @@
 require_relative '../spec_helper'
 
-describe "cnb" do
-  it "locally" do
-    run!("which pack")
 
-    repo_path = hatchet_path("heroku/ruby-getting-started")
-    image_name = "heroku-buildpack-ruby-tests:#{SecureRandom.hex}"
+class CnbRun
+  attr_accessor :image_name, :output, :repo_path, :buildpack_path, :builder
 
-    build_out = run!("pack build #{image_name} --path #{repo_path} --buildpack #{buildpack_path} --builder heroku/buildpacks:18")
-    expect(build_out).to match("Compiling Ruby/Rails")
+  def initialize(repo_path, builder: "heroku/buildpacks:18", buildpack_path: )
+    @repo_path = repo_path
+    @image_name = "heroku-buildpack-ruby-tests:#{SecureRandom.hex}"
+    @builder = builder
+    @buildpack_path = buildpack_path
+    @build_output = ""
+  end
 
-    run_out = run!("docker run #{image_name} 'ruby -v'").chomp
-    expect(run_out).to match("2.4.4")
+  def call
+    command = "pack build #{image_name} --path #{repo_path} --buildpack #{buildpack_path} --builder heroku/buildpacks:18"
+    @output = `#{command}`
+    raise "Command #{command.inspect} failed. Output: #{out}" unless $?.success?
+    yield self
   ensure
-    if image_name
-      docker_list = run("docker images | grep #{image_name}").chomp
-      run!("docker rmi #{image_name}") if !docker_list.empty?
+    teardown
+  end
+
+  def teardown
+    return unless image_name
+
+    docker_list = run("docker images | grep #{image_name}").chomp
+    run!("docker rmi #{image_name}") if !docker_list.empty?
+    @image_name = nil
+  end
+
+  def run(cmd)
+    `docker run #{image_name} '#{cmd}'`.chomp
+  end
+
+  def run!(cmd)
+    out = run(cmd)
+    raise "Command #{cmd.inspect} failed. Output: #{out}" unless $?.success?
+    out
+  end
+end
+
+describe "cnb" do
+  it "locally runs default_ruby app" do
+    CnbRun.new(hatchet_path("rack/default_ruby"), buildpack_path: buildpack_path).call do |app|
+      expect(app.output).to match("Compiling Ruby/Rack")
+
+      run_out = app.run!("ruby -v")
+      expect(run_out).to match(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+    end
+  end
+
+  it "locally runs rails getting started" do
+    CnbRun.new(hatchet_path("heroku/ruby-getting-started"), buildpack_path: buildpack_path).call do |app|
+      expect(app.output).to match("Compiling Ruby/Rails")
+
+      run_out = app.run!("ruby -v")
+      expect(run_out).to match("2.4.4")
     end
   end
 end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -32,6 +32,8 @@ describe "Ruby apps" do
     it "works" do
       Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK).deploy do |app|
         expect(app.output).to match("cd version ruby 2.5.1")
+
+        expect(app.run("which ruby").chomp).to eq("/app/bin/ruby")
       end
     end
   end


### PR DESCRIPTION
In #888 a relative path was accidentally introduced into the `.profile.d/ruby.sh` script:

```
export PATH="bin:$HOME/vendor/bundle/bin:$HOME/vendor/bundle/ruby/2.6.0/bin:$PATH"
```

That first path `bin` is relative and should be `$HOME/bin`.

Without an absolute path, changing into a different directory means that the system version of ruby will be used

```
~ $ which ruby
bin/ruby
~ $ mkdir foo; cd foo; which ruby
/usr/bin/ruby
```

> Note different results from 

This is a regression  was not caught by tests previously because the version of ruby that the test `cd_ruby` uses is 2.5.1 and that happens to match system ruby. To fix for catching future regressions the test is now more explicit.

Unfortunately there's a bug in hatchet preventing that specific test https://github.com/heroku/hatchet/issues/71 so instead I'm at least asserting that it's an absolute path.