### PR TITLE
Fix CI Test runs not using bundler cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master (unreleased)
 
+## v215 (4/9/2020)
+
+* Fix bundler cache not being used in CI builds (https://github.com/heroku/heroku-buildpack-ruby/pull/978)
+
 ## v214 (4/2/2020)
 
 * Default Ruby version is now 2.6.6 (https://github.com/heroku/heroku-buildpack-ruby/pull/974)

--- a/lib/language_pack/test/ruby.rb
+++ b/lib/language_pack/test/ruby.rb
@@ -12,6 +12,7 @@ class LanguagePack::Ruby
       setup_profiled
       allow_git do
         install_bundler_in_app(slug_vendor_base)
+        load_bundler_cache
         build_bundler(bundle_path: "vendor/bundle", default_bundle_without: "development")
         post_bundler
         create_database_yml

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -33,6 +33,19 @@ describe "CI" do
     end
   end
 
+  it "Uses the cache" do
+    runner = Hatchet::Runner.new("ruby_no_rails_test")
+    runner.run_ci do |test_run|
+      expect(test_run.output).to match("Fetching rake")
+
+      test_run.instance_variable_set(:"@status", false)
+      test_run.create_test_run
+      test_run.wait! {  }
+
+      expect(test_run.output).to_not match("Fetching rake")
+    end
+  end
+
   it "Works with a rails app that does not have activerecord" do
     Hatchet::Runner.new("activerecord_rake_tasks_does_not_exist").run_ci do |test_run|
       expect(test_run.output).to_not match("db:migrate")


### PR DESCRIPTION
When testing the same code in the same pipeline the cache should be used so gems do not have to be re-installed. This same test passes using an older version of the buildpack:

```
$ HATCHET_BUILDPACK_BRANCH="v211" rspec spec/hatchet/ci_spec.rb:39
```