### PR TITLE
[changelog skip] Clean up paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ group :development, :test do
   gem "netrc"
   gem "git", github: "hone/ruby-git", branch: "master"
   gem 'json', '~> 2.0.2'
-  gem 'ci-queue', github: 'shopify/ci-queue', branch: 'rspec-log-order'
+  gem 'ci-queue'
   gem 'redis'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,6 @@ GIT
   specs:
     git (1.2.6)
 
-GIT
-  remote: https://github.com/shopify/ci-queue.git
-  revision: 0713fe26a8b0be6290ad109a651b7cf5b242930a
-  branch: rspec-log-order
-  specs:
-    ci-queue (0.16.0)
-      ansi
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -23,6 +15,8 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
     ansi (1.5.0)
+    ci-queue (0.17.2)
+      ansi
     citrus (3.0.2)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
@@ -50,29 +44,29 @@ GEM
     moneta (1.0.0)
     multi_json (1.14.1)
     netrc (0.11.0)
-    parallel (1.17.0)
-    parallel_tests (2.29.1)
+    parallel (1.19.1)
+    parallel_tests (2.32.0)
       parallel
     platform-api (2.2.0)
       heroics (~> 0.0.25)
       moneta (~> 1.0.0)
-    rake (12.3.2)
-    redis (4.1.2)
+    rake (13.0.1)
+    redis (4.1.3)
     repl_runner (0.0.3)
       activesupport
     rrrretry (1.0.0)
-    rspec-core (3.8.2)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.4)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-retry (0.6.1)
+      rspec-support (~> 3.9.0)
+    rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.8.2)
+    rspec-support (3.9.2)
     thor (0.20.3)
     thread_safe (0.3.6)
     threaded (0.0.4)
-    toml-rb (1.1.2)
+    toml-rb (2.0.1)
       citrus (~> 3.0, > 3.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -82,7 +76,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ci-queue!
+  ci-queue
   excon
   git!
   heroku_hatchet

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -4,7 +4,7 @@ describe "Buildpack internals" do
   it "handles PATH with a newline in it correctly" do
     buildpacks = [
       "https://github.com/sharpstone/export_path_with_newlines_buildpack",
-      Hatchet::App.default_buildpack,
+      :default,
       "https://github.com/heroku/null-buildpack"
     ]
     Hatchet::Runner.new("default_ruby", buildpacks: buildpacks).deploy do |app|

--- a/spec/hatchet/jvm_spec.rb
+++ b/spec/hatchet/jvm_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper'
 
 describe "JvmInstaller" do
   it "JVM is installed by jvm-common only" do
-    buildpacks = ["heroku/jvm",
-                  Hatchet::App.default_buildpack] # default is heroku-ruby-buildpack here
+    buildpacks = [
+      "heroku/jvm",
+      :default # default is heroku-ruby-buildpack here
+
+    ]
     app = Hatchet::Runner.new("ruby_193_jruby_1_7_27", stack: 'heroku-18', buildpacks: buildpacks)
     app.setup!
 

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -66,7 +66,11 @@ end
 
 describe "Rails 5.1" do
   it "works with webpacker + yarn (js friends)" do
-    Hatchet::Runner.new("rails51_webpacker").deploy do |app, heroku|
+    buildpacks = [
+      Hatchet::App.default_buildpack,
+      "https://github.com/sharpstone/force_absolute_paths_buildpack"
+    ]
+    Hatchet::Runner.new("rails51_webpacker", buildpacks: buildpacks).deploy do |app, heroku|
       expect(app.output).to include("Installing yarn")
       expect(app.output).to include("yarn install")
 

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -42,7 +42,7 @@ describe "Rails 5" do
         "active_storage_local",
         buildpacks: [
           "https://github.com/heroku/heroku-buildpack-activestorage-preview",
-          Hatchet::App.default_buildpack
+          :default
         ]
       )
       app.setup!
@@ -67,7 +67,7 @@ end
 describe "Rails 5.1" do
   it "works with webpacker + yarn (js friends)" do
     buildpacks = [
-      Hatchet::App.default_buildpack,
+      :default,
       "https://github.com/sharpstone/force_absolute_paths_buildpack"
     ]
     Hatchet::Runner.new("rails51_webpacker", buildpacks: buildpacks).deploy do |app, heroku|

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -12,7 +12,7 @@ describe "Ruby apps" do
   describe "running Ruby from outside the default dir" do
     it "works" do
       buildpacks = [
-        Hatchet::App.default_buildpack,
+        :default,
         "https://github.com/sharpstone/force_absolute_paths_buildpack"
       ]
       Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks).deploy do |app|

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -11,7 +11,11 @@ describe "Ruby apps" do
 
   describe "running Ruby from outside the default dir" do
     it "works" do
-      Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK).deploy do |app|
+      buildpacks = [
+        Hatchet::App.default_buildpack,
+        "https://github.com/sharpstone/force_absolute_paths_buildpack"
+      ]
+      Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks).deploy do |app|
         expect(app.output).to match("cd version ruby 2.5.1")
 
         expect(app.run("which ruby").chomp).to eq("/app/bin/ruby")


### PR DESCRIPTION
During the CNB work it was uncovered that there were some behaviors of absolute paths in the `export` file and the profile.d script that were not tested. In looking at these issues some of the code wasn't clear. This is a pure refactor intended to clarify intent.