### PR TITLE
Gracefully handle unrecognised stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master (unreleased)
 
+* Gracefully handle unrecognised stacks ([#982](https://github.com/heroku/heroku-buildpack-ruby/pull/982))
+
 ## v215 (4/9/2020)
 
 * Fix bundler cache not being used in CI builds (https://github.com/heroku/heroku-buildpack-ruby/pull/978)

--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -28,13 +28,20 @@ class LanguagePack::Helpers::DownloadPresence
     end
   end
 
-  def next_stack(current_stack: )
-    next_index = @stacks.index(current_stack) + 1
+  def supported_stack?(current_stack: )
+    @stacks.include?(current_stack)
+  end
 
+  def next_stack(current_stack: )
+    return unless supported_stack?(current_stack: current_stack)
+
+    next_index = @stacks.index(current_stack) + 1
     @stacks[next_index]
   end
 
   def exists_on_next_stack?(current_stack: )
+    return false unless supported_stack?(current_stack: current_stack)
+
     next_index = @stacks.index(current_stack) + 1
     @threads[next_index]
   end

--- a/spec/helpers/download_presence_spec.rb
+++ b/spec/helpers/download_presence_spec.rb
@@ -77,4 +77,16 @@ describe LanguagePack::Helpers::DownloadPresence do
     expect(download.exists?).to eq(true)
     expect(download.valid_stack_list).to include(LanguagePack::Helpers::DownloadPresence::STACKS.last)
   end
+
+  it "handles the current stack not being in the known stacks list" do
+    download = LanguagePack::Helpers::DownloadPresence.new(
+      "#{LanguagePack::RubyVersion::DEFAULT_VERSION}.tgz",
+    )
+
+    download.call
+    
+    expect(download.supported_stack?(current_stack: "unknown-stack")).to be_falsey
+    expect(download.next_stack(current_stack: "unknown-stack")).to be_nil
+    expect(download.exists_on_next_stack?(current_stack:"unknown-stack")).to be_falsey
+  end
 end


### PR DESCRIPTION
Previously if the current stack was not in the download presence check's list of known stacks, the compile would fail with:

```
lib/language_pack/helpers/download_presence.rb:32:in `next_stack': undefined method `+' for nil:NilClass (NoMethodError)
	from /app/tmp/buildpacks/.../lib/language_pack/ruby.rb:469:in `warn_stack_upgrade'
	from /app/tmp/buildpacks/.../lib/language_pack/ruby.rb:462:in `warn_outdated_ruby'
	from /app/tmp/buildpacks/.../lib/language_pack/ruby.rb:115:in `block in compile'
```

Refs [W-7457565](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007QfR8IAK/view).