### PR TITLE
Vendor Heroku-20 binaries in the published buildpack [changelog skip]

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,6 +25,9 @@ ruby_version = "2.6.6"
   [[publish.Vendor]]
   url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.6.6.tgz"
   dir = "vendor/ruby/heroku-18"
+  [[publish.Vendor]]
+  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.6.6.tgz"
+  dir = "vendor/ruby/heroku-20"
 
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
For parity with the existing stacks.

Skipping changelog since the stack is only available internally at present.

Refs [W-7457565](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007QfR8IAK/view).