### PR TITLE
Reverting the changes to binstubs_relative_paths introduced in Refactoring #980

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -224,7 +224,8 @@ WARNING
   def binstubs_relative_paths(gem_layer_path = ".")
     [
       "#{gem_layer_path}/#{bundler_binstubs_path}", # Binstubs from bundler, eg. vendor/bundle/bin
-      "#{gem_layer_path}/#{slug_vendor_base}/bin"   # Binstubs from rubygems, eg. vendor/bundle/ruby/2.6.0/bin
+      "#{gem_layer_path}/#{slug_vendor_base}/bin",  # Binstubs from rubygems, eg. vendor/bundle/ruby/2.6.0/bin
+      "#{gem_layer_path}/bin"
     ]
   end
 


### PR DESCRIPTION
@schneems 
 
I am facing a buildpack failure on our app because we are using heroku-buildpack-ruby with an additional buildpack which fails after the introduction of the refactoring in #980. 

My understanding is that #980 is a pure refactoring and therefore this path shouldn't be removed there([code path](https://github.com/heroku/heroku-buildpack-ruby/pull/980/files#diff-3fc66e13e389ff4d15c7ca3ddb86464eL228)). Also, I have verified on my end that this change fixes our build issue.       

Thanks