### PR TITLE
[changelog skip] Fix regression caused in #980

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -358,12 +358,15 @@ SHELL
         ENV[key] ||= value
       end
 
+      paths = []
       gem_path = "#{gem_layer_path}/#{slug_vendor_base}"
       ENV["GEM_PATH"] = gem_path
       ENV["GEM_HOME"] = gem_path
 
-      paths = []
-      paths << "#{File.expand_path(".")}/bin" unless ruby_version.ruby_192_or_lower? # For Ruby 1.9.2 and lower there is a "build" and non-"build" Ruby
+      # Need to remove `./bin` folder since it links to the wrong --prefix ruby binstubs breaking require in Ruby 1.9.2 and 1.8.7.
+      # Because for 1.9.2 and 1.8.7 there is a "build" ruby and a non-"build" Ruby
+      paths << "#{File.expand_path(".")}/bin" unless ruby_version.ruby_192_or_lower?
+
       paths << "#{gem_layer_path}/#{bundler_binstubs_path}" # Binstubs from bundler, eg. vendor/bundle/bin
       paths << "#{gem_layer_path}/#{slug_vendor_base}/bin"  # Binstubs from rubygems, eg. vendor/bundle/ruby/2.6.0/bin
       paths << "#{slug_vendor_jvm}/bin" if ruby_version.jruby?

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -135,7 +135,6 @@ WARNING
 
     gem_layer = Layer.new(@layer_dir, "gems", launch: true, cache: true)
     setup_language_pack_environment(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
-    setup_export(gem_layer)
     setup_profiled(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
     allow_git do
       # TODO install bundler in separate layer
@@ -159,6 +158,7 @@ WARNING
       install_binaries
       run_assets_precompile_rake_task
     end
+    setup_export(gem_layer)
     config_detect
     best_practice_warnings
     cleanup
@@ -363,7 +363,7 @@ SHELL
       ENV["GEM_HOME"] = gem_path
 
       paths = []
-      paths << "#{ruby_layer_path}/bin" unless ruby_version.ruby_192_or_lower? # For Ruby 1.9.2 and lower there is a "build" and non-"build" Ruby
+      paths << "#{File.expand_path(".")}/bin" unless ruby_version.ruby_192_or_lower? # For Ruby 1.9.2 and lower there is a "build" and non-"build" Ruby
       paths << "#{gem_layer_path}/#{bundler_binstubs_path}" # Binstubs from bundler, eg. vendor/bundle/bin
       paths << "#{gem_layer_path}/#{slug_vendor_base}/bin"  # Binstubs from rubygems, eg. vendor/bundle/ruby/2.6.0/bin
       paths << "#{slug_vendor_jvm}/bin" if ruby_version.jruby?

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -38,6 +38,10 @@ module LanguagePack
       @version_without_patchlevel = @version.sub(/-p-?\d+/, '')
     end
 
+    def ruby_192_or_lower?
+      Gem::Version.new(self.ruby_version) <= Gem::Version.new("1.9.2")
+    end
+
     # https://github.com/bundler/bundler/issues/4621
     def version_for_download
       if rbx?

--- a/lib/language_pack/test/rails2.rb
+++ b/lib/language_pack/test/rails2.rb
@@ -1,7 +1,7 @@
 #module LanguagePack::Test::Rails2
 class LanguagePack::Rails2
   # sets up the profile.d script for this buildpack
-  def setup_profiled
+  def setup_profiled(ruby_layer_path: , gem_layer_path: )
     super
     set_env_default "RACK_ENV",  "test"
     set_env_default "RAILS_ENV", "test"

--- a/lib/language_pack/test/ruby.rb
+++ b/lib/language_pack/test/ruby.rb
@@ -7,9 +7,9 @@ class LanguagePack::Ruby
       remove_vendor_bundle
       install_ruby(slug_vendor_ruby, build_ruby_path)
       install_jvm
-      setup_language_pack_environment
+      setup_language_pack_environment(ruby_layer_path: File.expand_path("."), gem_layer_path: File.expand_path("."))
       setup_export
-      setup_profiled
+      setup_profiled(ruby_layer_path: "$HOME", gem_layer_path: "$HOME") # $HOME is set to /app at run time
       allow_git do
         install_bundler_in_app(slug_vendor_base)
         load_bundler_cache


### PR DESCRIPTION
In #980 this value was being added to the export file:

```
/tmp/<build_path>/$HOME/bin
```

> Where <build_path> is a random value for every run.

In codon $HOME is set to `/app` instead of `/tmp/<build_path>` so this will be expanded to:

```
/tmp/<build_path>//home/bin
```

Which does not exist.

This PR expands $HOME in the export file to be the full build path manually.


## Reproduction

To reproduce this failure, you can point an app at master current commit:

```
$ heroku buildpacks

1. https://github.com/heroku/heroku-buildpack-ruby#479faabc67d38bf8f1e7f55dd22b512ee78e3294
2. https://github.com/schneems/buildpack-ruby-rake-deploy-tasks#schneems/debug
```

```
$ heroku config  | grep DEPLOY
DEPLOY_TASKS:             db:migrate
```

```
$ cat Gemfile.lock | grep railties
      railties (>= 3.2, < 6.1)
      railties (>= 4.2.0)
      railties (>= 4.2.0)
      railties (>= 3.2)
      railties (>= 3.1)
      railties (= 5.2.4.2)
    railties (5.2.4.2)
      railties (>= 5.0)
      railties (>= 4.2)
      railties (>= 5.2.0)
      railties (>= 4.0.0)
      railties (>= 4.0.0)
```

This results in a failure when deploying:

```
remote: -----> Rake app detected
remote: PATH:
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/./vendor/bundle/bin:/tmp/build_a711fa6dc6a465c901c1be9eacfd193a/./vendor/bundle/ruby/2.5.0/bin:/tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/ruby-2.5.8/bin:/tmp/tmp.bajvtvlsrP/bin/:/usr/local/bin:/usr/bin:/bin:/tmp/codon/vendor/bin:/tmp/build_a711fa6dc6a465c901c1be9eacfd193a//app/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/bin:/usr/bin:/bin:/tmp/codon/vendor/bin
remote: rake aborted!
remote: ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/execjs-2.7.0/lib/execjs/runtimes.rb:58:in `autodetect'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/execjs-2.7.0/lib/execjs.rb:5:in `<module:ExecJS>'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/execjs-2.7.0/lib/execjs.rb:4:in `<top (required)>'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:291:in `block in require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:257:in `load_dependency'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:291:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/uglifier-4.2.0/lib/uglifier.rb:5:in `<top (required)>'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:76:in `each'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:76:in `block in require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:65:in `each'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:65:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/bundler-2.0.2/lib/bundler.rb:114:in `require'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/config/application.rb:7:in `<top (required)>'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/Rakefile:4:in `require_relative'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/Rakefile:4:in `<top (required)>'
remote: /tmp/build_a711fa6dc6a465c901c1be9eacfd193a/vendor/bundle/ruby/2.5.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
remote: (See full trace by running task with --trace)
remote:  !     Push rejected, failed to compile Rake app.
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !	Push rejected to morning-sea-36366.
remote:
To https://git.heroku.com/morning-sea-36366.git
```

Note the bad path in the debug output:

```
/tmp/build_a711fa6dc6a465c901c1be9eacfd193a//app/bin
```



## Related

- https://github.com/heroku/heroku-buildpack-ruby/pull/987
- Internal Support ticket: https://heroku.support/856187
