### PR TITLE
[changelog skip] Amend run-on sentence

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -519,7 +519,7 @@ SHELL
 
       #{@outdated_version_check.suggested_ruby_minor_version}
 
-      The latest version will include security and bug fixes, we always recommend
+      The latest version will include security and bug fixes. We always recommend
       running the latest version of your minor release.
 
       Please upgrade your Ruby version.


### PR DESCRIPTION
This is a very minor change [requested of a customer](https://heroku.support/865586). I've amended the run on sentence to be two sentences instead so it reads a little easier.

The changelog check fails but I'm unsure if this change requires a new changelog item.