### PR TITLE
Allow Nolockfile to get to compile phase

### DIFF
--- a/lib/language_pack/no_lockfile.rb
+++ b/lib/language_pack/no_lockfile.rb
@@ -1,7 +1,7 @@
 require "language_pack"
-require "language_pack/base"
+require "language_pack/ruby"
 
-class LanguagePack::NoLockfile < LanguagePack::Base
+class LanguagePack::NoLockfile < LanguagePack::Ruby
   def self.use?
     !File.exists?("Gemfile.lock")
   end


### PR DESCRIPTION
Nolockfile does not define a number of things that base needs in terms of subclass overrides. By simply changing the parent class, we get reasonable versions of those things and allow the build to get as far as compile, so that the error can be emitted.

The error output without this change looks like:

```
[builder] -----> Compiling Ruby/NoLockfile
[builder]
[builder]  !
[builder]  !     must subclass
[builder]  !
[builder] /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/base.rb:65:in `default_addons': must subclass (RuntimeError)
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/base.rb:124:in `build_release'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/base.rb:132:in `write_release_toml'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/base.rb:103:in `build'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/bin/support/ruby_build:26:in `block (2 levels) in <main>'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/base.rb:190:in `log'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/bin/support/ruby_build:25:in `block in <main>'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/instrument.rb:35:in `block in trace'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/instrument.rb:18:in `block (2 levels) in instrument'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/instrument.rb:40:in `yield_with_block_depth'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/instrument.rb:17:in `block in instrument'
[builder]       from /tmp/tmp.dL7R7BOXyl/lib/ruby/2.6.0/benchmark.rb:308:in `realtime'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/instrument.rb:16:in `instrument'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/lib/language_pack/instrument.rb:35:in `trace'
[builder]       from /cnb/buildpacks/heroku_ruby/0.0.1/bin/support/ruby_build:21:in `<main>'
```