### PR TITLE
[close #1001][changelog skip] Put Yarn first on the path

### DIFF
--- a/hatchet.json
+++ b/hatchet.json
@@ -86,11 +86,8 @@
   "heroku": [
     "heroku/ruby-getting-started"
   ],
-  "multibuildpack": [
-    "sharpstone/node_multi"
-  ],
   "node": [
-    "sharpstone/webpacker_no_execjs"
+    "sharpstone/minimal_webpacker"
   ],
   "ci": [
     "sharpstone/rails5_ruby_schema_format",

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -33,10 +33,8 @@
   - 9ddca7b694875499165eb56adffd3e29b38405c5
 - - "./repos/jruby/jruby_naether"
   - 4a11f8af5a3cca21f3659394e5bbac3cca9b6a2c
-- - "./repos/multibuildpack/node_multi"
-  - c8f822a0cdd3b7ed92f19bd1112bd9e301bc4a5e
-- - "./repos/node/webpacker_no_execjs"
-  - 26792540c924699c69e4c79019b65bc9192586ea
+- - "./repos/node/minimal_webpacker"
+  - bca8b8169c553a0f62f0263b621cf3a5813e4023
 - - "./repos/rack/default_ruby"
   - da748a59340be8b950e7bbbfb32077eb67d70c3c
 - - "./repos/rack/mri_187_nokogiri"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -333,10 +333,10 @@ EOF
     instrument 'ruby.setup_language_pack_environment' do
       if ruby_version.jruby?
         ENV["PATH"] += ":bin"
-        ENV["JAVA_MEM"] = run(<<-SHELL).chomp
-#{set_jvm_max_heap}
-echo #{default_java_mem}
-SHELL
+        ENV["JAVA_MEM"] = run(<<~SHELL).chomp
+          #{set_jvm_max_heap}
+          echo #{default_java_mem}
+        SHELL
         ENV["JRUBY_OPTS"] = env('JRUBY_BUILD_OPTS') || env('JRUBY_OPTS')
         ENV["JAVA_HOME"] = @jvm_installer.java_home
       end

--- a/spec/hatchet/node_spec.rb
+++ b/spec/hatchet/node_spec.rb
@@ -1,30 +1,39 @@
 require 'spec_helper'
 
-describe "Node" do
-  it "works with node buildpack" do
-    Hatchet::Runner.new("node_multi", buildpacks: ["heroku/nodejs", :default]).deploy do |app|
-      expect(app.output).to match("Node Version in Ruby buildpack is: v4.1.2")
-      expect(app.run("node -v")).to match("v4.1.2")
+describe "Node and Yarn" do
+  it "works without the node buildpack" do
+    buildpacks = [
+      :default,
+      "https://github.com/sharpstone/force_absolute_paths_buildpack"
+    ]
+    Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks).deploy do |app, heroku|
+      # https://rubular.com/r/4bkL8fYFTQwt0Q
+      expect(app.output).to match(/vendor\/yarn-v\d+\.\d+\.\d+\/bin\/yarn is the yarn directory/)
+      expect(app.output).to_not include(".heroku/yarn/bin/yarn is the yarn directory")
+
+      expect(app.output).to include("bin/node is the node directory")
+      expect(app.output).to_not include(".heroku/node/bin/node is the node directory")
+
+      expect(app.run("which node")).to match("/app/bin/node")     # We put node in bin/node
+      expect(app.run("which yarn")).to match("/app/vendor/yarn-") # We put yarn in /app/vendor/yarn-
     end
   end
 
-  it "node is installed by default without multi buildpack" do
-    default_node_version = LanguagePack::Helpers::NodeInstaller.new.version
-    Hatchet::Runner.new("node_multi").deploy do |app|
-      expect(app.output).to match("Node Version in Ruby buildpack is: v#{default_node_version}")
-      expect(app.run("node -v")).to match(default_node_version)
-    end
-  end
+  it "works with the node buildpack" do
+    buildpacks = [
+      "heroku/nodejs",
+      :default,
+      "https://github.com/sharpstone/force_absolute_paths_buildpack"
+    ]
 
-  it "doesn't install node without execjs or webpacker" do
-    Hatchet::Runner.new("default_ruby").deploy do |app|
-      expect(app.run("node -v")).to match("node: command not found")
-    end
-  end
+    Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks).deploy do |app, heroku|
+      expect(app.output).to include("yarn install")
+      expect(app.output).to include(".heroku/yarn/bin/yarn is the yarn directory")
+      expect(app.output).to include(".heroku/node/bin/node is the node directory")
 
-  it "installs node when webpacker is detected but no execjs" do
-    Hatchet::Runner.new("webpacker_no_execjs").deploy do |app|
-      expect(app.output).to match("Installing node-v")
+      expect(app.run("which node")).to match("/app/.heroku/node/bin")
+      expect(app.run("which yarn")).to match("/app/.heroku/yarn/bin")
     end
   end
 end
+

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -64,18 +64,27 @@ describe "Rails 5" do
   end
 end
 
-describe "Rails 5.1" do
-  it "works with webpacker + yarn (js friends)" do
-    buildpacks = [
-      :default,
-      "https://github.com/sharpstone/force_absolute_paths_buildpack"
-    ]
-    Hatchet::Runner.new("rails51_webpacker", buildpacks: buildpacks).deploy do |app, heroku|
-      expect(app.output).to include("Installing yarn")
-      expect(app.output).to include("yarn install")
+describe "Rails 5.1 with webpacker" do
+  it "calls bin/yarn no matter what is on the path" do
+    Hatchet::Runner.new("rails51_webpacker").tap do |app|
+      # We put our version of yarn first on the path ahead of bin/yarn
+      # however webpacker explicitly calls bin/yarn instead of calling
+      # `yarn install`
+      app.before_deploy do
+        File.open("bin/yarn", "w") do |f|
+          f.write <<~EOM
+          #! /usr/bin/env bash
 
-      expect(app.run("which -a node")).to match("/app/bin/node")
-      expect(app.run("which -a yarn")).to match("/app/vendor/yarn-")
+          echo "Called bin/yarn binstub"
+          `yarn install`
+          EOM
+        end
+        run("chmod +x bin/yarn")
+      end
+
+      app.deploy do
+        expect(app.output).to include("Called bin/yarn binstub")
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again
 
   config.expect_with :rspec do |c|
+    c.max_formatted_output_length = Float::INFINITY
     c.syntax = :expect
   end
   config.mock_with :nothing


### PR DESCRIPTION
The binstub that Rails generates has a bug in it that prevents calling `yarn install` from any directory other than the app root. We were accidentally handling this when we install yarn (without the nodejs buildpack) since we prepend the yarn path https://github.com/heroku/heroku-buildpack-ruby/blob/af368418f2aef9f455afd7f0b77b3137aa8d38a5/lib/language_pack/ruby.rb#L696. However if the app is using the `heroku/nodejs` then the `bin/yarn` binstub will appear first in the buildpack after the changes in https://github.com/heroku/heroku-buildpack-ruby/commit/8413eecb42ce8a99b47194ab9d237093175b915f.

To fix this, we are manually putting yarn first on the path at runtime and build time.

While this is a fix to a regression on master, it has never been released. This fix preserves existing behavior with the deployed buildpack. (In which the `bin/yarn` binstub is not being used).