### PR TITLE
Switch to using /usr/bin/env bash

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The actual compilation code lives in `bin/support/ruby_compile`. This file instead
 # bootstraps the ruby needed and then executes `bin/support/ruby_compile`
 

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The actual `bin/test-compile` code lives in `bin/ruby_test-compile`. This file instead
 # bootstraps the ruby needed and then executes `bin/ruby_test-compile`
 

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The actual `bin/test-compile` code lives in `bin/ruby_test-compile`. This file instead
 # bootstraps the ruby needed and then executes `bin/ruby_test-compile`
 

--- a/support/s3/hmac
+++ b/support/s3/hmac
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Implement HMAC functionality on top of the OpenSSL digest functions.
 # licensed under the terms of the GNU GPL v2
 # Copyright 2007 Victor Lowther <victor.lowther@gmail.com>

--- a/support/s3/s3
+++ b/support/s3/s3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # basic amazon s3 operations
 # Licensed under the terms of the GNU GPL v2
 # Copyright 2007 Victor Lowther <victor.lowther@gmail.com>


### PR DESCRIPTION
The main motiviation for switching the shebang is so that I can use
https://github.com/edmorley/heroku-buildpack-timestamps

But it's generally a good idea to have shebang lines that make scripts
portable, even if it is only going to run on heroku