### PR TITLE
[changelog skip][close #977] Recommend recent Ruby in warning

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -565,12 +565,18 @@ EOF
 
       topic "Using Ruby version: #{ruby_version.version_for_download}"
       if !ruby_version.set
-        warn(<<-WARNING)
-You have not declared a Ruby version in your Gemfile.
-To set your Ruby version add this line to your Gemfile:
-#{ruby_version.to_gemfile}
-# See https://devcenter.heroku.com/articles/ruby-versions for more information.
-WARNING
+        warn(<<~WARNING)
+          You have not declared a Ruby version in your Gemfile.
+
+          To declare a Ruby version add this line to your Gemfile:
+
+          ```
+          ruby "#{LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER}"
+          ```
+
+          For more information see:
+            https://devcenter.heroku.com/articles/ruby-versions
+        WARNING
       end
     end
 


### PR DESCRIPTION
Previously when we gave people a warning that they were not setting their Ruby version we recommended that they set that version in their Gemfile. Since our default ruby versions are "sticky" it was common that we were recommending very old ruby versions:

```
###### WARNING:

       You have not declared a Ruby version in your Gemfile.
       To set your Ruby version add this line to your Gemfile:
       ruby '2.4.1'
```

Instead of recommending their current version (Which is also available via the deploy output elsewhere) we are recommending the current default version. So in the previous case where the user was using 2.4.1, our recommended Gemfile in the warning would be `2.6.6`.