### PR TITLE
use correct lock file (not default one)

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -208,9 +208,9 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def bundler_version_escape_valve!
-    topic("Removing BUNDLED WITH version in the Gemfile.lock")
-    contents = File.read("Gemfile.lock")
-    File.open("Gemfile.lock", "w") do |f|
+    topic("Removing BUNDLED WITH version in the #{@gemfile_lock_path}")
+    contents = File.read(@gemfile_lock_path)
+    File.open(@gemfile_lock_path, "w") do |f|
       f.write contents.sub(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m, '')
     end
   end


### PR DESCRIPTION
`bundler_version_escape_valve!` was moved in this commit https://github.com/heroku/heroku-buildpack-ruby/commit/4b3bfc6fe1659e9e7b0a00f29d3f0341a73ff029
and still uses the default lockfile
