### PR TITLE
[changelog skip] Failing test for #1005

### DIFF
--- a/hatchet.lock
+++ b/hatchet.lock
@@ -36,7 +36,7 @@
 - - "./repos/node/minimal_webpacker"
   - bca8b8169c553a0f62f0263b621cf3a5813e4023
 - - "./repos/rack/default_ruby"
-  - da748a59340be8b950e7bbbfb32077eb67d70c3c
+  - master
 - - "./repos/rack/mri_187_nokogiri"
   - 3fcce9c85bf560dba285cc385ae9845729195826
 - - "./repos/rack/mri_192"

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -9,7 +9,7 @@ describe "Stack Changes" do
 
       app.push!
 
-      expect(app.output).to match("Installing rack 1.5.0")
+      expect(app.output).to match("Installing rack")
       expect(app.output).to match("Changing stack")
     end
   end
@@ -22,7 +22,7 @@ describe "Stack Changes" do
 
       app.push!
       puts app.output
-      expect(app.output).to match("Using rack 1.5.0")
+      expect(app.output).to match("Using rack")
     end
   end
 end


### PR DESCRIPTION
The files in `bin/` such as `bin/rake` are come from the compiled binaries. For some versions of Ruby they start with a binstub that looks like this:

```
$ cd ~/Downloads/ruby-2.3.8
$ ls bin
erb	gem	irb	rake	rdoc	ri	ruby
$ cat bin/rake | head -n 1
#!/app/vendor/ruby-2.3.8/bin/ruby
```

This does not work at build due to the path `/app` not being where the app is.

This test fails because `bin/rake` has a bad shebang line when `rake assets:precompile` is run it will give an error:

```
       +remote: -----> Detecting rake tasks
       +remote:        Could not detect rake tasks
       +remote:        ensure you can run `$ bundle exec rake -P` against your app
       +remote:        and using the production group of your Gemfile.
       +remote:        bash: /tmp/build_d8662c03cfa0321567ab12e0a1e6f4f3/bin/rake: /app/vendor/ruby-2.4.9/bin/ruby: bad interpreter: No such file or directory
```