### PR TITLE
[close #1027][changelog skip] Fix frozen string error

### DIFF
--- a/lib/language_pack/helpers/binstub_wrapper.rb
+++ b/lib/language_pack/helpers/binstub_wrapper.rb
@@ -43,7 +43,7 @@ class LanguagePack::Helpers::BinstubWrapper < SimpleDelegator
     @shebang ||= begin
       @binstub.open(&:readline)
     rescue EOFError
-      ""
+      String.new("")
     end
   end
 

--- a/spec/helpers/binstub_check_spec.rb
+++ b/spec/helpers/binstub_check_spec.rb
@@ -15,6 +15,16 @@ describe LanguagePack::Helpers::BinstubCheck do
     return ruby_bin_dir
   end
 
+  it "handles empty binstubs" do
+    Tempfile.create("foo.txt") do |f|
+      expect { Pathname.new(f).open(&:readline) }.to raise_error(EOFError)
+
+      binstub = LanguagePack::Helpers::BinstubWrapper.new(f.path)
+      expect(binstub.bad_shebang?).to be_falsey
+      expect(binstub.binary?).to be_falsey
+    end
+  end
+
   it "can determine if a file is binary or not" do
     binstub = LanguagePack::Helpers::BinstubWrapper.new(get_ruby_path!)
 


### PR DESCRIPTION
Since the `binstub_wrapper` is using the magic frozen comment any string literals will be immutable. The `force_encoding` method apparently mutates the string so this raises an error. 

By always returning a mutable string we can avoid this situation.