### PR TITLE
Document v217 release in master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * The spring library is now disabled by setting the enviornment variable DISABLE_SPRING=1 (https://github.com/heroku/heroku-buildpack-ruby/pull/1017)
 * Warn when a bad "shebang" line in a binstub is detected (https://github.com/heroku/heroku-buildpack-ruby/pull/1014)
 * Default node version now 12.16.2, yarn is 1.22.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/986)
+
+ ## v217 (7/2/2020)
+
 * Gracefully handle unrecognised stacks ([#982](https://github.com/heroku/heroku-buildpack-ruby/pull/982))
 
 ## v216 (rolled back)

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v216"
+    BUILDPACK_VERSION = "v217"
   end
 end


### PR DESCRIPTION
I've done something a bit funny with this release. The default branch is very far ahead of what was released in v215. There's some bugs preventing a release, but a release of stack support is blocking other work.

There's two ways to release that work:

- Revert everything on default branch back to v215 and then re-apply the patches we need for stack support, cut a release from master, then un-revert everything that was reverted.
  - Pros: The release will come from a point in time in the default branch.
  - Cons there's a lot of hoops to jump through. Mistakes might get made, it is messy.


- Keep default branch separate from the code released in v217. All commits to the v217 branch are cherry-picked from master/main, the only difference is we're re-writing history to not have the rest of the features.
  - Pros: The default branch commits stay clean, there's no reverting and then un-reverting
  - Cons: The release v217 is being made from a branch which might be confusing in the future.

The PR https://github.com/heroku/heroku-buildpack-ruby/pull/1029 along with this one uses the second option. By releasing off of a branch and updating the documentation on master with another commit.