### PR TITLE
CNB: make the gems layer accessible to subsequent buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The spring library is now disabled by setting the enviornment variable DISABLE_SPRING=1 (https://github.com/heroku/heroku-buildpack-ruby/pull/1017)
 * Warn when a bad "shebang" line in a binstub is detected (https://github.com/heroku/heroku-buildpack-ruby/pull/1014)
 * Default node version now 12.16.2, yarn is 1.22.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/986)
+* CNB: Fix the `gems` layer not being made accessible by subsequent buildpacks (https://github.com/heroku/heroku-buildpack-ruby/pull/1033)
 
  ## v217 (7/2/2020)
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -136,7 +136,7 @@ WARNING
     ruby_layer.metadata[:engine_version] = ruby_version.engine_version
     ruby_layer.write
 
-    gem_layer = Layer.new(@layer_dir, "gems", launch: true, cache: true)
+    gem_layer = Layer.new(@layer_dir, "gems", launch: true, cache: true, build: true)
     setup_language_pack_environment(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
     setup_profiled(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
     allow_git do


### PR DESCRIPTION
The `gems` layer writes a couple of environment variables to `#{layer.path}/env.build` ([ref 1](https://github.com/heroku/heroku-buildpack-ruby/blob/125191fdf57bf80f0cebf1f2d6009f77be6ae99a/lib/language_pack/ruby.rb#L164), [ref 2](https://github.com/heroku/heroku-buildpack-ruby/blob/be6cd5fe8327cc2686f11d07e73e2b489ba0347d/lib/language_pack/base.rb#L249)) but because [the `build` option](https://github.com/buildpacks/spec/blob/main/buildpack.md#build-layers) is not set on the layer, these environment variables are not made accessible to subsequent buildpacks.

This sets `build: true` on the `gems` layer to correct that.