### PR TITLE
[close #934] Skip rake task if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master (unreleased)
 
+* Rake task "assets:clean" will not get called if it does not exist (https://github.com/heroku/heroku-buildpack-ruby/pull/1018)
+
 ## v218 (7/13/2020)
 
 * The rake binstub generated from compiling Ruby will no longer be placed in the local `bin/rake` location (https://github.com/heroku/heroku-buildpack-ruby/pull/1031)

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -82,7 +82,7 @@ WARNING
         end
 
         precompile = rake.task("assets:precompile")
-        return true unless precompile.is_defined?
+        return true if precompile.not_defined?
 
         topic("Preparing app for Rails asset pipeline")
 
@@ -95,12 +95,15 @@ WARNING
           log "assets_precompile", :status => "success"
           puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
 
-          puts "Cleaning assets"
-          rake.task("assets:clean").invoke(env: rake_env)
+          clean_task = rake.task("assets:clean")
+          if clean_task.task_defined?
+            puts "Cleaning assets"
+            clean_task.invoke(env: rake_env)
 
-          cleanup_assets_cache
-          @cache.store public_assets_folder
-          @cache.store default_assets_cache
+            cleanup_assets_cache
+            @cache.store public_assets_folder
+            @cache.store default_assets_cache
+          end
         else
           precompile_fail(precompile.output)
         end

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -84,6 +84,9 @@ describe "Rails 5.1 with webpacker" do
 
       app.deploy do
         expect(app.output).to include("Called bin/yarn binstub")
+
+        expect(app.output).to match("rake assets:precompile")
+        expect(app.output).to match("rake assets:clean")
       end
     end
   end

--- a/spec/hatchet/rails6_spec.rb
+++ b/spec/hatchet/rails6_spec.rb
@@ -11,10 +11,18 @@ describe "Rails 6" do
   it "deploys and serves web requests via puma" do
     before_deploy = Proc.new do
       run! "echo 'web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}' > Procfile"
+
+      # Test Clean task does not get called if it does not exist
+      # This file will only have the `assets:precompile` task in it, but not `assets:clean`
+      run! %Q{echo 'task "assets:precompile" do ; end' > Rakefile}
     end
 
     Hatchet::Runner.new('rails6-basic', before_deploy: before_deploy).deploy do |app|
       expect(app.output).to match("Fetching railties 6")
+
+      expect(app.output).to match("rake assets:precompile")
+      expect(app.output).to_not match("rake assets:clean")
+
       expect(web_boot_status(app)).to_not eq("crashed")
     end
   end


### PR DESCRIPTION
If the `assets:clean` task does not exist, don't call it.