### PR TITLE
[changelog skip] Promote tag to release and vendor CNB

### DIFF
--- a/.github/workflows/release_cnb.yml
+++ b/.github/workflows/release_cnb.yml
@@ -1,0 +1,55 @@
+name: Release CNB
+
+on: [push] # Could use to push tags
+
+jobs:
+  build:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1.40.0
+        with:
+          ruby-version: 2.6.6
+      - uses: actions/checkout@v2
+      - name: bundle install
+        run: bundle install --jobs 4 --retry 3
+      - name: build tar file
+        run: bundle exec rake buildpack:tarball
+      - uses: actions/upload-artifact@v2
+        with:
+          name: buildpack.tgz
+          path: buildpacks/*
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Get Version'
+        run: |
+          [[ $GITHUB_REF =~ ^refs\/tags\/(.*)$ ]] && version=${BASH_REMATCH[1]}
+          echo "::set-env name=VERSION::$version"
+      - name: 'Download list binary'
+        uses: actions/download-artifact@v2
+        with:
+          name: buildpack.tgz
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: heroku-buildpack-ruby-${{ env.VERSION }}.tgz
+          asset_name: heroku-buildpack-ruby-${{ env.VERSION }}.tgz
+          asset_content_type: application/gzip

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ require "tmpdir"
 require 'hatchet/tasks'
 ENV["BUILDPACK_LOG_FILE"] ||= "tmp/buildpack.log"
 
+require_relative 'lib/rake/deploy_check'
 require_relative 'lib/rake/tarballer'
 
 S3_BUCKET_NAME  = "heroku-buildpack-ruby"
@@ -64,7 +65,25 @@ def install_gem(gem_name, version)
 end
 
 namespace :buildpack do
+  desc "releases the next version of the buildpack"
+  task :release do
+    deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+    puts "Attempting to deploy #{deploy.next_version}, overwrite with RELEASE_VERSION env var"
+    deploy.check!
 
+    if deploy.push_tag?
+      sh("git tag -f ", deploy.next_version) do |out, status|
+        raise "Could not `git tag -f #{deploy.version}`: #{out}" unless status.success?
+      end
+      sh("git push --tags") do |out, status|
+        raise "Could not `git push --tags`: #{out}" unless status.success?
+      end
+    end
+
+    command = "heroku buildpacks:publish heroku/ruby #{deploy.next_version}"
+    puts "Releasing to heroku: `#{command}`"
+    exec(command)
+  end
   desc "stage a tarball of the buildpack, this runs on github actions to deploy CNB"
   task :tarball do
     tarballer = Tarballer.new(name: "heroku-buildpack-ruby", directory: __dir__)

--- a/lib/rake/deploy_check.rb
+++ b/lib/rake/deploy_check.rb
@@ -1,0 +1,131 @@
+# A class for checking if a local copy of a repo can be tagged for a deploy
+#
+# Example:
+#
+#   deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+#   deploy.check! # Checks that current main branch matches what's on github
+#
+# It also can pull tag versions and determine the next sequential version automatically:
+#
+#   deploy.next_version # => "v999" # Assuming the last version was v998
+#
+# It can determine status of tags
+#
+#   deploy.push_tags? #=> false
+#
+class DeployCheck
+  attr_reader :github_url
+
+  def initialize(github: , next_version: ENV["RELEASE_VERSION"])
+    @github = github
+    @github_url = "https://github.com/#{github}"
+    @next_version = next_version
+    @remote_tag_array = nil
+  end
+
+  def check!
+    check_version!
+    check_unstaged!
+    check_branch!
+    check_changelog!
+    check_sync!
+  end
+
+  def push_tag?
+    return true if !tag_exists_on_remote?
+    return false if remote_tag_matches?
+
+    # Tag exists, but is not the same commit, raise an error
+    raise <<~EOM
+      The tag you're pushing (#{next_version}) to #{@github} already exists and does not have the same SHA.
+      You must resolve this manually.
+    EOM
+  end
+
+  # Returns tuthy value if the remote contains the next version already
+  def tag_exists_on_remote?
+    remote_tag_array.include?(next_version)
+  end
+
+  # Returns a truthy value if the remote tag SHA matches the current local sha
+  def remote_tag_matches?(remote_sha: remote_commit_sha(next_version), local_sha: local_commit)
+    remote_sha == local_sha
+  end
+
+  # Raises an error if there are unstaged modifications
+  def check_unstaged!
+    run!("git diff --quiet HEAD") do
+      raise "Must have all changes committed. There are unstaged commits locally"
+    end
+  end
+
+  # Raises an error if not on the designated branch
+  def check_branch!(name = "main")
+    out = run("git rev-parse --abbrev-ref HEAD")
+    raise "Must be on main branch. Branch: #{out}" unless out == name
+  end
+
+  # Raises an error if the changelog does not have an entry with the designated version
+  def check_changelog!
+    if !File.read("CHANGELOG.md").include?("## #{next_version}")
+      raise "Expected CHANGELOG.md to include #{next_version} but it did not"
+    end
+  end
+
+  # Raises an error if the local sha does not match the remote sha
+  def check_sync!(local_sha: local_commit_sha, remote_sha: remote_commit_sha)
+    return if remote_sha == local_sha
+
+    raise <<~EOM
+      Must be in-sync with #{@github}. Local comit: #{local_sha.inspect} #{@github}: #{remote_sha.inspect}
+      "Make sure that you've pulled: `git pull --rebase #{@github_url} main`
+    EOM
+  end
+
+  def check_version!
+    version = next_version
+
+    raise "Must look like a version: #{version}. Must start with `v` and include only digits" unless version.match?(/^v\d+$/)
+  end
+
+  def local_commit_sha
+    run!("git rev-parse HEAD")
+  end
+
+  def remote_commit_sha(branch_or_tag = "main")
+    run!("git ls-remote #{@github_url} #{branch_or_tag}").split("\t").first
+  end
+
+  def run(cmd)
+    `#{cmd}`.strip
+  end
+
+  def next_version
+    @next_version || "v#{next_version_number}"
+  end
+
+  def remote_tag_array
+    @remote_tag_array ||= begin
+      cmd = String.new("")
+      cmd << "git ls-remote --tags #{@github_url}"
+      cmd << "| awk '{print $2}' | cut -d '/' -f 3 | cut -d '^' -f 1"
+      run!(cmd).each_line.map(&:strip).select {|line| line.strip.match?(/^v\d+$/) } # https://rubular.com/r/8eFB9r8nOVrM7H
+    end
+  end
+
+  private def next_version_number
+   integer_tag_array = remote_tag_array.map {|line| line.sub(/^v/, '').to_i }.sort # Ascending order
+   integer_tag_array.last.next
+  end
+
+  def run!(cmd)
+    out = run(cmd)
+    return out if $?.success?
+
+    if block_given?
+      yield out, $?
+    else
+      raise "Command #{cmd} expected to return successfully did not: #{out}"
+    end
+  end
+end

--- a/lib/rake/tarballer.rb
+++ b/lib/rake/tarballer.rb
@@ -1,0 +1,52 @@
+require 'fileutils'
+require 'pathname'
+
+$:.unshift File.join(__dir__, "..") # put lib on the path
+require "language_pack/installers/heroku_ruby_installer"
+require "language_pack/ruby_version"
+require "language_pack/version"
+
+# This class takes a target directory (such as the buildpack)
+# and tars it up so it's in a form ready to be run
+#
+# In addition to TAR logic it also vendors ruby versions so
+# they don't need to be pulled at runtime
+class Tarballer
+  STACKS = %W{cedar-14 heroku-16 heroku-18}
+
+  def initialize(name: , directory: , io: STDOUT)
+    @name = name
+    @source_directory = Pathname.new(directory)
+    @version = LanguagePack::Base::BUILDPACK_VERSION
+    @dest_directory = @source_directory.join("buildpacks")
+    @dest_directory.mkpath
+    @io = io
+  end
+
+  def call(stacks: STACKS)
+    Dir.mktmpdir do |tmpdir_base|
+      tmp_dir = Pathname.new(tmpdir_base).join(@name)
+      run! "cp -r #{@source_directory} #{tmp_dir}"
+
+      Dir.chdir(tmp_dir) do |buildpack_dir|
+        stacks.each do |stack|
+          installer    = LanguagePack::Installers::HerokuRubyInstaller.new(stack)
+          ruby_version = LanguagePack::RubyVersion.new("ruby-#{LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER}")
+          installer.fetch_unpack(ruby_version, "vendor/ruby/#{stack}")
+        end
+        run! "tar czf #{tmp_dir.join('.buildpack.tgz')} *"
+      end
+
+      tar_destination = @dest_directory.join("heroku-buildpack-ruby-#{@version}.tgz")
+      @io.puts "Writing to #{tar_destination}"
+
+      FileUtils.cp(tmp_dir.join('.buildpack.tgz'), tar_destination)
+    end
+  end
+
+  private def run!(cmd)
+    out = `#{cmd}`
+    raise "Command: #{cmd} was expected to succeed but it did not. Output: #{out}" unless $?.success?
+    out
+  end
+end

--- a/spec/rake/deploy_check_spec.rb
+++ b/spec/rake/deploy_check_spec.rb
@@ -1,0 +1,141 @@
+require "spec_helper"
+require "rake/deploy_check"
+
+describe "A helper class for deploying" do
+  describe "tests that hit github" do
+    it "know remote tags" do
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+      expect(deploy.remote_tag_array.class).to eq(Array)
+      expect(deploy.remote_tag_array).to include("v218")
+    end
+
+    it "remote sha" do
+      deploy = DeployCheck.new(github: "sharpstone/do_not_delete_or_modify")
+      expect(deploy.remote_commit_sha).to eq("3a9ff6433a05560acfd06dda03a11605a96ae133")
+    end
+
+    it "local_commit_sha" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          run!("git clone https://github.com/sharpstone/default_ruby #{dir} 2>&1 && cd #{dir} && git checkout 6e642963acec0ff64af51bd6fba8db3c4176ed6e 2>&1 && git checkout -b mybranch 2>&1")
+          deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+          expect(deploy.local_commit_sha).to eq("6e642963acec0ff64af51bd6fba8db3c4176ed6e")
+        end
+      end
+    end
+  end
+
+  describe "tests that do NOT hit github" do
+    it "checks multiple things" do
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+      deploy.instance_variable_set("@methods_called", [])
+
+      def deploy.check_version!; @methods_called << :check_version! ;end
+      def deploy.check_unstaged!; @methods_called << :check_unstaged! ;end
+      def deploy.check_branch!; @methods_called << :check_branch! ;end
+      def deploy.check_changelog!; @methods_called << :check_changelog! ;end
+      def deploy.check_sync!; @methods_called << :check_sync! ;end
+
+      deploy.check!
+
+      methods_called = deploy.instance_variable_get("@methods_called")
+      expect(methods_called).to include(:check_version!)
+      expect(methods_called).to include(:check_unstaged!)
+      expect(methods_called).to include(:check_branch!)
+      expect(methods_called).to include(:check_changelog!)
+      expect(methods_called).to include(:check_sync!)
+    end
+
+    it "checks version" do
+      ["v123abc", "123", "V123"].each do |bad_version|
+        deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby", next_version: bad_version)
+        expect {
+          deploy.check_version!
+        }.to raise_error(/Must look like a version/)
+      end
+    end
+
+    it "checks local sha and remote sha match" do
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+      expect {
+        deploy.check_sync!(local_sha: "a", remote_sha: "not a")
+      }.to raise_error(/Must be in-sync/)
+
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+      deploy.check_sync!(
+        local_sha: "cbe100933b1e50953f0da35aafc50374ae2a31f9",
+        remote_sha: "cbe100933b1e50953f0da35aafc50374ae2a31f9"
+      )
+    end
+
+    it "github url" do
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+      expect(deploy.github_url).to eq("https://github.com/heroku/heroku-buildpack-ruby")
+    end
+
+    it "knows the next version" do
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby", next_version: "v123")
+
+      def deploy.remote_tag_array; [ "v123" ] ; end
+
+      expect(deploy.tag_exists_on_remote?).to be_truthy
+
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby", next_version: "v124")
+
+      def deploy.remote_tag_array; [ "v123" ] ; end
+
+      expect(deploy.tag_exists_on_remote?).to be_falsey
+    end
+
+    it "checks remote tags for existance" do
+      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+
+      def deploy.remote_tag_array; [ "v123" ] ; end
+
+      expect(deploy.next_version).to eq("v124")
+    end
+
+    it "checks unstaged" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+          run!("echo 'blerg' >> foo.txt")
+          run!("git init .; git add . ; git commit -m first")
+          deploy.check_unstaged!
+
+          run!("echo 'foo' >> foo.txt")
+          expect { deploy.check_unstaged! }.to raise_error(/Must have all changes committed/)
+        end
+      end
+    end
+
+    it "checks branch" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+          run!("echo 'blerg' >> foo.txt")
+          run!("git init .; git add . ; git commit -m first")
+          run!("git checkout -B main")
+          deploy.check_branch!
+
+          expect { deploy.check_branch!("not_main") }.to raise_error(/Must be on main branch/)
+        end
+      end
+    end
+
+    it "checks CHANGELOG" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby", next_version: "v999")
+          run!("touch CHANGELOG.md")
+          expect {
+            deploy.check_changelog!
+          }.to raise_error(/Expected CHANGELOG.md to include v999/)
+
+          run!("echo '## v999' >> CHANGELOG.md")
+          deploy.check_changelog!
+        end
+      end
+    end
+  end
+end

--- a/spec/rake/tarballer_spec.rb
+++ b/spec/rake/tarballer_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require "rake/tarballer"
+
+def real_entries(dir)
+  Dir.entries(dir) - [".", ".."]
+end
+
+describe "tarballer" do
+  it "blerg" do
+    Dir.mktmpdir do |dir|
+      dir = Pathname.new(dir)
+      run!("echo 'foo' >> #{dir}/foo.txt")
+      run!("mkdir -p #{dir}/vendor/ruby")
+
+      tarballer = Tarballer.new(name: 'heroku-buildpack-ruby', directory: dir, io: StringIO.new)
+      tarballer.call(stacks: ["heroku-18"])
+
+      # Test tar generated
+      tgz_name = "heroku-buildpack-ruby-#{LanguagePack::Base::BUILDPACK_VERSION}.tgz"
+      buildpacks_dir = real_entries("#{dir}/buildpacks")
+      expect(buildpacks_dir).to include(tgz_name)
+
+      # Test tar contents
+      tgz_file = dir.join("buildpacks", tgz_name)
+      tar_contents = run!("tar -tvf #{tgz_file}").strip
+      expect(tar_contents).to include("vendor/ruby/heroku-18/bin/gem")
+      expect(tar_contents).to include("foo.txt")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec/core'
 require 'hatchet'
 require 'fileutils'
+require 'stringio'
 require 'hatchet'
 require 'rspec/retry'
 require 'language_pack'


### PR DESCRIPTION
When a tag is created, this action will build a vendored version of the Ruby buildpack for CNB, create a release from the tag, and then attach the tarball of the buildpack to the release.

To cut a new release run:

```
$ git tag v219 && git push --tags
```

This pr also re-adds a top level interface for deploying changes that are on master:

```
$ bundle exec rake buildpack:release
```