### PR TITLE
Revert "[close #943] Use Bundler env vars for config (#1039)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Main (unreleased)
 
-* Persistent bundler config is now being set using the `BUNDLE_*` env vars (https://github.com/heroku/heroku-buildpack-ruby/pull/1039)
 * Rake task "assets:clean" will not get called if it does not exist (https://github.com/heroku/heroku-buildpack-ruby/pull/1018)
 * CNB: Fix the `gems` layer not being made accessible by subsequent buildpacks (https://github.com/heroku/heroku-buildpack-ruby/pull/1033)
 

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -30,6 +30,12 @@ class LanguagePack::Rails4 < LanguagePack::Rails3
     end
   end
 
+  def build_bundler(default_bundle_without)
+    instrument "rails4.build_bundler" do
+      super
+    end
+  end
+
   def compile
     instrument "rails4.compile" do
       super

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -100,16 +100,12 @@ WARNING
       warn_bad_binstubs
       install_ruby(slug_vendor_ruby, build_ruby_path)
       install_jvm
-      setup_language_pack_environment(
-        ruby_layer_path: File.expand_path("."),
-        gem_layer_path: File.expand_path("."),
-        bundle_path: "vendor/bundle",
-        bundle_default_without: "development:test"
-      )
+      setup_language_pack_environment(ruby_layer_path: File.expand_path("."), gem_layer_path: File.expand_path("."))
+      setup_profiled(ruby_layer_path: "$HOME", gem_layer_path: "$HOME") # $HOME is set to /app at run time
       allow_git do
         install_bundler_in_app(slug_vendor_base)
         load_bundler_cache
-        build_bundler
+        build_bundler(bundle_path: "vendor/bundle", default_bundle_without: "development:test")
         post_bundler
         create_database_yml
         install_binaries
@@ -118,7 +114,6 @@ WARNING
       config_detect
       best_practice_warnings
       warn_outdated_ruby
-      setup_profiled(ruby_layer_path: "$HOME", gem_layer_path: "$HOME") # $HOME is set to /app at run time
       setup_export
       cleanup
       super
@@ -142,12 +137,8 @@ WARNING
     ruby_layer.write
 
     gem_layer = Layer.new(@layer_dir, "gems", launch: true, cache: true, build: true)
-    setup_language_pack_environment(
-      ruby_layer_path: ruby_layer.path,
-      gem_layer_path: gem_layer.path,
-      bundle_path: "#{gem_layer.path}/vendor/bundle",
-      bundle_default_without: "development:test"
-    )
+    setup_language_pack_environment(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
+    setup_profiled(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
     allow_git do
       # TODO install bundler in separate layer
       topic "Loading Bundler Cache"
@@ -155,7 +146,7 @@ WARNING
         valid_bundler_cache?(gem_layer.path, gem_layer.metadata)
       end
       install_bundler_in_app("#{gem_layer.path}/#{slug_vendor_base}")
-      build_bundler
+      build_bundler(bundle_path: "#{gem_layer.path}/vendor/bundle", default_bundle_without: "development:test")
       # TODO post_bundler might need to be done in a new layer
       bundler.clean
       gem_layer.metadata[:gems] = Digest::SHA2.hexdigest(File.read("Gemfile.lock"))
@@ -170,7 +161,6 @@ WARNING
       install_binaries
       run_assets_precompile_rake_task
     end
-    setup_profiled(ruby_layer_path: ruby_layer.path, gem_layer_path: gem_layer.path)
     setup_export(gem_layer)
     config_detect
     best_practice_warnings
@@ -355,7 +345,7 @@ EOF
   end
 
   # sets up the environment variables for the build process
-  def setup_language_pack_environment(ruby_layer_path:, gem_layer_path:, bundle_path:, bundle_default_without:)
+  def setup_language_pack_environment(ruby_layer_path:, gem_layer_path:)
     instrument 'ruby.setup_language_pack_environment' do
       if ruby_version.jruby?
         ENV["PATH"] += ":bin"
@@ -403,11 +393,6 @@ EOF
       paths << ENV["PATH"]
 
       ENV["PATH"] = paths.join(":")
-
-      ENV["BUNDLE_WITHOUT"] = env("BUNDLE_WITHOUT") || bundle_default_without
-      ENV["BUNDLE_PATH"] = bundle_path
-      ENV["BUNDLE_BIN"] = bundler_binstubs_path
-      ENV["BUNDLE_DEPLOYMENT"] = "1"
     end
   end
 
@@ -441,11 +426,6 @@ EOF
         set_export_default "JAVA_OPTS",  default_java_opts
         set_export_default "JRUBY_OPTS", default_jruby_opts
       end
-
-      set_export_default "BUNDLE_PATH", ENV["BUNDLE_PATH"], layer
-      set_export_default "BUNDLE_WITHOUT", ENV["BUNDLE_WITHOUT"], layer
-      set_export_default "BUNDLE_BIN", ENV["BUNDLE_BIN"], layer
-      set_export_default "BUNDLE_DEPLOYMENT", ENV["BUNDLE_DEPLOYMENT"], layer if ENV["BUNDLE_DEPLOYMENT"] # Unset on windows since we delete the Gemfile.lock
     end
   end
 
@@ -481,11 +461,6 @@ EOF
         set_env_default "JAVA_OPTS", default_java_opts
         set_env_default "JRUBY_OPTS", default_jruby_opts
       end
-
-      set_env_default "BUNDLE_PATH", ENV["BUNDLE_PATH"]
-      set_env_default "BUNDLE_WITHOUT", ENV["BUNDLE_WITHOUT"]
-      set_env_default "BUNDLE_BIN", ENV["BUNDLE_BIN"]
-      set_env_default "BUNDLE_DEPLOYMENT", ENV["BUNDLE_DEPLOYMENT"] if ENV["BUNDLE_DEPLOYMENT"] # Unset on windows since we delete the Gemfile.lock
     end
   end
 
@@ -864,47 +839,44 @@ BUNDLE
   end
 
   # runs bundler to install the dependencies
-  def build_bundler
+  def build_bundler(bundle_path:, default_bundle_without:)
     instrument 'ruby.build_bundler' do
       log("bundle") do
-        if File.exist?("#{Dir.pwd}/.bundle/config")
-          warn(<<~WARNING, inline: true)
-            You have the `.bundle/config` file checked into your repository
-             It contains local state like the location of the installed bundle
-             as well as configured git local gems, and other settings that should
-            not be shared between multiple checkouts of a single repo. Please
-            remove the `.bundle/` folder from your repo and add it to your `.gitignore` file.
+        bundle_without = env("BUNDLE_WITHOUT") || default_bundle_without
+        bundle_bin     = "bundle"
+        bundle_command = "#{bundle_bin} install --without #{bundle_without} --path #{bundle_path} --binstubs #{bundler_binstubs_path}"
+        bundle_command << " -j4"
 
-            https://devcenter.heroku.com/articles/bundler-configuration
-          WARNING
+        if File.exist?("#{Dir.pwd}/.bundle/config")
+          warn(<<-WARNING, inline: true)
+You have the `.bundle/config` file checked into your repository
+ It contains local state like the location of the installed bundle
+ as well as configured git local gems, and other settings that should
+not be shared between multiple checkouts of a single repo. Please
+remove the `.bundle/` folder from your repo and add it to your `.gitignore` file.
+https://devcenter.heroku.com/articles/bundler-configuration
+WARNING
         end
 
         if bundler.windows_gemfile_lock?
+          warn(<<-WARNING, inline: true)
+Removing `Gemfile.lock` because it was generated on Windows.
+Bundler will do a full resolve so native gems are handled properly.
+This may result in unexpected gem versions being used in your app.
+In rare occasions Bundler may not be able to resolve your dependencies at all.
+https://devcenter.heroku.com/articles/bundler-windows-gemfile
+WARNING
+
           log("bundle", "has_windows_gemfile_lock")
-
           File.unlink("Gemfile.lock")
-          ENV.delete("BUNDLE_DEPLOYMENT")
-
-          warn(<<~WARNING, inline: true)
-            Removing `Gemfile.lock` because it was generated on Windows.
-            Bundler will do a full resolve so native gems are handled properly.
-            This may result in unexpected gem versions being used in your app.
-            In rare occasions Bundler may not be able to resolve your dependencies at all.
-
-            https://devcenter.heroku.com/articles/bundler-windows-gemfile
-          WARNING
+        else
+          # using --deployment is preferred if we can
+          bundle_command += " --deployment"
         end
-
-        bundle_command = String.new("")
-        bundle_command << "BUNDLE_WITHOUT=#{ENV["BUNDLE_WITHOUT"]} "
-        bundle_command << "BUNDLE_PATH=#{ENV["BUNDLE_PATH"]} "
-        bundle_command << "BUNDLE_BIN=#{ENV["BUNDLE_BIN"]} "
-        bundle_command << "BUNDLE_DEPLOYMENT=#{ENV["BUNDLE_DEPLOYMENT"]} " if ENV["BUNDLE_DEPLOYMENT"] # Unset on windows since we delete the Gemfile.lock
-        bundle_command << "bundle install -j4"
 
         topic("Installing dependencies using bundler #{bundler.version}")
 
-        bundler_output = String.new("")
+        bundler_output = ""
         bundle_time    = nil
         env_vars = {}
         Dir.mktmpdir("libyaml-") do |tmpdir|
@@ -946,9 +918,9 @@ BUNDLE
           instrument "ruby.bundle_clean" do
             # Only show bundle clean output when not using default cache
             if load_default_cache?
-              run("bundle clean > /dev/null", user_env: true, env: env_vars)
+              run("#{bundle_bin} clean > /dev/null", user_env: true, env: env_vars)
             else
-              pipe("bundle clean", out: "2> /dev/null", user_env: true, env: env_vars)
+              pipe("#{bundle_bin} clean", out: "2> /dev/null", user_env: true, env: env_vars)
             end
           end
           @bundler_cache.store
@@ -962,28 +934,28 @@ BUNDLE
           puts "Bundler Output: #{bundler_output}"
           if bundler_output.match(/An error occurred while installing sqlite3/)
             mcount "fail.sqlite3"
-            error_message += <<~ERROR
+            error_message += <<-ERROR
 
-              Detected sqlite3 gem which is not supported on Heroku:
-              https://devcenter.heroku.com/articles/sqlite3
+Detected sqlite3 gem which is not supported on Heroku:
+https://devcenter.heroku.com/articles/sqlite3
             ERROR
           end
 
           if bundler_output.match(/but your Gemfile specified/)
             mcount "fail.ruby_version_mismatch"
-            error_message += <<~ERROR
+            error_message += <<-ERROR
 
-              Detected a mismatch between your Ruby version installed and
-              Ruby version specified in Gemfile or Gemfile.lock. You can
-              correct this by running:
+Detected a mismatch between your Ruby version installed and
+Ruby version specified in Gemfile or Gemfile.lock. You can
+correct this by running:
 
-                  $ bundle update --ruby
-                  $ git add Gemfile.lock
-                  $ git commit -m "update ruby version"
+    $ bundle update --ruby
+    $ git add Gemfile.lock
+    $ git commit -m "update ruby version"
 
-              If this does not solve the issue please see this documentation:
+If this does not solve the issue please see this documentation:
 
-              https://devcenter.heroku.com/articles/ruby-versions#your-ruby-version-is-x-but-your-gemfile-specified-y
+https://devcenter.heroku.com/articles/ruby-versions#your-ruby-version-is-x-but-your-gemfile-specified-y
             ERROR
           end
 

--- a/lib/language_pack/test/ruby.rb
+++ b/lib/language_pack/test/ruby.rb
@@ -8,23 +8,18 @@ class LanguagePack::Ruby
       warn_bad_binstubs
       install_ruby(slug_vendor_ruby, build_ruby_path)
       install_jvm
-      setup_language_pack_environment(
-        ruby_layer_path: File.expand_path("."),
-        gem_layer_path: File.expand_path("."),
-        bundle_path: "vendor/bundle",
-        bundle_default_without: "development"
-      )
+      setup_language_pack_environment(ruby_layer_path: File.expand_path("."), gem_layer_path: File.expand_path("."))
       setup_export
+      setup_profiled(ruby_layer_path: "$HOME", gem_layer_path: "$HOME") # $HOME is set to /app at run time
       allow_git do
         install_bundler_in_app(slug_vendor_base)
         load_bundler_cache
-        build_bundler
+        build_bundler(bundle_path: "vendor/bundle", default_bundle_without: "development")
         post_bundler
         create_database_yml
         install_binaries
         prepare_tests
       end
-      setup_profiled(ruby_layer_path: "$HOME", gem_layer_path: "$HOME") # $HOME is set to /app at run time
       super
     end
   end

--- a/spec/hatchet/node_spec.rb
+++ b/spec/hatchet/node_spec.rb
@@ -6,9 +6,7 @@ describe "Node and Yarn" do
       :default,
       "https://github.com/sharpstone/force_absolute_paths_buildpack"
     ]
-    config = {FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS: "BUNDLE_PATH"}
-
-    Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks, config: config).deploy do |app, heroku|
+    Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks).deploy do |app, heroku|
       # https://rubular.com/r/4bkL8fYFTQwt0Q
       expect(app.output).to match(/vendor\/yarn-v\d+\.\d+\.\d+\/bin\/yarn is the yarn directory/)
       expect(app.output).to_not include(".heroku/yarn/bin/yarn is the yarn directory")
@@ -27,9 +25,8 @@ describe "Node and Yarn" do
       :default,
       "https://github.com/sharpstone/force_absolute_paths_buildpack"
     ]
-    config = {FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS: "BUNDLE_PATH"}
 
-    Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks, config: config).deploy do |app, heroku|
+    Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks).deploy do |app, heroku|
       expect(app.output).to include("yarn install")
       expect(app.output).to include(".heroku/yarn/bin/yarn is the yarn directory")
       expect(app.output).to include(".heroku/node/bin/node is the node directory")

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -113,9 +113,7 @@ describe "Ruby apps" do
         :default,
         "https://github.com/sharpstone/force_absolute_paths_buildpack"
       ]
-      config = {FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS: "BUNDLE_PATH"}
-
-      Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks, config: config).deploy do |app|
+      Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks).deploy do |app|
         expect(app.output).to match("cd version ruby 2.5.1")
 
         expect(app.run("which ruby").chomp).to eq("/app/bin/ruby")


### PR DESCRIPTION
This reverts commit 0449897f249bacc66f57c62e891dd847a40daaba. 

Due to issue described in #1046

```
heroku buildpacks:set heroku/ruby
git push heroku
remote: -----> Compressing...
remote:        Done: 137.8M


heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
git push heroku
remote: -----> Compressing...
remote:        Done: 351.3M
```