### PR TITLE
[changelog skip] Limit dependabot concurrency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
+    open-pull-requests-limit: 1 # Limit concurrent CI runs from executing
     schedule:
       interval: "weekly"
     labels:

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem "rake"
   gem "parallel_tests"
   gem 'rspec-retry'
-  gem 'json', '~> 2.3.0'
+  gem 'json'
   gem 'ci-queue'
   gem 'redis'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ansi (1.5.0)
-    ci-queue (0.17.2)
-      ansi
+    ci-queue (0.20.5)
     citrus (3.0.2)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     erubis (2.7.0)
     excon (0.76.0)
     heroics (0.1.1)
@@ -19,11 +17,11 @@ GEM
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    json (2.3.0)
+    json (2.3.1)
     moneta (1.0.0)
     multi_json (1.15.0)
-    parallel (1.19.1)
-    parallel_tests (2.32.0)
+    parallel (1.19.2)
+    parallel_tests (3.2.0)
       parallel
     platform-api (3.0.0)
       heroics (~> 0.1.1)
@@ -31,16 +29,16 @@ GEM
       rate_throttle_client (~> 0.1.0)
     rake (13.0.1)
     rate_throttle_client (0.1.2)
-    redis (4.1.3)
+    redis (4.2.1)
     rrrretry (1.0.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.1)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.9.2)
+    rspec-support (3.9.3)
     thor (0.20.3)
     threaded (0.0.4)
     toml-rb (2.0.1)
@@ -53,7 +51,7 @@ DEPENDENCIES
   ci-queue
   excon
   heroku_hatchet
-  json (~> 2.3.0)
+  json
   parallel_tests
   rake
   redis


### PR DESCRIPTION
Dependabot sent me 5 concurrent PRs which caused rate throttling to kick in and caused all my tests to go over their time limit and fail.
 
This PR limits dependabot to 1 PR at a time. To avoid this problem in the future.