### PR TITLE
[changelog skip] ✂️ Hatchet#setup!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (7.1.0)
+    heroku_hatchet (7.1.3)
       excon (~> 0)
       platform-api (~> 3)
       rrrretry (~> 1)

--- a/spec/hatchet/jvm_spec.rb
+++ b/spec/hatchet/jvm_spec.rb
@@ -7,10 +7,7 @@ describe "JvmInstaller" do
       :default # default is heroku-ruby-buildpack here
 
     ]
-    app = Hatchet::Runner.new("ruby_193_jruby_1_7_27", stack: 'heroku-18', buildpacks: buildpacks)
-    app.setup!
-
-    app.deploy do |app|
+    Hatchet::Runner.new("ruby_193_jruby_1_7_27", stack: 'heroku-18', buildpacks: buildpacks).deploy do |app|
       expect(app.output).to match("Using pre-installed JDK")
       expect(app.run("java -version")).to match("1.8.0")
       sleep 3

--- a/spec/hatchet/rails23_spec.rb
+++ b/spec/hatchet/rails23_spec.rb
@@ -2,8 +2,7 @@ require_relative '../spec_helper'
 
 describe "Rails 2.3.x" do
   it "should deploy on ruby 1.9.3 on cedar-14" do
-    app = Hatchet::Runner.new('rails23_mri_193', stack: "cedar-14").setup!
-    app.deploy do |app, heroku|
+    Hatchet::Runner.new('rails23_mri_193', stack: "cedar-14").deploy do |app|
       # assert deploy is successful
     end
   end

--- a/spec/hatchet/rails3_spec.rb
+++ b/spec/hatchet/rails3_spec.rb
@@ -2,9 +2,7 @@ require_relative '../spec_helper'
 
 describe "Rails 3.x" do
   it "should deploy on ruby 1.9.3" do
-    app = Hatchet::Runner.new("rails3_mri_193", stack: "cedar-14")
-    app.setup!
-    app.deploy do |app, heroku|
+    Hatchet::Runner.new("rails3_mri_193", stack: "cedar-14").deploy do |app, heroku|
       expect(app.output).to include("Asset precompilation completed")
 
       expect(app.output).to match("WARNING")

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -43,10 +43,9 @@ describe "Rails 5" do
         buildpacks: [
           "https://github.com/heroku/heroku-buildpack-activestorage-preview",
           :default
-        ]
+        ],
+        config: {'HEROKU_DEBUG_RAILS_RUNNER' => 'true'}
       )
-      app.setup!
-      app.set_config('HEROKU_DEBUG_RAILS_RUNNER' => 'true')
       app.deploy do |app, heroku|
         expect(app.output).to_not match('binary dependencies required')
         expect(app.output).to     match('config.active_storage.service')

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -3,7 +3,6 @@ require_relative '../spec_helper'
 describe "Ruby Versions on cedar-14" do
   it "should allow patchlevels" do
     app = Hatchet::Runner.new('mri_193_p547', stack: "cedar-14")
-    app.setup!
     app.deploy do |app|
       version = '1.9.3p547'
       expect(app.output).to match("ruby-1.9.3-p547")
@@ -13,7 +12,6 @@ describe "Ruby Versions on cedar-14" do
 
   it "should deploy ruby 1.9.2 properly" do
     app = Hatchet::Runner.new('mri_192', stack: "cedar-14")
-    app.setup!
     app.deploy do |app|
       version = '1.9.2'
       expect(app.output).to match(version)
@@ -23,7 +21,6 @@ describe "Ruby Versions on cedar-14" do
 
   it "should deploy ruby 1.9.3 properly" do
     app = Hatchet::Runner.new('mri_193', stack: "cedar-14")
-    app.setup!
     app.deploy do |app|
       version = '1.9.3'
       expect(app.output).to match(version)
@@ -33,7 +30,6 @@ describe "Ruby Versions on cedar-14" do
 
   it "should deploy ruby 2.0.0 properly" do
     app = Hatchet::Runner.new('mri_200', stack: "cedar-14")
-    app.setup!
     app.deploy do |app|
       version = '2.0.0'
       expect(app.output).to match(version)
@@ -45,7 +41,6 @@ describe "Ruby Versions on cedar-14" do
 
   it "should deploy jruby 1.7.16.1 (jdk 7) properly on cedar-14 with sys props file" do
     app = Hatchet::Runner.new("ruby_193_jruby_17161_jdk7", stack: "cedar-14")
-    app.setup!
     app.deploy do |app|
       expect(app.output).to match("Installing JVM: openjdk-7")
       expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
@@ -56,7 +51,6 @@ end
 describe "Ruby versions" do
   it "should deploy jdk 8 on heroku-18  by default" do
     app = Hatchet::Runner.new("ruby_193_jruby_1_7_27", stack: "heroku-18")
-    app.setup!
     app.deploy do |app|
       expect(app.output).to match("Installing JVM: openjdk-8")
       expect(app.output).to match("JRUBY_OPTS is:  -Xcompile.invokedynamic=false")
@@ -73,7 +67,6 @@ describe "Ruby versions" do
 
   it "should deploy jruby with the naether gem" do
     app = Hatchet::Runner.new("jruby_naether", stack: DEFAULT_STACK)
-    app.setup!
     app.deploy do |app|
       expect(app.output).to match("Installing naether")
       expect(app.output).not_to include("An error occurred while installing naether")
@@ -84,7 +77,6 @@ end
 describe "Upgrading ruby apps" do
   it "works when changing from default version" do
     app = Hatchet::Runner.new("default_ruby", stack: DEFAULT_STACK)
-    app.setup!
     app.deploy do |app|
       expect(app.run("env | grep MALLOC_ARENA_MAX")).to match("MALLOC_ARENA_MAX=2")
       expect(app.run("env | grep DISABLE_SPRING")).to match("DISABLE_SPRING=1")

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -200,10 +200,7 @@ end
 describe "Rack" do
   it "should not overwrite already set environment variables" do
     custom_env = "FFFUUUUUUU"
-    app = Hatchet::Runner.new("default_ruby")
-    app.setup!
-    app.set_config("RACK_ENV" => custom_env)
-    expect(app.run("env")).to match(custom_env)
+    app = Hatchet::Runner.new("default_ruby", config: {"RACK_ENV" => custom_env})
 
     app.deploy do |app|
       expect(app.run("env")).to match(custom_env)

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -2,8 +2,7 @@ require_relative "../spec_helper"
 
 describe "Stack Changes" do
   xit "should reinstall gems on stack change" do
-    app = Hatchet::Runner.new('default_ruby', stack: "heroku-18").setup!
-    app.deploy do |app, heroku|
+    Hatchet::Runner.new('default_ruby', stack: "heroku-18").deploy do |app|
       app.update_stack("heroku-16")
       run!('git commit --allow-empty -m "heroku-16 migrate"')
 
@@ -15,8 +14,7 @@ describe "Stack Changes" do
   end
 
   it "should not reinstall gems if the stack did not change" do
-    app = Hatchet::Runner.new('default_ruby', stack: "heroku-16").setup!
-    app.deploy do |app, heroku|
+    Hatchet::Runner.new('default_ruby', stack: "heroku-16").deploy do |app|
       app.update_stack("heroku-16")
       run!(%Q{git commit --allow-empty -m "cedar migrate"})
 


### PR DESCRIPTION
Originally the Hatchet#setup! method only created an app and set config. Now it's responsible for also mutating files if there's a before_deploy action and for creating a git directory if using a non-git path.

Originally calling `setup!` was necessary before calling `deploy` if you wanted to do something like set config on an app before deploy. It was necessary because the Hatchet::Runner.new interface did not have a `config:` interface. That's no longer the case, so it's not needed.

Using this outside of the repo is dangerous. We should probably make it a private API. But...first lets remove it from our existing buildpacks.

While nothing in the ruby buildpack currently accidentally modifies the existing disk, it's purely by accident. If we were to copy and paste a test and modify it, it's possible that could change. Let's remove all use of `Hatchet#setup!` to be safe.