### PR TITLE
[changelog skip] Skip changelog of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    commit_message:
+      prefix: "[changelog skip]"


### PR DESCRIPTION
Currently dependabot PRs are failing our check changelog script:


https://github.com/heroku/heroku-buildpack-ruby/pull/1062

(Click on the red "x" to see status). 

With this PR this check will be skipped.