### PR TITLE
[changelog skip] Schneems/fix dependabot key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-    commit_message:
+    commit-message:
       prefix: "[changelog skip]"


### PR DESCRIPTION
It's `commit-message` and not `commit_message`. It would be lovely if dependabot could warn on this before the file gets changed and merged.

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#commit-message