### PR TITLE
Fix dependabot?

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,3 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-    commit-message:
-      prefix: "[changelog skip]"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -5,6 +5,7 @@ on:
   types: [opened, reopened, edited, synchronize]
 jobs:
   build:
+    if: !contains(github.event.issue.labels.*.name, "dependencies")
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Dependabot caps the message prefix to 15 characters:

![](https://www.dropbox.com/s/gebohhtdfj54izq/Screen%20Shot%202020-09-28%20at%204.08.15%20PM.png?raw=1)

This PR allows for [log skip] to be a valid replacement for [changelog skip]. It replaces the previous [ci skip] since we are required to have CI run on every PR anyway. 

Then we tell dependabot to use that interface.