### PR TITLE
[changelog skip] Fix git tagging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,8 +72,8 @@ namespace :buildpack do
     deploy.check!
 
     if deploy.push_tag?
-      sh("git tag -f ", deploy.next_version) do |out, status|
-        raise "Could not `git tag -f #{deploy.version}`: #{out}" unless status.success?
+      sh("git tag -f #{deploy.next_version}") do |out, status|
+        raise "Could not `git tag -f #{deploy.next_version}`: #{out}" unless status.success?
       end
       sh("git push --tags") do |out, status|
         raise "Could not `git push --tags`: #{out}" unless status.success?


### PR DESCRIPTION
I'm not sure why but passing in `deploy.next_version` as an argument to `sh` isn't working as expected. Instead I'm just sending in one full command.

Also there was a bug in the raise because I was referencing `version` instead of `next_version`. That is now fixed.