### PR TITLE
[changelog skip] Fix mutating test

### DIFF
--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,10 +12,10 @@ module LanguagePack
       end
     end
 
-    DEFAULT_VERSION_NUMBER = "2.6.6"
-    DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}"
-    LEGACY_VERSION_NUMBER  = "1.9.2"
-    LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}"
+    DEFAULT_VERSION_NUMBER = "2.6.6".freeze
+    DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
+    LEGACY_VERSION_NUMBER  = "1.9.2".freeze
+    LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}".freeze
     RUBY_VERSION_REGEX     = %r{
         (?<ruby_version>\d+\.\d+\.\d+){0}
         (?<patchlevel>p-?\d+){0}

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -33,7 +33,7 @@ describe "Bundler" do
   end
 
   it "deploys with version 1.x" do
-    abi_version = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
+    abi_version = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER.dup
     abi_version[-1] = "0" # turn 2.6.6 into 2.6.0
     pending("Must enable HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
 


### PR DESCRIPTION
This was reported to generate a failure:

```
$ be rspec ./spec/hatchet/bundler_spec.rb[1:2] ./spec/helpers/ruby_version_spec.rb[1:6]
```

Log: https://dashboard.heroku.com/pipelines/ac057663-170b-4bdd-99d0-87560eb3a570/tests/1182

Output:

```
  1) RubyVersion correctly sets default ruby versions

     Failure/Error:

       Hatchet::App.new("default_ruby").in_directory_fork do |dir|
         ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
         version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
         version        = LanguagePack::RubyVersion::DEFAULT_VERSION
         expect(ruby_version.version_without_patchlevel).to eq(version)
         expect(ruby_version.engine_version).to eq(version_number)
         expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
         expect(ruby_version.engine).to eq(:ruby)
         expect(ruby_version.default?).to eq(true)
       end

     RuntimeError:
       /app/vendor/bundle/ruby/2.6.0/gems/rspec-support-3.9.3/lib/rspec/support.rb:97:in `block in <module:Support>':  (RSpec::Expectations::ExpectationNotMetError)

       expected: "2.6.0"
            got: "2.6.6"
       (compared using ==)
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-support-3.9.3/lib/rspec/support.rb:106:in `notify_failure'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.2/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:38:in `handle_failure'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:27:in `with_matcher'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.2/lib/rspec/expectations/expectation_target.rb:65:in `to'
       	from /app/spec/helpers/ruby_version_spec.rb:95:in `block (3 levels) in <top (required)>'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:395:in `block (3 levels) in in_directory_fork'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:377:in `block (2 levels) in in_directory'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:375:in `chdir'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:375:in `block in in_directory'
       	from /app/vendor/ruby-2.6.6/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:373:in `in_directory'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:394:in `block (2 levels) in in_directory_fork'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:389:in `fork'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:389:in `block in in_directory_fork'
       	from /app/vendor/ruby-2.6.6/lib/ruby/2.6.0/tempfile.rb:336:in `create'
       	from /app/vendor/bundle/ruby/2.6.0/gems/heroku_hatchet-7.3.0/lib/hatchet/app.rb:388:in `in_directory_fork'
       	from /app/spec/helpers/ruby_version_spec.rb:90:in `block (2 levels) in <top (required)>'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/example.rb:262:in `instance_exec'
       	from /app/vendor/bundle/ruby/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/example.rb:262:in `block in run'
```

It only fails with this test order though. Also from the output:

```
7 examples, 1 failure

Failed examples:

rspec ./spec/helpers/ruby_version_spec.rb:89 # RubyVersion correctly sets default ruby versions
./spec/hatchet/bundler_spec.rb[1:2]
./spec/helpers/ruby_version_spec.rb[1:6]
./spec/hatchet/rails5_spec.rb[1:2:2]
./spec/helpers/shell_spec.rb[1:4:1]
./spec/helpers/download_presence_spec.rb[1:5]
./spec/hatchet/buildpack_spec.rb[1:1]
./spec/hatchet/rubies_spec.rb[1:4]
```

This was failing because the bundler_spec test was accidentally mutating the version string constant. This PR freezes the constant strings and duplicates the constant before mutation.