### PR TITLE
Allow support for BUNDLE_WITHOUT with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+* BUNDLE_WITHOUT now accommodates values with single spaces (https://github.com/heroku/heroku-buildpack-ruby/pull/1083)
+
 ## v219 (8/6/2020)
 
 * Fix double installation of bundler on CI runs when no test script is specified (https://github.com/heroku/heroku-buildpack-ruby/pull/1073)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -406,6 +406,11 @@ EOF
       ENV["PATH"] = paths.join(":")
 
       ENV["BUNDLE_WITHOUT"] = env("BUNDLE_WITHOUT") || bundle_default_without
+      if ENV["BUNDLE_WITHOUT"].include?(' ')
+        ENV["BUNDLE_WITHOUT"] = ENV["BUNDLE_WITHOUT"].tr(' ', ':')
+
+        warn("Your BUNDLE_WITHOUT contains a space, we are converting it to a colon `:` BUNDLE_WITHOUT=#{ENV["BUNDLE_WITHOUT"]}", inline: true)
+      end
       ENV["BUNDLE_PATH"] = bundle_path
       ENV["BUNDLE_BIN"] = bundler_binstubs_path
       ENV["BUNDLE_DEPLOYMENT"] = "1"
@@ -900,7 +905,7 @@ BUNDLE
         end
 
         bundle_command = String.new("")
-        bundle_command << "BUNDLE_WITHOUT=#{ENV["BUNDLE_WITHOUT"]} "
+        bundle_command << "BUNDLE_WITHOUT='#{ENV["BUNDLE_WITHOUT"]}' "
         bundle_command << "BUNDLE_PATH=#{ENV["BUNDLE_PATH"]} "
         bundle_command << "BUNDLE_BIN=#{ENV["BUNDLE_BIN"]} "
         bundle_command << "BUNDLE_DEPLOYMENT=#{ENV["BUNDLE_DEPLOYMENT"]} " if ENV["BUNDLE_DEPLOYMENT"] # Unset on windows since we delete the Gemfile.lock

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 
 describe "Bundler" do
+  it "can be configured with BUNDLE_WITHOUT env var with spaces in it" do
+    Hatchet::Runner.new("default_ruby", config: {"BUNDLE_WITHOUT" => "foo bar baz"}).tap do |app|
+      app.deploy do
+        expect(app.output).to match("BUNDLE_WITHOUT='foo:bar:baz'")
+        expect(app.output).to match("Your BUNDLE_WITHOUT contains a space")
+      end
+    end
+  end
+
   it "deploys with version 2.x with Ruby 2.5" do
     ruby_version = "2.5.7"
     abi_version = ruby_version.dup


### PR DESCRIPTION
In v218 we switched from configuring bundler via flags to env vars. It turns out that bundler supports defining an `--without` value with a space in it, but it does not support BUNDLE_WITHOUT with a space in it:

```
$ bundle install --without foo bar
$ bundle config | grep without -a1

without
Set for your local app (/private/tmp/40a4b42d7e884ebf62a1f85a3c5abd38/.bundle/config): [:foo, :bar]
```

But:

```
$ BUNDLE_WITHOUT="foo bar" bundle config | grep without -a1

without
Set via BUNDLE_WITHOUT: [:"foo bar"]
```

> Note in this example it is showing `:"foo bar"` as one group instead of two values.

To fix this, we can reproduce the bundler logic of replacing a space with a colon https://github.com/rubygems/rubygems/blob/ce27b98272d5c37ebf45b2b1b66894699ae47d58/bundler/lib/bundler/cli/install.rb#L151. 

Related ticket: https://heroku.support/924687