### PR TITLE
[changelog skip] Prefer String#strip to #chomp

### DIFF
--- a/lib/language_pack/helpers/binstub_check.rb
+++ b/lib/language_pack/helpers/binstub_check.rb
@@ -51,7 +51,7 @@ class LanguagePack::Helpers::BinstubCheck
       For example bin/#{@bad_binstubs.first.basename} has the shebang line:
 
       ```
-      #{@bad_binstubs.first.open(&:readline).chomp}
+      #{@bad_binstubs.first.open(&:readline).strip}
       ```
 
       It should be:

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -152,7 +152,7 @@ class LanguagePack::Helpers::BundlerWrapper
       if output.match(/No ruby version specified/)
         ""
       else
-        output.chomp.sub('(', '').sub(')', '').sub(/(p-?\d+)/, ' \1').split.join('-')
+        output.strip.sub('(', '').sub(')', '').sub(/(p-?\d+)/, ' \1').split.join('-')
       end
     end
   end

--- a/lib/language_pack/metadata.rb
+++ b/lib/language_pack/metadata.rb
@@ -21,7 +21,7 @@ class LanguagePack::Metadata
 
   def read(key)
     full_key = "#{FOLDER}/#{key}"
-    File.read(full_key).chomp if exists?(key)
+    File.read(full_key).strip if exists?(key)
   end
 
   def exists?(key)

--- a/lib/language_pack/rails41.rb
+++ b/lib/language_pack/rails41.rb
@@ -34,7 +34,7 @@ class LanguagePack::Rails41 < LanguagePack::Rails4
 
     @app_secret ||= begin
       if @metadata.exists?(key)
-        @metadata.read(key).chomp
+        @metadata.read(key).strip
       else
         secret = SecureRandom.hex(64)
         @metadata.write(key, secret)

--- a/lib/language_pack/test/rails2.rb
+++ b/lib/language_pack/test/rails2.rb
@@ -61,7 +61,7 @@ FILE
 
     if schema_load.not_defined? && structure_load.not_defined?
       result = detect_schema_format
-      case result.lines.last.chomp
+      case result.lines.last.strip
       when "ruby"
         schema_load    = rake.task("db:schema:load")
       when "sql" # currently not a possible edge case, we think

--- a/spec/cnb/basic_local_pack_spec.rb
+++ b/spec/cnb/basic_local_pack_spec.rb
@@ -27,13 +27,13 @@ class CnbRun
     return unless image_name
     repo_name, tag_name = image_name.split(":")
 
-    docker_list = `docker images --no-trunc | grep #{repo_name} | grep #{tag_name}`.chomp
+    docker_list = `docker images --no-trunc | grep #{repo_name} | grep #{tag_name}`.strip
     run_local!("docker rmi #{image_name} --force") if !docker_list.empty?
     @image_name = nil
   end
 
   def run(cmd)
-    `docker run #{image_name} '#{cmd}'`.chomp
+    `docker run #{image_name} '#{cmd}'`.strip
   end
 
   def run!(cmd)

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -118,7 +118,7 @@ describe "Ruby apps" do
       Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks, config: config).deploy do |app|
         expect(app.output).to match("cd version ruby 2.5.1")
 
-        expect(app.run("which ruby").chomp).to eq("/app/bin/ruby")
+        expect(app.run("which ruby").strip).to eq("/app/bin/ruby")
       end
     end
   end

--- a/spec/helpers/binstub_check_spec.rb
+++ b/spec/helpers/binstub_check_spec.rb
@@ -2,7 +2,7 @@ require_relative "../spec_helper.rb"
 
 describe LanguagePack::Helpers::BinstubCheck do
   def get_ruby_path!
-    out = `which ruby`.chomp
+    out = `which ruby`.strip
     raise "command `which ruby` failed with output: #{out}" unless $?.success?
 
     return Pathname.new(out)


### PR DESCRIPTION
When manipulating the results of a shell result, it's common to want to remove the newline.

```
puts `ruby -v`.inspect # => "ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]\n"
```

This is commonly done by calling `chomp`. However there are some situations that are suspected to sometimes (but not always) contain two extra lines being tracked in https://github.com/heroku/hatchet/issues/120

## Chomp fails

- https://dashboard.heroku.com/pipelines/ac057663-170b-4bdd-99d0-87560eb3a570/tests/1195
- https://dashboard.heroku.com/pipelines/ac057663-170b-4bdd-99d0-87560eb3a570/tests/1197
- Maybe there are multiple newlines in the original string. We can switch to strip instead of chomp.

```
  1) Ruby apps running Ruby from outside the default dir works
     Failure/Error:
             Hatchet::Runner.new('cd_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks, config: config).deploy do |app|
               expect(app.output).to match("cd version ruby 2.5.1")       

               expect(app.run("which ruby").chomp).to eq("/app/bin/ruby")
             end

       App: hatchet-t-1ec16baaca (cd_ruby)
       expected: "/app/bin/ruby"
            got: "/app/bin/ruby\n"
       (compared using ==)
```

This PR replaces all uses of `chomp` that are intended to strip off trailing newlines with strip

```ruby
puts "/hello\n\n".chomp.inspect # => "/hello\n"
puts "/hello\n\n".strip.inspect # => "/hello"
```

It's not a perfect replacement, because `strip` also removes other whitespace characters and it modifies the beginning and end of the string. That being said, the ability to remove multiple newlines or any excess whitespace is the behavior we want.