### PR TITLE
[close #1089] Fix yarn not on path on CNB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Main (unreleased)
 
+* Fix bug preventing yarn from being accessed at runtime with CNB (https://github.com/heroku/heroku-buildpack-ruby/pull/1089)
 * Remove excessive Active Storage warnings (https://github.com/heroku/heroku-buildpack-ruby/pull/1087)
 
 ## v220 (8/7/2020)

--- a/lib/language_pack/test/ruby.rb
+++ b/lib/language_pack/test/ruby.rb
@@ -22,6 +22,7 @@ class LanguagePack::Ruby
         post_bundler
         create_database_yml
         install_binaries
+        install_binaries(File.expand_path("vendor"))
         prepare_tests
       end
       setup_profiled(ruby_layer_path: "$HOME", gem_layer_path: "$HOME") # $HOME is set to /app at run time

--- a/spec/cnb/basic_local_pack_spec.rb
+++ b/spec/cnb/basic_local_pack_spec.rb
@@ -50,6 +50,14 @@ class CnbRun
 end
 
 describe "cnb" do
+  it "installs yarn" do
+    CnbRun.new(hatchet_path("node/minimal_webpacker"), buildpack_paths: [buildpack_path]).call do |app|
+
+      run_out = app.run!("yarn -v")
+      expect(run_out).to match(LanguagePack::Helpers::Nodebin.yarn["number"])
+    end
+  end
+
   it "locally runs default_ruby app" do
     CnbRun.new(hatchet_path("rack/default_ruby"), buildpack_paths: [buildpack_path]).call do |app|
       expect(app.output).to match("Compiling Ruby/Rack")

--- a/spec/cnb/basic_local_pack_spec.rb
+++ b/spec/cnb/basic_local_pack_spec.rb
@@ -53,6 +53,8 @@ describe "cnb" do
   it "installs yarn" do
     CnbRun.new(hatchet_path("node/minimal_webpacker"), buildpack_paths: [buildpack_path]).call do |app|
 
+      run_out = app.run!("echo $PATH")
+
       run_out = app.run!("yarn -v")
       expect(run_out).to match(LanguagePack::Helpers::Nodebin.yarn["number"])
     end


### PR DESCRIPTION
Currently, we're installing yarn to `vendor/` directory but we were putting a different directory into a layer for CNB. This PR fixes the issue by creating a new layer just for vendor binaries (which currently only yarn uses).