### PR TITLE
Add Heroku-20 to the download presence check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Main (unreleased)
 
 * Remove excessive Active Storage warnings (https://github.com/heroku/heroku-buildpack-ruby/pull/1087)
+* Add Heroku-20 to the download presence check (https://github.com/heroku/heroku-buildpack-ruby/pull/1093)
 
 ## v220 (8/7/2020)
 

--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -8,7 +8,7 @@
 #
 #    download = LanguagePack::Helpers::DownloadPresence.new(
 #      'ruby-1.9.3.tgz',
-#      stacks: ['cedar-14', 'heroku-16', 'heroku-18']
+#      stacks: ['cedar-14', 'heroku-16', 'heroku-18', 'heroku-20']
 #    )
 #
 #    download.call
@@ -16,7 +16,7 @@
 #    puts download.exists? #=> true
 #    puts download.valid_stack_list #=> ['cedar-14']
 class LanguagePack::Helpers::DownloadPresence
-  STACKS = ['cedar-14', 'heroku-16', 'heroku-18']
+  STACKS = ['cedar-14', 'heroku-16', 'heroku-18', 'heroku-20']
 
   def initialize(path, stacks: STACKS)
     @path = path


### PR DESCRIPTION
Since Heroku-20 is now in public beta, so it's fine for the buildpack to reference it in build output.

See:
https://devcenter.heroku.com/changelog-items/1937

Closes [W-8250744](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008h988IAA/view).