### PR TITLE
Handle BUNDLED WITH deletion in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+* Fix Gemfile.lock read bug from preventing propper removal of BUNDLED WITH declaration ()
+
 ## v222 (11/02/2020)
 
 * CNB support for Heroku-20 (https://github.com/heroku/heroku-buildpack-ruby/pull/1096)

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -168,6 +168,14 @@ class LanguagePack::Helpers::BundlerWrapper
     Gem::Version.new(@version) < Gem::Version.new("2.1.4")
   end
 
+  def bundler_version_escape_valve!
+    topic("Removing BUNDLED WITH version in the Gemfile.lock")
+    contents = File.read(@gemfile_lock_path, mode: "rt")
+    File.open(@gemfile_lock_path, "w") do |f|
+      f.write contents.sub(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m, '')
+    end
+  end
+
   private
   def fetch_bundler
     instrument 'fetch_bundler' do
@@ -222,11 +230,4 @@ class LanguagePack::Helpers::BundlerWrapper
     end
   end
 
-  def bundler_version_escape_valve!
-    topic("Removing BUNDLED WITH version in the Gemfile.lock")
-    contents = File.read("Gemfile.lock")
-    File.open("Gemfile.lock", "w") do |f|
-      f.write contents.sub(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m, '')
-    end
-  end
 end

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -20,9 +20,24 @@ describe "BundlerWrapper" do
   end
 
   it "handles windows BUNDLED WITH" do
-    wrapper = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: fixture_path("windows_lockfile/Gemfile"))
+    Dir.mktmpdir do |dir|
+      tmp_dir = Pathname(dir)
+      FileUtils.cp_r(fixture_path("windows_lockfile/."), tmp_dir)
 
-    expect(wrapper.version).to eq(LanguagePack::Helpers::BundlerWrapper::BLESSED_BUNDLER_VERSIONS["2"])
+      tmp_gemfile_path = tmp_dir.join("Gemfile")
+      tmp_gemfile_lock_path = tmp_dir.join("Gemfile.lock")
+
+      expect(tmp_gemfile_lock_path.read).to match("BUNDLED")
+
+      wrapper = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: tmp_gemfile_path )
+
+      expect(wrapper.version).to eq(LanguagePack::Helpers::BundlerWrapper::BLESSED_BUNDLER_VERSIONS["2"])
+
+      def wrapper.topic(*args); end # Silence output in tests
+      wrapper.bundler_version_escape_valve!
+
+      expect(tmp_gemfile_lock_path.read).to_not match("BUNDLED")
+    end
   end
 
   it "detects windows gemfiles" do


### PR DESCRIPTION
Windows Gemfile.lock uses `\r\n` instead of `\n` for newlines which can cause issues when matching regex. We are using regex to strip out BUNDLED WITH and were not previously handling windows Gemfile.lock by mistake.

There is other code that reads in the major version of BUNDLED WITH and it uses a read mode of `rt` which solves the problem.

The solution is to change this other location to also use a read mode of `rt`:

```
irb(main):009:0> !!File.read("./spec/fixtures/windows_lockfile/Gemfile.lock").match(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m)
=> false
irb(main):010:0> !!File.read("./spec/fixtures/windows_lockfile/Gemfile.lock", mode: 'rt').match(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+
\.\d+/m)
=> true
```

The test now also assert the desired behavior of removing BUNDLED WITH occurs.