### PR TITLE
Fail detection with a CNB-friendly exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Main (unreleased)
 
 * Fix Gemfile.lock read bug from preventing propper removal of BUNDLED WITH declaration ()
+* Fail detection with a CNB-friendly exit code ()
 
 ## v222 (11/02/2020)
 

--- a/bin/detect
+++ b/bin/detect
@@ -16,5 +16,5 @@ if [ -f "$APP_DIR/Gemfile" ]; then
   exit 0
 else
   echo "no"
-  exit 1
+  exit 100
 fi


### PR DESCRIPTION
The CNB spec defines the following exit codes for detection scripts:

* `0` - passed detection
* `100` - failed detection
* anything else - error

(ref: https://github.com/buildpacks/spec/blob/main/buildpack.md#detection)

My understanding is that this change is in-line with the [Heroku Buildpack API](https://devcenter.heroku.com/articles/buildpack-api#bin-detect), but let me know if that's not the case.