### PR TITLE
[changelog skip] This fixes the tests and I don't know why

### DIFF
--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -42,34 +42,44 @@ describe "BundlerWrapper" do
 
   it "detects windows gemfiles" do
     Hatchet::App.new("rails4_windows_mri193").in_directory_fork do |dir|
-      expect(@bundler.install.windows_gemfile_lock?).to be_truthy
+      Bundler.with_unbundled_env do
+        expect(@bundler.install.windows_gemfile_lock?).to be_truthy
+      end
     end
   end
 
   describe "when executing bundler" do
-    before do
-      @bundler.install
-    end
-
     it "handles apps with ruby versions locked in Gemfile.lock" do
       Hatchet::App.new("problem_gemfile_version").in_directory_fork do |dir|
-        expect(@bundler.ruby_version).to eq("ruby-2.5.1-p0")
+        Bundler.with_unbundled_env do
+          @bundler.install
 
-        ruby_version = LanguagePack::RubyVersion.new(@bundler.ruby_version, is_new: true)
-        expect(ruby_version.version_for_download).to eq("ruby-2.5.1")
+          expect(@bundler.ruby_version).to eq("ruby-2.5.1-p0")
+
+          ruby_version = LanguagePack::RubyVersion.new(@bundler.ruby_version, is_new: true)
+          expect(ruby_version.version_for_download).to eq("ruby-2.5.1")
+        end
       end
     end
 
     it "handles JRuby pre gemfiles" do
       Hatchet::App.new("jruby-minimal").in_directory_fork do |dir|
-        expect(@bundler.ruby_version).to eq("ruby-2.3.1-p0-jruby-9.1.7.0")
+        Bundler.with_unbundled_env do
+          @bundler.install
+
+          expect(@bundler.ruby_version).to eq("ruby-2.3.1-p0-jruby-9.1.7.0")
+        end
       end
     end
 
     it "handles app with output in their Gemfile" do
       Hatchet::App.new("problem_gemfile_version").in_directory_fork do |dir|
-        run!(%{echo '\nputs "some output"\n' >> Gemfile})
-        expect(@bundler.ruby_version).to eq("ruby-2.5.1-p0")
+        Bundler.with_unbundled_env do
+          @bundler.install
+
+          run!(%{echo '\nputs "some output"\n' >> Gemfile})
+          expect(@bundler.ruby_version).to eq("ruby-2.5.1-p0")
+        end
       end
     end
   end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -17,25 +17,23 @@ describe "RubyVersion" do
   end
 
   it "knows the next logical version" do
-    Hatchet::App.new("ruby_25").in_directory_fork do |dir|
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
-      version_number = "2.5.0"
-      version        = "ruby-#{version_number}"
+    version_number = "2.5.0"
+    ruby_version   = LanguagePack::RubyVersion.new("ruby-#{version_number}-p0", is_new: true)
+    version        = "ruby-#{version_number}"
 
-      expect(ruby_version.version_without_patchlevel).to eq(version)
-      expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
-      expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
-      expect(ruby_version.next_logical_version(2)).to eq("ruby-2.5.2")
-      expect(ruby_version.next_logical_version(20)).to eq("ruby-2.5.20")
+    expect(ruby_version.version_without_patchlevel).to eq(version)
+    expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
+    expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
+    expect(ruby_version.next_logical_version(2)).to eq("ruby-2.5.2")
+    expect(ruby_version.next_logical_version(20)).to eq("ruby-2.5.20")
 
-      # Minor version
-      expect(ruby_version.next_minor_version).to eq("ruby-2.6.0")
-      expect(ruby_version.next_minor_version(2)).to eq("ruby-2.7.0")
+    # Minor version
+    expect(ruby_version.next_minor_version).to eq("ruby-2.6.0")
+    expect(ruby_version.next_minor_version(2)).to eq("ruby-2.7.0")
 
-      # Major Version
-      expect(ruby_version.next_major_version).to eq("ruby-3.0.0")
-      expect(ruby_version.next_major_version(2)).to eq("ruby-4.0.0")
-    end
+    # Major Version
+    expect(ruby_version.next_major_version).to eq("ruby-3.0.0")
+    expect(ruby_version.next_major_version(2)).to eq("ruby-4.0.0")
   end
 
   it "does not include patchlevels when the patchlevel is negative for download" do
@@ -64,66 +62,76 @@ describe "RubyVersion" do
 
   it "correctly sets ruby version for bundler specified versions" do
     Hatchet::App.new("mri_193").in_directory_fork do |dir|
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
-      version_number = "1.9.3"
-      version        = "ruby-#{version_number}"
-      expect(ruby_version.version_without_patchlevel).to eq(version)
-      expect(ruby_version.engine_version).to eq(version_number)
-      expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
-      expect(ruby_version.engine).to eq(:ruby)
+      Bundler.with_unbundled_env do
+        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+        version_number = "1.9.3"
+        version        = "ruby-#{version_number}"
+        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.engine_version).to eq(version_number)
+        expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
+        expect(ruby_version.engine).to eq(:ruby)
+      end
     end
   end
 
   it "correctly sets default ruby versions" do
     Hatchet::App.new("default_ruby").in_directory_fork do |dir|
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
-      version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
-      version        = LanguagePack::RubyVersion::DEFAULT_VERSION
-      expect(ruby_version.version_without_patchlevel).to eq(version)
-      expect(ruby_version.engine_version).to eq(version_number)
-      expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
-      expect(ruby_version.engine).to eq(:ruby)
-      expect(ruby_version.default?).to eq(true)
+      Bundler.with_unbundled_env do
+        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+        version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
+        version        = LanguagePack::RubyVersion::DEFAULT_VERSION
+        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.engine_version).to eq(version_number)
+        expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
+        expect(ruby_version.engine).to eq(:ruby)
+        expect(ruby_version.default?).to eq(true)
+      end
     end
   end
 
   it "correctly sets default legacy version" do
     Hatchet::App.new("default_ruby").in_directory_fork do |dir|
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: false)
-      version_number = LanguagePack::RubyVersion::LEGACY_VERSION_NUMBER
-      version        = LanguagePack::RubyVersion::LEGACY_VERSION
-      expect(ruby_version.version_without_patchlevel).to eq(version)
-      expect(ruby_version.engine_version).to eq(version_number)
-      expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
-      expect(ruby_version.engine).to eq(:ruby)
+      Bundler.with_unbundled_env do
+        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: false)
+        version_number = LanguagePack::RubyVersion::LEGACY_VERSION_NUMBER
+        version        = LanguagePack::RubyVersion::LEGACY_VERSION
+        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.engine_version).to eq(version_number)
+        expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
+        expect(ruby_version.engine).to eq(:ruby)
+      end
     end
   end
 
   it "detects Ruby 2.0.0" do
     Hatchet::App.new("mri_200").in_directory_fork do |dir|
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
-      version_number = "2.0.0"
-      version        = "ruby-#{version_number}"
-      expect(ruby_version.version_without_patchlevel).to eq(version)
-      expect(ruby_version.engine_version).to eq(version_number)
-      expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
-      expect(ruby_version.engine).to eq(:ruby)
+      Bundler.with_unbundled_env do
+        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+        version_number = "2.0.0"
+        version        = "ruby-#{version_number}"
+        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.engine_version).to eq(version_number)
+        expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
+        expect(ruby_version.engine).to eq(:ruby)
+      end
     end
   end
 
 
   it "detects non mri engines" do
     Hatchet::App.new("ruby_193_jruby_173").in_directory_fork do |dir|
-      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
-      version_number = "1.9.3"
-      engine_version = "1.7.3"
-      engine         = :jruby
-      version        = "ruby-#{version_number}-#{engine}-#{engine_version}"
-      to_gemfile     = "ruby '#{version_number}', :engine => '#{engine}', :engine_version => '#{engine_version}'"
-      expect(ruby_version.version_without_patchlevel).to eq(version)
-      expect(ruby_version.engine_version).to eq(engine_version)
-      expect(ruby_version.to_gemfile).to eq(to_gemfile)
-      expect(ruby_version.engine).to eq(engine)
+      Bundler.with_unbundled_env do
+        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+        version_number = "1.9.3"
+        engine_version = "1.7.3"
+        engine         = :jruby
+        version        = "ruby-#{version_number}-#{engine}-#{engine_version}"
+        to_gemfile     = "ruby '#{version_number}', :engine => '#{engine}', :engine_version => '#{engine_version}'"
+        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.engine_version).to eq(engine_version)
+        expect(ruby_version.to_gemfile).to eq(to_gemfile)
+        expect(ruby_version.engine).to eq(engine)
+      end
     end
   end
 
@@ -131,8 +139,10 @@ describe "RubyVersion" do
     bundle_error_msg = "Zomg der was a problem in da gemfile"
     error_klass      = LanguagePack::Helpers::BundlerWrapper::GemfileParseError
     Hatchet::App.new("bad_gemfile_on_platform").in_directory_fork do |dir|
-      @bundler       = LanguagePack::Helpers::BundlerWrapper.new().install
-      expect { LanguagePack::RubyVersion.new(@bundler.ruby_version) }.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
+      Bundler.with_unbundled_env do
+        @bundler       = LanguagePack::Helpers::BundlerWrapper.new().install
+        expect { LanguagePack::RubyVersion.new(@bundler.ruby_version) }.to raise_error(error_klass, /#{Regexp.escape(bundle_error_msg)}/)
+      end
     end
   end
 end


### PR DESCRIPTION
Recently the CI tests on main started failing:

```
  1) RubyVersion correctly sets default legacy version

     Failure/Error:
       Hatchet::App.new("default_ruby").in_directory_fork do |dir|
         ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: false)
         version_number = LanguagePack::RubyVersion::LEGACY_VERSION_NUMBER
         version        = LanguagePack::RubyVersion::LEGACY_VERSION
         expect(ruby_version.version_without_patchlevel).to eq(version)
         expect(ruby_version.engine_version).to eq(version_number)
         expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
         expect(ruby_version.engine).to eq(:ruby)
       end
     RuntimeError:
       -----> Installing bundler 1.17.3
       -----> Removing BUNDLED WITH version in the Gemfile.lock
       /app/lib/language_pack/helpers/bundler_wrapper.rb:151:in `block in ruby_version': There was an error parsing your Gemfile, we cannot continue (LanguagePack::Helpers::BundlerWrapper::GemfileParseError)
       /app/vendor/bundle/ruby/2.6.0/gems/bundler-2.1.4/lib/bundler/spec_set.rb:86:in `block in materialize': Could not find rake-13.0.1 in any of the sources (Bundler::GemNotFound)
```

I'm honestly not sure how this failure seemingly came out of nowhere. 

The fix is to wrap all calls to `@bundle.install` in a `Bundler.with_unbundled_env` block which essentially "resets" the bundler environment to how it was before the bundle exec mutated it.

I'm fine with doing that in these locations. It's a common strategy, for example: https://github.com/heroku/heroku-buildpack-ruby-experimental/blob/c210f289312e6185a60b953396f57f2ef0b60c6a/spec/unit/ruby_detect_version_spec.rb#L82

The thing I don't understand is why it's only needed now, or what changed to make this needed.