### PR TITLE
[changelog skip] Use correct method name in script

### DIFF
--- a/lib/rake/deploy_check.rb
+++ b/lib/rake/deploy_check.rb
@@ -48,7 +48,7 @@ class DeployCheck
   end
 
   # Returns a truthy value if the remote tag SHA matches the current local sha
-  def remote_tag_matches?(remote_sha: remote_commit_sha(next_version), local_sha: local_commit)
+  def remote_tag_matches?(remote_sha: remote_commit_sha(next_version), local_sha: local_commit_sha)
     remote_sha == local_sha
   end
 
@@ -125,7 +125,7 @@ class DeployCheck
     if block_given?
       yield out, $?
     else
-      raise "Command #{cmd} expected to return successfully did not: #{out}"
+      raise "Command #{cmd} expected to return successfully did not: #{out.inspect}"
     end
   end
 end

--- a/spec/rake/deploy_check_spec.rb
+++ b/spec/rake/deploy_check_spec.rb
@@ -4,9 +4,18 @@ require "rake/deploy_check"
 describe "A helper class for deploying" do
   describe "tests that hit github" do
     it "know remote tags" do
-      deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
-      expect(deploy.remote_tag_array.class).to eq(Array)
-      expect(deploy.remote_tag_array).to include("v218")
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          run!("touch foo; git init; git add .; git commit -m first")
+
+          deploy = DeployCheck.new(github: "heroku/heroku-buildpack-ruby")
+          expect(deploy.remote_tag_array.class).to eq(Array)
+          expect(deploy.remote_tag_array).to include("v218")
+
+          expect(deploy.remote_tag_matches?(local_sha: "nope")).to be_falsey
+          expect(deploy.remote_tag_matches?(remote_sha: "nope")).to be_falsey
+        end
+      end
     end
 
     it "remote sha" do


### PR DESCRIPTION
There's a bug in the release script:

```
$ be rake buildpack:release
Attempting to deploy v224, overwrite with RELEASE_VERSION env var
rake aborted!
NameError: undefined local variable or method `local_commit' for #<DeployCheck:0x00007fd311b6f238>
Did you mean?  local_commit_sha
/Users/rschneeman/Documents/projects/work/heroku-buildpack-ruby/lib/rake/deploy_check.rb:51:in `remote_tag_matches?'
/Users/rschneeman/Documents/projects/work/heroku-buildpack-ruby/lib/rake/deploy_check.rb:36:in `push_tag?'
/Users/rschneeman/Documents/projects/work/heroku-buildpack-ruby/Rakefile:74:in `block (2 levels) in <top (required)>'
/Users/rschneeman/.gem/ruby/2.6.6/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/Users/rschneeman/.gem/ruby/2.6.6/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/Users/rschneeman/.gem/ruby/2.6.6/bin/bundle:23:in `load'
/Users/rschneeman/.gem/ruby/2.6.6/bin/bundle:23:in `<main>'
Tasks: TOP => buildpack:release
(See full trace by running task with --trace)
```

This commit fixes it. This class shells out to git so to test it, dependency injection is used in the tests and this method (which acts
as a default arg) was never being called.