### PR TITLE
[changelog skip] Update buildpack tests

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,7 @@
       },
       "buildpacks": [
         { "url": "https://github.com/heroku/heroku-buildpack-cli.git" },
-        { "url": "https://github.com/heroku/heroku-buildpack-ruby#v211" }
+        { "url": "heroku/ruby" }
       ]
     }
   }

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -41,6 +41,8 @@ cat<<EOF
   This is most likely a temporary internal error. If the problem
   persists, make sure that you are not running a custom or forked
   version of the Heroku Ruby buildpack which may need updating.
+
+  url: $heroku_buildpack_ruby_url
 EOF
   exit 1
 }

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,9 +17,6 @@ ruby_version = "2.6.6"
   dir = "."
   files = ["./.env"]
   [[publish.Vendor]]
-  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar-14/ruby-2.6.6.tgz"
-  dir = "vendor/ruby/cedar-14"
-  [[publish.Vendor]]
   url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-16/ruby-2.6.6.tgz"
   dir = "vendor/ruby/heroku-16"
   [[publish.Vendor]]


### PR DESCRIPTION
The heroku-16 stack is deprecated. With heroku-20 tests were failing:

```
-----> Building on the Heroku-20 stack
-----> Fetching https://github.com/heroku/heroku-buildpack-cli.git buildpack...
       buildpack downloaded
-----> Fetching https://github.com/heroku/heroku-buildpack-ruby#v211 buildpack...
       buildpack downloaded
-----> heroku-cli app detected
=== Fetching and vendoring Heroku CLI into slug
=== Installing profile.d script
 ›   Warning: Our terms of service have changed:
 ›   https://dashboard.heroku.com/terms-of-service
heroku/7.49.0 linux-x64 node-v12.16.2
=== Heroku CLI installation done
-----> Ruby app detected
  Failed to download a Ruby executable for bootstrapping!
  This is most likely a temporary internal error. If the problem
  persists, make sure that you are not running a custom or forked
  version of the Heroku Ruby buildpack which may need updating.
/tmp/buildpacks/b2f3365577702f34ed6e4203939f02452cc3ab33/bin/test-compile: line 11: /tmp/tmp.KitelDjTSM/bin/ruby: No such file or directory
```

This commit ensures we're testing against the latest buildpack release instead of a very old tag. In addition, we're dropping building cedar-14 and adding the download url to the above error message.