### PR TITLE
[close #1126] Update bundler to 2.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+* Bundler 2.x is now 2.2.11 (https://github.com/heroku/heroku-buildpack-ruby/pull/1132)
+
 ## v224 (2/25/2021)
 
 * Ruby buildpack now relies on the JVM buildpack to install java for Jruby apps (https://github.com/heroku/heroku-buildpack-ruby/pull/1119)

--- a/changelogs/unreleased/bundler_2_2_11.md
+++ b/changelogs/unreleased/bundler_2_2_11.md
@@ -1,0 +1,3 @@
+##  Ruby apps with Bundler 2.x now receive version 2.2.11
+
+The [Ruby Buildpack](https://devcenter.heroku.com/articles/ruby-support#libraries) now includes Bundler 2.2.11. Applications specifying Bundler 2.x in their `Gemfile.lock` will now receive this version of bundler.

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.1.4"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.11"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
Bundler < 2.2.10 has "Source Priority" vulnerability #1126. This PR updates bundler to the latest version (2.2.11).