### PR TITLE
[close #1135] Update bundler to 2.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+* Bundler 2.x is now 2.2.12 (https://github.com/heroku/heroku-buildpack-ruby/pull/1140)
+
 ## v225 (2/25/2021)
 
 * Bundler 2.x is now 2.2.11 (https://github.com/heroku/heroku-buildpack-ruby/pull/1132)

--- a/changelogs/unreleased/bundler_2_2_12.md
+++ b/changelogs/unreleased/bundler_2_2_12.md
@@ -1,0 +1,3 @@
+##  Ruby apps with Bundler 2.x now receive version 2.2.12
+
+The [Ruby Buildpack](https://devcenter.heroku.com/articles/ruby-support#libraries) now includes Bundler 2.2.12. Applications specifying Bundler 2.x in their `Gemfile.lock` will now receive this version of bundler.

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.11"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.12"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
Bundler 2.2.11 contains an issue with "duplicate path gems" that is resolved in 2.2.12.