### PR TITLE
[changelog skip] Remove Heroku-16 from tests:

### DIFF
--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -3,8 +3,8 @@ require_relative "../spec_helper"
 describe "Stack Changes" do
   xit "should reinstall gems on stack change" do
     Hatchet::Runner.new('default_ruby', stack: "heroku-18").deploy do |app|
-      app.update_stack("heroku-16")
-      run!('git commit --allow-empty -m "heroku-16 migrate"')
+      app.update_stack("heroku-20")
+      run!('git commit --allow-empty -m "heroku-20 migrate"')
 
       app.push!
 
@@ -14,8 +14,8 @@ describe "Stack Changes" do
   end
 
   it "should not reinstall gems if the stack did not change" do
-    Hatchet::Runner.new('default_ruby', stack: "heroku-16").deploy do |app|
-      app.update_stack("heroku-16")
+    Hatchet::Runner.new('default_ruby', stack: "heroku-20").deploy do |app|
+      app.update_stack("heroku-20")
       run!(%Q{git commit --allow-empty -m "cedar migrate"})
 
       app.push!


### PR DESCRIPTION
```
Hatchet::App::FailedDeployError: Could not deploy 'hatchet-t-5e1aedd6a2' (default_ruby) using 'Hatchet::GitApp' at path: 'test/fixtures/repos/ruby/default_ruby'
if this was expected add `allow_failure: true` to your deploy hash.
Buildpack: nil
Repo: https://git.heroku.com/hatchet-t-5e1aedd6a2.git
output:
remote: Compressing source files... done.
remote: Building source:
remote:
remote: !   Your app is using the Heroku-16 stack, which will be end-of-life on May 1st, 2021.
remote: !
remote: !   Builds on Heroku-16 will not be possible from June 1st, 2021.
remote: !
remote: !   Please upgrade the stack of your app as soon as possible:
remote: !   https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack
remote: !
remote: !   Heroku-16 EOL FAQ: https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq
remote: !
remote: !   THIS IS A ONE-OFF NOTICE. THE NEXT DEPLOY WILL FUNCTION WITHOUT INTERRUPTION.
remote: !
remote: !   The next warning of this kind will occur in: 7 day(s).
remote:
To https://git.heroku.com/hatchet-t-5e1aedd6a2.git
Collapse
```