### PR TITLE
Remove support for Heroku-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Main (unreleased)
 
+* Remove support for the Cedar-14 and Heroku-16 stacks (https://github.com/heroku/heroku-buildpack-ruby/pull/1163)
+
 ## v227 (4/19/2021)
 
 * Bundler 2.x is now 2.2.16 (https://github.com/heroku/heroku-buildpack-ruby/pull/1150)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,10 +17,6 @@ dir = "."
 files = ["./.env"]
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-16/ruby-2.6.6.tgz"
-dir = "vendor/ruby/heroku-16"
-
-[[publish.Vendor]]
 url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.6.6.tgz"
 dir = "vendor/ruby/heroku-18"
 

--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -8,7 +8,7 @@
 #
 #    download = LanguagePack::Helpers::DownloadPresence.new(
 #      'ruby-1.9.3.tgz',
-#      stacks: ['cedar-14', 'heroku-16', 'heroku-18', 'heroku-20']
+#      stacks: ['heroku-18', 'heroku-20']
 #    )
 #
 #    download.call
@@ -16,7 +16,7 @@
 #    puts download.exists? #=> true
 #    puts download.valid_stack_list #=> ['cedar-14']
 class LanguagePack::Helpers::DownloadPresence
-  STACKS = ['cedar-14', 'heroku-16', 'heroku-18', 'heroku-20']
+  STACKS = ['heroku-18', 'heroku-20']
 
   def initialize(path, stacks: STACKS)
     @path = path

--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -7,7 +7,7 @@
 #   ruby_version = LanguagePack::RubyVersion.new("ruby-2.2.5")
 #   outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
 #     current_ruby_version: ruby_version,
-#     fetcher: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, "heroku-16")
+#     fetcher: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, "heroku-20")
 #   )
 #
 #   outdated.call

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -203,15 +203,6 @@ private
     return false
   end
 
-  def stack_not_14_not_16?
-    case stack
-    when "cedar-14", "heroku-16"
-      return false
-    else
-      return true
-    end
-  end
-
   def warn_bundler_upgrade
     old_bundler_version  = @metadata.read("bundler_version").strip if @metadata.exists?("bundler_version")
 
@@ -608,7 +599,7 @@ EOF
           On Heroku CI you can set your stack in the `app.json`. For example:
 
           ```
-          "stack": "heroku-16"
+          "stack": "heroku-20"
           ```
         ERROR
       end
@@ -730,19 +721,6 @@ EOF
     end
   end
 
-  # install libyaml into the LP to be referenced for psych compilation
-  # @param [String] tmpdir to store the libyaml files
-  def install_libyaml(dir)
-    return false if stack_not_14_not_16?
-
-    instrument 'ruby.install_libyaml' do
-      FileUtils.mkdir_p dir
-      Dir.chdir(dir) do
-        @fetchers[:buildpack].fetch_untar("#{@stack}/#{LIBYAML_PATH}.tgz")
-      end
-    end
-  end
-
   # remove `vendor/bundle` that comes from the git repo
   # in case there are native ext.
   # users should be using `bundle pack` instead.
@@ -844,7 +822,6 @@ BUNDLE
         env_vars = {}
         Dir.mktmpdir("libyaml-") do |tmpdir|
           libyaml_dir = "#{tmpdir}/#{LIBYAML_PATH}"
-          install_libyaml(libyaml_dir)
 
           # need to setup compile environment for the psych gem
           yaml_include   = File.expand_path("#{libyaml_dir}/include").shellescape

--- a/lib/rake/tarballer.rb
+++ b/lib/rake/tarballer.rb
@@ -12,7 +12,7 @@ require "language_pack/version"
 # In addition to TAR logic it also vendors ruby versions so
 # they don't need to be pulled at runtime
 class Tarballer
-  STACKS = %W{cedar-14 heroku-16 heroku-18}
+  STACKS = %W{heroku-18 heroku-20}
 
   def initialize(name: , directory: , io: STDOUT)
     @name = name


### PR DESCRIPTION
The Heroku-16 stack reached end-of-life on May 1st, 2021, and from June 1st, 2021, builds were disabled:
https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

This change:
* Removes Heroku-16 + Cedar-14 from the Ruby version presence check.
* Removes the now unused `libyaml` vendoring step, since it only ran on Heroku-16 and Cedar-14.
* Makes the buildpack release process no longer vendor the Heroku-16 Ruby archive.

Refs GUS-W-9329723.