### PR TITLE
Upgrade Bundler to 2.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Main (unreleased)
 
 * Remove support for the Cedar-14 and Heroku-16 stacks (https://github.com/heroku/heroku-buildpack-ruby/pull/1163)
+* Bundler 2.x is now 2.2.21 ()
 
 ## v227 (4/19/2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Main (unreleased)
 
 * Remove support for the Cedar-14 and Heroku-16 stacks (https://github.com/heroku/heroku-buildpack-ruby/pull/1163)
-* Bundler 2.x is now 2.2.21 ()
+* Bundler 2.x is now 2.2.21 (https://github.com/heroku/heroku-buildpack-ruby/pull/1169)
 
 ## v227 (4/19/2021)
 

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.16"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.21"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
* Versions <2.2.18 have a "dependency confusion" vulnerability. 2.2.18 introduced a new lockfile format which prevents the problem by ensuring every gem has only one source.
* Versions <2.2.21 are unable to recreate lockfiles without also forcing an upgrade of all gems.

Resolves https://github.com/heroku/heroku-buildpack-ruby/issues/1167.

Initial commit doesn't include a link for this PR in the changelog; I will make a followup commit with the link.