### PR TITLE
[close #1167] Bundler version is 2.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Main (unreleased)
 
+## v228 (6/24/2021)
+
+* Bundler 2.x is now 2.2.21 (https://github.com/heroku/heroku-buildpack-ruby/pull/1170)
 * Remove support for the Cedar-14 and Heroku-16 stacks (https://github.com/heroku/heroku-buildpack-ruby/pull/1163)
 
 ## v227 (4/19/2021)

--- a/changelogs/v228/bundler_2_2_21.md
+++ b/changelogs/v228/bundler_2_2_21.md
@@ -1,0 +1,3 @@
+##  Ruby apps with Bundler 2.x now receive version 2.2.21
+
+The [Ruby Buildpack](https://devcenter.heroku.com/articles/ruby-support#libraries) now includes Bundler 2.2.21. Applications specifying Bundler 2.x in their `Gemfile.lock` will now receive bundler: 2.2.21.

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.16"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.21"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
The current bundler version 2.2.15 has a "dependency confusion vulnerability" https://github.com/advisories/GHSA-fp4w-jxhp-m23p

Upgrading to 2.2.21 mitigates this issue.