### PR TITLE
Allow running specs with RSpec 3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,7 +126,7 @@ begin
 
   desc "Run specs"
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = %w(-fs --color)
+    t.rspec_opts = %w(-fd --color)
     #t.ruby_opts  = %w(-w)
   end
   task :default => :spec


### PR DESCRIPTION
The `-s` alias for the documentation formatter was removed in RSpec 3. See https://github.com/rspec/rspec-core/commit/b8d55efcf4b6b5e1656b9c2a4095c6dd3054ea03.

Without this patch, I get the following error:

```
$ bundle exec rake
/home/deivid/.rbenv/versions/2.6.6/bin/ruby -I/home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib:/home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-support-3.9.3/lib /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb -fs --color
No examples found.
Traceback (most recent call last):
	12: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/exe/rspec:4:in `<main>'
	11: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/runner.rb:45:in `invoke'
	10: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/runner.rb:71:in `run'
	 9: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/runner.rb:86:in `run'
	 8: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/runner.rb:99:in `setup'
	 7: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/runner.rb:132:in `configure'
	 6: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/configuration_options.rb:24:in `configure'
	 5: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/configuration_options.rb:118:in `load_formatters_into'
	 4: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/configuration_options.rb:118:in `each'
	 3: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/configuration_options.rb:118:in `block in load_formatters_into'
	 2: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/configuration.rb:968:in `add_formatter'
	 1: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/formatters.rb:152:in `add'
/home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib/rspec/core/formatters.rb:184:in `find_formatter': Formatter 's' unknown - maybe you meant 'documentation' or 'progress'?. (ArgumentError)
/home/deivid/.rbenv/versions/2.6.6/bin/ruby -I/home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/lib:/home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-support-3.9.3/lib /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.3/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb -fs --color failed
```