### PR TITLE
Allow configuring `HATCHET_BUILDPACK_BASE`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'rspec/retry'
 require 'language_pack'
 require 'language_pack/shell_helpers'
 
-ENV["HATCHET_BUILDPACK_BASE"] = "https://github.com/heroku/heroku-buildpack-ruby"
+ENV["HATCHET_BUILDPACK_BASE"] ||= "https://github.com/heroku/heroku-buildpack-ruby"
 
 ENV['RACK_ENV'] = 'test'
 


### PR DESCRIPTION
So that specs can also pass when run on forks.