### PR TITLE
[changelog skip] Allow `rspec --only-failures` to work by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ buildpacks/*
 .anvil/
 tmp/*.log
 log/*.log
+spec/examples.txt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   config.full_backtrace      = true
   config.verbose_retry       = true # show retry status in spec process
   config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   config.expect_with :rspec do |c|
     c.max_formatted_output_length = Float::INFINITY


### PR DESCRIPTION
It's useful when focusing on fixing a failing test run, since it only runs currently failing specs.