### PR TITLE
use WEB_CONCURRENCY.sh for WEB_CONCURRENCY default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Main (unreleased)
 
-## v229 (?/??/2021)
-
 * Fix interoperability with other Heroku buildpacks' `$WEB_CONCURRENCY` handling (https://github.com/heroku/heroku-buildpack-ruby/pull/1188)
 
 ## v228 (6/24/2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Main (unreleased)
 
+## v229 (?/??/2021)
+
+* Fix interoperability with other Heroku buildpacks' `$WEB_CONCURRENCY` handling (https://github.com/heroku/heroku-buildpack-ruby/pull/1188)
+
 ## v228 (6/24/2021)
 
 * Bundler 2.x is now 2.2.21 (https://github.com/heroku/heroku-buildpack-ruby/pull/1170)

--- a/changelogs/unreleased/WEB_CONCURRENCY.md
+++ b/changelogs/unreleased/WEB_CONCURRENCY.md
@@ -1,0 +1,7 @@
+## Ruby buildpack now clears previous default buildpack `WEB_CONCURRENCY` values
+
+Some buildpacks may set a default value for the `WEB_CONCURRENCY` environment variable during dyno startup.
+
+When multiple buildpacks define default values, the declaration from the last buildpack in the list of multiple buildpacks takes precedence, as this is the [primary language of an app](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack).
+
+The Ruby buildpack is now interoperable with other buildpacks in this regard; for example, using `heroku/nodejs` as the first, and `heroku/ruby` as the second buildpack, will no longer lead to Node.js default values for `WEB_CONCURRENCY` to apply at runtime.

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -206,11 +206,11 @@ private ##################################
   def setup_language_pack_environment
   end
 
-  def add_to_profiled(string)
+  def add_to_profiled(string, filename = "ruby.sh", mode = "a")
     profiled_path = @layer_dir ? "#{@layer_dir}/ruby/profile.d/" : "#{build_path}/.profile.d/"
 
     FileUtils.mkdir_p profiled_path
-    File.open("#{profiled_path}/ruby.sh", "a") do |file|
+    File.open("#{profiled_path}/#{filename}", mode) do |file|
       file.puts string
     end
   end

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -206,7 +206,7 @@ private ##################################
   def setup_language_pack_environment
   end
 
-  def add_to_profiled(string, filename = "ruby.sh", mode = "a")
+  def add_to_profiled(string, filename: "ruby.sh", mode: "a")
     profiled_path = @layer_dir ? "#{@layer_dir}/ruby/profile.d/" : "#{build_path}/.profile.d/"
 
     FileUtils.mkdir_p profiled_path

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -412,7 +412,9 @@ EOF
       set_env_override "DISABLE_SPRING", "1"
 
       set_env_default "MALLOC_ARENA_MAX", "2"     if default_malloc_arena_max?
-      add_to_profiled (env("SENSIBLE_DEFAULTS") ? set_default_web_concurrency : ""), "WEB_CONCURRENCY.sh", "w" # always write that file, even if its empty (meaning no defaults apply), for interop with other buildpacks - and we overwrite that file rather than appending (which is the default)
+
+      web_concurrency = env("SENSIBLE_DEFAULTS") ? set_default_web_concurrency : ""
+      add_to_profiled(web_concurrency, filename: "WEB_CONCURRENCY.sh", mode: "w") # always write that file, even if its empty (meaning no defaults apply), for interop with other buildpacks - and we overwrite the file rather than appending (which is the default)
 
       # TODO handle JRUBY
       if ruby_version.jruby?

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -412,7 +412,7 @@ EOF
       set_env_override "DISABLE_SPRING", "1"
 
       set_env_default "MALLOC_ARENA_MAX", "2"     if default_malloc_arena_max?
-      add_to_profiled set_default_web_concurrency if env("SENSIBLE_DEFAULTS")
+      add_to_profiled (env("SENSIBLE_DEFAULTS") ? set_default_web_concurrency : ""), "WEB_CONCURRENCY.sh", "w" # always write that file, even if its empty (meaning no defaults apply), for interop with other buildpacks - and we overwrite that file rather than appending (which is the default)
 
       # TODO handle JRUBY
       if ruby_version.jruby?

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -206,3 +206,24 @@ describe "Rack" do
     end
   end
 end
+
+describe "WEB_CONCURRENCY.sh" do
+  it "from a preceding buildpack is overwritten by this buildpack" do
+    buildpacks = [
+      "heroku/nodejs",
+      :default
+    ]
+    before_deploy = -> { run!(%Q{echo "{}" > package.json}) }
+    Hatchet::Runner.new('default_ruby', stack: DEFAULT_STACK, buildpacks: buildpacks, before_deploy: before_deploy).deploy do |app|
+      expect(app.run("cat .profile.d/WEB_CONCURRENCY.sh").strip).to be_empty
+      expect(app.run("echo $WEB_CONCURRENCY").strip).to be_empty
+      expect(app.run("echo $WEB_CONCURRENCY", :heroku => {:env => "WEB_CONCURRENCY=0"}).strip).to eq("0")
+    end
+  end
+  it "has defaults set with SENSIBLE_DEFAULTS on" do
+    config = { "SENSIBLE_DEFAULTS" => "1"}
+    Hatchet::Runner.new('default_ruby', stack: DEFAULT_STACK, config: config).deploy do |app|
+      expect(app.run("env")).to match("WEB_CONCURRENCY=")
+    end
+  end
+end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -220,6 +220,7 @@ describe "WEB_CONCURRENCY.sh" do
       expect(app.run("echo $WEB_CONCURRENCY", :heroku => {:env => "WEB_CONCURRENCY=0"}).strip).to eq("0")
     end
   end
+
   it "has defaults set with SENSIBLE_DEFAULTS on" do
     config = { "SENSIBLE_DEFAULTS" => "1"}
     Hatchet::Runner.new('default_ruby', stack: DEFAULT_STACK, config: config).deploy do |app|


### PR DESCRIPTION
The Node.js, PHP and Python buildpacks write their WEB_CONCURRENCY defaults logic to this file name.

This ensures that the last buildpack to run defines the defaults an app will use.

If each buildpack were to use its own filename, then whatever file is evaluated first by the Shell on startup would set an initial value, and following files would see the variable already set and likely skip their calculation, or apply their own lower/upper limit enforcement, as it cannot know whether the variable was set by a user, or by some other buildpack's startup logic

(the Shell sources files using a glob pattern from .profile.d/ on startup, which on GNU Bash is in alnum order, see https://www.gnu.org/software/bash/manual/bash.html#Filename-Expansion)

This change uses the same filename as other buildpacks, ensuring that e.g. if heroku/nodejs is used as the first and heroku/ruby as the second buildpack, the defaults set by this buildpack will apply.

Right now, in this constellation, .profile.d/ruby.sh runs first, and sets a default value, then .profile.d/WEB_CONCURRENCY.sh runs later, and does nothing, as the defaults fit within Node.js's current logic - but if a user sets WEB_CONCURRENCY=0 manually, then Node.js' logic kicks in, and re-sets the value to 1, as Node.js doesn't allow a value of 0.

Ruby's Puma however allows "single mode", and for that, the value needs to be 0: https://github.com/puma/puma/issues/2393

Refs https://github.com/heroku/heroku-buildpack-nodejs/pull/926

GUS-W-9788823