### PR TITLE
[changelog skip] drop sqlite3 test Ruby version requirement

### DIFF
--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -179,8 +179,7 @@ end
 
 describe "Raise errors on specific gems" do
   it "should raise on sqlite3" do
-    before_deploy = -> { run!(%Q{echo "ruby '2.5.4' >> Gemfile"}) }
-    Hatchet::Runner.new("sqlite3_gemfile", allow_failure: true, before_deploy: before_deploy).deploy do |app|
+    Hatchet::Runner.new("sqlite3_gemfile", allow_failure: true).deploy do |app|
       expect(app).not_to be_deployed
       expect(app.output).to include("Detected sqlite3 gem which is not supported")
       expect(app.output).to include("devcenter.heroku.com/articles/sqlite3")


### PR DESCRIPTION
due to broken quoting, the test currently just echos a string to stdout rather than writing it to Gemfile as intended
    
however, the desired Ruby version isn't available on heroku-20, and the test clearly works without the requirement, so we can omit it altogether