### PR TITLE
Increase default Ruby version to 2.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ jobs:
       - checkout
       - run:
           command: |
-            rvm install 2.6.6
-            rvm use ruby-2.6.6
-            export PATH="/opt/circleci/.rvm/rubies/ruby-2.6.6/bin:$PATH"
-            export GEM_HOME="/opt/circleci/.rvm/gems/ruby-2.6.6"
-            export GEM_PATH="/opt/circleci/.rvm/gems/ruby-2.6.6"
+            rvm install 2.7.4
+            rvm use ruby-2.7.4
+            export PATH="/opt/circleci/.rvm/rubies/ruby-2.7.4/bin:$PATH"
+            export GEM_HOME="/opt/circleci/.rvm/gems/ruby-2.7.4"
+            export GEM_PATH="/opt/circleci/.rvm/gems/ruby-2.7.4"
             gem install bundler -v 2.1.0
             bundle install
             bundle exec rake hatchet:setup_ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## v229 (7/30/2021)
 
-* Default Ruby version is now 2.7.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/974)
-
+* Default Ruby version is now 2.7.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/1193)
 * Fix interoperability with other Heroku buildpacks' `$WEB_CONCURRENCY` handling (https://github.com/heroku/heroku-buildpack-ruby/pull/1188)
 
 ## v228 (6/24/2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v229 (7/30/2021)
 
+* Default Ruby version is now 2.7.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/974)
+
 * Fix interoperability with other Heroku buildpacks' `$WEB_CONCURRENCY` handling (https://github.com/heroku/heroku-buildpack-ruby/pull/1188)
 
 ## v228 (6/24/2021)

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.6'
+ruby '2.7.4'
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.7.4p191
 
 BUNDLED WITH
    2.1.4

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.2"
 id = "heroku/ruby"
 version = "0.1.2"
 name = "Ruby"
-ruby_version = "2.6.6"
+ruby_version = "2.7.4"
 
 [publish]
 
@@ -17,11 +17,11 @@ dir = "."
 files = ["./.env"]
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.6.6.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.7.4.tgz"
 dir = "vendor/ruby/heroku-18"
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.6.6.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.7.4.tgz"
 dir = "vendor/ruby/heroku-20"
 
 [[stacks]]

--- a/changelogs/ruby_274_default.md
+++ b/changelogs/ruby_274_default.md
@@ -1,0 +1,3 @@
+## Default Ruby version for new apps is now 2.7.4
+
+The [default Ruby version for new Ruby applications is 2.7.4](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.

--- a/hatchet.json
+++ b/hatchet.json
@@ -3,7 +3,6 @@
     "sharpstone/asset_precompile_fail",
     "sharpstone/asset_precompile_pass",
     "sharpstone/asset_precompile_not_found",
-    "sharpstone/connect_to_database_on_first_push",
     "sharpstone/no_rakefile",
     "sharpstone/bad_rakefile",
     "sharpstone/default_with_rakefile"
@@ -46,8 +45,6 @@
     "sharpstone/rails3_default_ruby",
     "sharpstone/rails4_windows_mri193",
     "sharpstone/rails42_default_ruby",
-    "sharpstone/rails5",
-    "schneems/rails51_webpacker",
     "sharpstone/active_storage_non_local",
     "sharpstone/active_storage_local",
     "sharpstone/sprockets_asset_compile_true",

--- a/lib/language_pack/helpers/binstub_wrapper.rb
+++ b/lib/language_pack/helpers/binstub_wrapper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-#
+
+require 'delegate'
+
 # This is a helper class, it wraps a pathname object
 # and adds helper methods used to pull out the first line of the file ("the shebang")
 # as well as determining if the file is binary or not.

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,7 +12,7 @@ module LanguagePack
       end
     end
 
-    DEFAULT_VERSION_NUMBER = "2.6.6".freeze
+    DEFAULT_VERSION_NUMBER = "2.7.4".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}".freeze

--- a/spec/hatchet/bugs_spec.rb
+++ b/spec/hatchet/bugs_spec.rb
@@ -10,8 +10,25 @@ describe "Bugs" do
 
   context "database connections" do
     it "fails with better error message" do
-      Hatchet::Runner.new("connect_to_database_on_first_push", allow_failure: true).deploy do |app|
-        expect(app.output).to match("https://devcenter.heroku.com/articles/pre-provision-database")
+      Hatchet::Runner.new("ruby-getting-started", allow_failure: true).tap do |app| 
+        app.before_deploy do
+          Pathname("Rakefile").write(<<~EOM)
+            require 'bundler'
+            Bundler.require(:default)
+
+            require 'active_record'
+
+            task "assets:precompile" do
+              # Try to connect to a database that doesn't exist yet
+              ActiveRecord::Base.establish_connection
+              ActiveRecord::Base.connection.execute("")
+            end
+          EOM
+        end
+
+        app.deploy do
+          expect(app.output).to match("https://devcenter.heroku.com/articles/pre-provision-database")
+        end
       end
     end
   end

--- a/spec/hatchet/rails5_spec.rb
+++ b/spec/hatchet/rails5_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../spec_helper'
 
 describe "Rails 5" do
-  it "works" do
-    Hatchet::Runner.new("rails5", stack: "heroku-18").deploy do |app, heroku|
+  it "behaves correctly, not related to Rails 5 at all" do
+    Hatchet::Runner.new("ruby-getting-started", stack: "heroku-18").deploy do |app, heroku|
       # Test BUNDLE_DISABLE_VERSION_CHECK works
       expect(app.output).not_to include("The latest bundler is")
 
@@ -42,30 +42,3 @@ describe "Rails 5" do
   end
 end
 
-describe "Rails 5.1 with webpacker" do
-  it "calls bin/yarn no matter what is on the path" do
-    Hatchet::Runner.new("rails51_webpacker").tap do |app|
-      # We put our version of yarn first on the path ahead of bin/yarn
-      # however webpacker explicitly calls bin/yarn instead of calling
-      # `yarn install`
-      app.before_deploy do
-        File.open("bin/yarn", "w") do |f|
-          f.write <<~EOM
-          #! /usr/bin/env bash
-
-          echo "Called bin/yarn binstub"
-          `yarn install`
-          EOM
-        end
-        run("chmod +x bin/yarn")
-      end
-
-      app.deploy do
-        expect(app.output).to include("Called bin/yarn binstub")
-
-        expect(app.output).to match("rake assets:precompile")
-        expect(app.output).to match("rake assets:clean")
-      end
-    end
-  end
-end


### PR DESCRIPTION
Our policy is to stay on the latest patch release of the middle supported Ruby version. Supported versions are 3.0, 2.7, and 2.6 so the latest of the 2.7 is 2.7.4.

GUS-W-9831879