### PR TITLE
Correct CHANGELOG entries for #1188 and #1193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Main (unreleased)
+# Changelog
 
-## v229 (7/30/2021)
+## Main (unreleased)
 
 * Default Ruby version is now 2.7.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/1193)
+
+## v229 (8/30/2021)
+
 * Fix interoperability with other Heroku buildpacks' `$WEB_CONCURRENCY` handling (https://github.com/heroku/heroku-buildpack-ruby/pull/1188)
 
 ## v228 (6/24/2021)


### PR DESCRIPTION
* Moves the entry for #1193 to "unreleased", since it was not part of the v229 release.
* Fixes the date for the v229 release (it was published to the buildpack registry on `2021-08-30T15:57:32.024Z`).
* Turns the `Main` heading into an H2 so it's at the same heading level as the versioned headings.