### PR TITLE
Update Node and Yarn default versions

### DIFF
--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class LanguagePack::Helpers::Nodebin
   def self.hardcoded_node_lts
-    version = "12.16.2"
+    version = "16.13.0"
     {
       "number" => version,
       "url"    => "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"
@@ -10,7 +10,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_yarn
-    version = "1.22.4"
+    version = "1.22.17"
     {
       "number" => version,
       "url"    => "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v#{version}.tar.gz"


### PR DESCRIPTION
Updates Node to latest LTS and Yarn to latest version.

See https://github.com/heroku/heroku-buildpack-ruby/issues/1214 for details.