### PR TITLE
Update Ruby's default Node and Yarn versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Main (unreleased)
 
+* Default node version now 16.13.1, yarn is 1.22.17 (https://github.com/heroku/heroku-buildpack-ruby/pull/1238)
 * Remove instrumentation and LPXC logic (https://github.com/heroku/heroku-buildpack-ruby/pull/1229)
 
 ## v232 (11/9/2021)

--- a/changelogs/unreleased/node_yarn.md
+++ b/changelogs/unreleased/node_yarn.md
@@ -3,6 +3,6 @@
 Applications using the `heroku/ruby` buildpack that do not have a version of Node installed by another buildpack (such as the `heroku/nodejs` buildpack) will now receive:
 
 - Node version 16.13.1 (was previously 12.16.2)
-- Yarn version 1.2.17 (was previously 1.22.4)
+- Yarn version 1.22.17 (was previously 1.22.4)
 
 These versions and instructions on how to specify a specific version of these binaries can be found on the [installed binaries section of the Heroku Ruby Support page](https://devcenter.heroku.com/articles/ruby-support#installed-binaries).

--- a/changelogs/unreleased/node_yarn.md
+++ b/changelogs/unreleased/node_yarn.md
@@ -1,0 +1,8 @@
+## Ruby apps now default to Node version 16.13.1 and Yarn version 1.22.17
+
+Applications using the `heroku/ruby` buildpack that do not have a version of Node installed by another buildpack (such as the `heroku/nodejs` buildpack) will now receive:
+
+- Node version 16.13.1 (was previously 12.16.2)
+- Yarn version 1.2.17 (was previously 1.22.4)
+
+These versions and instructions on how to specify a specific version of these binaries can be found on the [installed binaries section of the Heroku Ruby Support page](https://devcenter.heroku.com/articles/ruby-support#installed-binaries).

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class LanguagePack::Helpers::Nodebin
   def self.hardcoded_node_lts
-    version = "12.16.2"
+    version = "16.13.1"
     {
       "number" => version,
       "url"    => "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"
@@ -10,7 +10,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_yarn
-    version = "1.22.4"
+    version = "1.22.17"
     {
       "number" => version,
       "url"    => "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v#{version}.tar.gz"


### PR DESCRIPTION
Applications using the `heroku/ruby` buildpack that do not have a version of Node installed by another buildpack (such as the `heroku/nodejs` buildpack) will now receive:

- Node version 16.13.1 (was previously 12.16.2)
- Yarn version 1.2.17 (was previously 1.22.4)


GUS-W-10255676