### PR TITLE
Fix Rails 7 tests

### DIFF
--- a/hatchet.lock
+++ b/hatchet.lock
@@ -46,7 +46,7 @@
 - - "./repos/rails_versions/active_storage_non_local"
   - 86dddf0127043abba1cb2890590a1d38f111edbd
 - - "./repos/rails_versions/rails-jsbundling"
-  - 6b60a3aa7eb9507865ebba6afcca150017ab66b4
+  - 192a71e0931aa00724412521dcad4d1e1db2ec0f
 - - "./repos/rails_versions/rails3_default_ruby"
   - a6b44db674c0d3538633989295e2cfd5e8e1ba0d
 - - "./repos/rails_versions/rails42_default_ruby"

--- a/spec/hatchet/rails7_spec.rb
+++ b/spec/hatchet/rails7_spec.rb
@@ -9,8 +9,6 @@ describe "Rails 6" do
   end
 
   it "works with jsbundling" do
-    skip("rails-turbo was yanked and I don't know why")
-
     Hatchet::Runner.new("rails-jsbundling").tap do |app|
       app.deploy do
         expect(app.output).to include("yarn install")


### PR DESCRIPTION
This test started failing because the `turbo-rails` gem we were using was yanked. https://github.com/hotwired/turbo-rails/issues/273. This commit revs the hatchet lock version to point at the latest changes to the fixture: https://github.com/sharpstone/rails-jsbundling/commit/192a71e0931aa00724412521dcad4d1e1db2ec0f

GUS-W-10261468