### PR TITLE
Reintroduce PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
+    open-pull-requests-limit: 1 # Limit concurrent CI runs from executing, do not remove
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
When multiple PRs are opened concurrently multiple tests are fired off. These all compete for the same API limits. Hatchet has baked in rate limiter. When it runs out of API requests, it will slow down. If too many concurrent CI executions are kicked off at one time, all the builds slow one another down, and prevent any of them from completing.