### PR TITLE
Fix database.yml indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Main (unreleased)
 
+## v234 (12/16/2021)
+
+* Fix YML indentation from v233 (https://github.com/heroku/heroku-buildpack-ruby/pull/1252)
+
 ## v233 (12/16/2021)
 
 * Default node version now 16.13.1, yarn is 1.22.17 (https://github.com/heroku/heroku-buildpack-ruby/pull/1238)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -905,25 +905,25 @@ require 'cgi'
 require 'uri'
 
 begin
-uri = URI.parse(ENV["DATABASE_URL"])
+  uri = URI.parse(ENV["DATABASE_URL"])
 rescue URI::InvalidURIError
-raise "Invalid DATABASE_URL"
+  raise "Invalid DATABASE_URL"
 end
 
 raise "No RACK_ENV or RAILS_ENV found" unless ENV["RAILS_ENV"] || ENV["RACK_ENV"]
 
 def attribute(name, value, force_string = false)
-if value
-  value_string =
-    if force_string
-      '"' + value + '"'
-    else
-      value
-    end
-  "\#{name}: \#{value_string}"
-else
-  ""
-end
+  if value
+    value_string =
+      if force_string
+        '"' + value + '"'
+      else
+        value
+      end
+    "\#{name}: \#{value_string}"
+  else
+    ""
+  end
 end
 
 adapter = uri.scheme
@@ -942,15 +942,15 @@ params = CGI.parse(uri.query || "")
 %>
 
 <%= ENV["RAILS_ENV"] || ENV["RACK_ENV"] %>:
-<%= attribute "adapter",  adapter %>
-<%= attribute "database", database %>
-<%= attribute "username", username %>
-<%= attribute "password", password, true %>
-<%= attribute "host",     host %>
-<%= attribute "port",     port %>
+  <%= attribute "adapter",  adapter %>
+  <%= attribute "database", database %>
+  <%= attribute "username", username %>
+  <%= attribute "password", password, true %>
+  <%= attribute "host",     host %>
+  <%= attribute "port",     port %>
 
 <% params.each do |key, value| %>
-<%= key %>: <%= value.first %>
+  <%= key %>: <%= value.first %>
 <% end %>
         DATABASE_YML
       end

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v233"
+    BUILDPACK_VERSION = "v234"
   end
 end


### PR DESCRIPTION
Close #1250

In https://github.com/heroku/heroku-buildpack-ruby/pull/1229/files#diff-d7f6f21bc5e80a7032506dae28ef835682a02ae9d2d9d162faccf793a826f1bcR944-R950 a helper method with a block was removed. All code within the block was indented. When the block was removed the indentation was incorrectly collapsed for the `config/database.yml` heredoc.

Prior to Rails 4.1 Heroku would over-write any database.yml to read from DATABASE_URL https://devcenter.heroku.com/changelog-items/709.

This is running tests, and adding a changelog for #1251