### PR TITLE
Specialize Rails7 Database setup on Heroku CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Fix deprecated rake tasks for Rails 7 on Heroku CI (https://github.com/heroku/heroku-buildpack-ruby/pull/1257)
+
 ## v235 (2022/01/03)
 
 * Bundler 2.x is now 2.2.33 (https://github.com/heroku/heroku-buildpack-ruby/pull/1248)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+## v236 (2022/01/04)
+
 * Fix deprecated rake tasks for Rails 7 on Heroku CI (https://github.com/heroku/heroku-buildpack-ruby/pull/1257)
 
 ## v235 (2022/01/03)

--- a/Rakefile
+++ b/Rakefile
@@ -95,6 +95,11 @@ namespace :buildpack do
 
       changelog_md.write(contents.gsub("## Main (unreleased)", new_section))
     end
+
+    version_rb = Pathname(__dir__).join("lib/language_pack/version.rb")
+    puts "Updating version.rb"
+    contents =  version_rb.read.gsub(/BUILDPACK_VERSION = .*$/, %Q{BUILDPACK_VERSION = "#{deploy.next_version.to_s}"})
+    version_rb.write(contents)
   end
 
   desc "releases the next version of the buildpack"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -46,7 +46,7 @@
 - - "./repos/rails_versions/active_storage_non_local"
   - 86dddf0127043abba1cb2890590a1d38f111edbd
 - - "./repos/rails_versions/rails-jsbundling"
-  - 192a71e0931aa00724412521dcad4d1e1db2ec0f
+  - 34bd25cef7c09758b3e7763a5d4be6dc94364606
 - - "./repos/rails_versions/rails3_default_ruby"
   - a6b44db674c0d3538633989295e2cfd5e8e1ba0d
 - - "./repos/rails_versions/rails42_default_ruby"

--- a/lib/language_pack/test.rb
+++ b/lib/language_pack/test.rb
@@ -3,5 +3,8 @@ require "language_pack"
 module LanguagePack::Test
 end
 
+# Behavior changes for the test pack work by opening existing language_pack
+# classes and over-writing their behavior to extend test functionality
 require "language_pack/test/ruby"
 require "language_pack/test/rails2"
+require "language_pack/test/rails7"

--- a/lib/language_pack/test/rails2.rb
+++ b/lib/language_pack/test/rails2.rb
@@ -1,4 +1,5 @@
-#module LanguagePack::Test::Rails2
+# Opens up the class of the Rails2 language pack and
+# overwrites methods defined in `language_pack/test/ruby.rb`
 class LanguagePack::Rails2
   # sets up the profile.d script for this buildpack
   def setup_profiled(ruby_layer_path: , gem_layer_path: )
@@ -51,7 +52,6 @@ FILE
     end
   end
 
-  private
   def db_prepare_test_rake_tasks
     schema_load    = rake.task("db:schema:load_if_ruby")
     structure_load = rake.task("db:structure:load_if_sql")

--- a/lib/language_pack/test/rails7.rb
+++ b/lib/language_pack/test/rails7.rb
@@ -1,0 +1,9 @@
+# Opens up the class of the Rails7 language pack and
+# overwrites methods defined in `language_pack/test/ruby.rb` or `language_pack/test/rails2.rb`
+class LanguagePack::Rails7
+  # Rails removed the db:schema:load_if_ruby and `db:structure:load_if_sql` tasks
+  # they've been replaced by `db:schema:load` instead
+  def db_prepare_test_rake_tasks
+    ["db:schema:load", "db:migrate"].map {|name| rake.task(name) }
+  end
+end

--- a/lib/language_pack/test/ruby.rb
+++ b/lib/language_pack/test/ruby.rb
@@ -1,4 +1,8 @@
-#module LanguagePack::Test::Ruby
+# Opens up the class of the Ruby language pack and
+# overwrites methods defined in `language_pack/ruby.rb`
+#
+# Other "test packs" futher extend this behavior by hooking into
+# methods or over writing methods defined here.
 class LanguagePack::Ruby
   def compile
     new_app?
@@ -26,7 +30,6 @@ class LanguagePack::Ruby
     super
   end
 
-  private
   def db_prepare_test_rake_tasks
     ["db:schema:load", "db:migrate"].map {|name| rake.task(name) }
   end

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v234"
+    BUILDPACK_VERSION = "v236"
   end
 end

--- a/spec/hatchet/rails7_spec.rb
+++ b/spec/hatchet/rails7_spec.rb
@@ -16,4 +16,11 @@ describe "Rails 6" do
       end
     end
   end
+
+  it "Works on Heroku CI" do
+    Hatchet::Runner.new("rails-jsbundling").run_ci do |test_run|
+      expect(test_run.output).to match("db:schema:load")
+      expect(test_run.output).to match("db:migrate")
+    end
+  end
 end


### PR DESCRIPTION
## Part 1: Test Rails 7 on Heroku CI

Added a test for Rails 7 to exercise behavior in https://github.com/heroku/heroku-buildpack-ruby/issues/1254. Update the Rails 7 example app to use the released version instead of alpha. Also, I updated the app to be a Heroku CI compatible app (adds app.json):

- https://github.com/sharpstone/rails-jsbundling/commit/34bd25cef7c09758b3e7763a5d4be6dc94364606
- https://github.com/sharpstone/rails-jsbundling/commit/a98a4e41708b48a36a0adb941df4b7d28d25d5d5
- https://github.com/sharpstone/rails-jsbundling/commit/b4ec664cbe63dd9176884f746f64a46bed879c21
- https://github.com/sharpstone/rails-jsbundling/commit/1fb48b40bf506fbc3fb7c00a67e8f98dce82ac07

Add CI tests against Rails 7. Which was needed to test specialization

## Part 2: Rails 7 Rake tasks for tests 

### Background

The Ruby buildpack sets up a Rails app's database for a customer. In Rails there are individual migrations which will add or remove a single table/column/etc. Then there is a "schema" that captures the final result of the whole process. Running individual migrations is fragile and prone to break it's also slow. To speed things up we first apply the saved schema, then we run the migrations.

Rails has two different formats for storing schema. There is a simplified "ruby" format that uses a DSL to describe the schema of the database. This is easy to read and understand but it doesn't support database specific calls (for example a GIN index in postgres cannot be applied to a Mysql database). So before we can apply a schema we have to determine which format of schema the developer wants us to apply.

Both schema formats can live in the app at the same time and they can be switched via a config flag in the app.

We handled that previously by calling these two tasks if they existed:

```
    schema_load    = rake.task("db:schema:load_if_ruby")
    structure_load = rake.task("db:structure:load_if_sql")
```

Otherwise we would fallback on calling:

```
rails runner 'puts ActiveRecord::Base.schema_format'
```

In Rails 6.1 the tasks used for database setup in our test pack were deprecated. They were removed in Rails 7 https://edgeguides.rubyonrails.org/7_0_release_notes.html. Existing Rails 7 apps still fallback to the `rails runner` method but it is slower and error prone see #1254.

### Fix

This PR moves to specialize the tasks for Rails7+ to use `db:schema:load` per deprecation instruction:

```
DEPRECATION WARNING: Using `bin/rails db:schema:load_if_ruby` is deprecated and will be removed in Rails 7.0. Configure the format using `config.active_record.schema_format = :ruby` to use `schema.rb` and run `bin/rails db:schema:load` instead. (called from <main> at /app/bin/rake:4)
```

That task will handle the logic for both determining the schema format and applying the schema.

GUS-W-10372684