### PR TITLE
Update default Ruby version to 3.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - pack/install-pack:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,72 @@
 version: 2.1
 orbs:
-  buildpacks: jkutner/buildpacks@0.1.0
-  ruby: circleci/ruby@0.2.1
+  pack: buildpacks/pack@0.2.4
+
 jobs:
   build:
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-02
     steps:
-      - buildpacks/install-pack:
-          version: "0.11.0"
       - checkout
+      - pack/install-pack:
+          version: 0.23.0
+      - restore_cache:
+          keys:
+            - v3-ruby-3.0.3
+            - v3-deps
+
+      - run:
+          name: Install ruby-install
+          command: |
+              wget -O ruby-install-0.8.3.tar.gz https://github.com/postmodern/ruby-install/archive/v0.8.3.tar.gz
+              tar -xzvf ruby-install-0.8.3.tar.gz
+              cd ruby-install-0.8.3/
+              sudo make install
+      - run:
+          name: Install chruby
+          command: |
+              wget -O chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
+              tar -xzvf chruby-0.3.9.tar.gz
+              cd chruby-0.3.9/
+              sudo make install
+
+      - run:
+          name: Ruby install
+          command: |
+              ruby-install ruby 3.0.3 --no-reinstall
+
+      - run:
+          name: Set chruby defaults
+          command: |
+            echo 'source /usr/local/share/chruby/chruby.sh' >> $BASH_ENV
+            echo 'chruby ruby-3.0.3' >> $BASH_ENV
+
+      - save_cache:
+          key: v3-ruby-3.0.3
+          paths:
+            - "~/.rubies"
+
       - run:
           command: |
-            rvm install 2.7.5
-            rvm use ruby-2.7.5
-            export PATH="/opt/circleci/.rvm/rubies/ruby-2.7.5/bin:$PATH"
-            export GEM_HOME="/opt/circleci/.rvm/gems/ruby-2.7.5"
-            export GEM_PATH="/opt/circleci/.rvm/gems/ruby-2.7.5"
-            gem install bundler -v 2.1.0
+            rvm implode --force
+            chruby 3.0.3
+
+            gem install bundler -v 2.2.32 --no-document
+            bundle config deployment 'true'
+            bundle config path ./vendor/bundle
             bundle install
+            bundle clean
+
             bundle exec rake hatchet:setup_ci
             echo "pack version: $(pack --version)"
-            rspec spec/cnb/
+
+            bundle exec rspec spec/cnb/
+
+      - save_cache:
+          key: v3-deps
+          paths:
+            - "./vendor/bundle"
+            - "./repos"
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.23.0
+          version: 0.24.0
       - restore_cache:
           keys:
             - v3-ruby-3.0.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
       - restore_cache:
           keys:
             - v3-ruby-3.0.3
-            - v3-deps
 
       - run:
           name: Install ruby-install
@@ -61,12 +60,6 @@ jobs:
             echo "pack version: $(pack --version)"
 
             bundle exec rspec spec/cnb/
-
-      - save_cache:
-          key: v3-deps
-          paths:
-            - "./vendor/bundle"
-            - "./repos"
 
 workflows:
   main:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Default Ruby version is now 3.0.3 (https://github.com/heroku/heroku-buildpack-ruby/pull/1270)
+
 ## v236 (2022/01/04)
 
 * Fix deprecated rake tasks for Rails 7 on Heroku CI (https://github.com/heroku/heroku-buildpack-ruby/pull/1257)

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.5'
+ruby '3.0.3'
 
 group :development, :test do
   gem "toml-rb"
@@ -16,4 +16,5 @@ group :development, :test do
   gem 'ci-queue'
   gem 'redis'
   gem 'dead_end'
+  gem 'cutlass'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.11.0)
-    thor (1.1.0)
+    thor (1.2.1)
     threaded (0.0.4)
     toml-rb (2.1.2)
       citrus (~> 3.0, > 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,13 @@ GEM
   specs:
     ci-queue (0.22.1)
     citrus (3.0.2)
+    cutlass (0.3.0)
+      docker-api (>= 2.0)
     dead_end (3.1.1)
     diff-lcs (1.5.0)
+    docker-api (2.2.0)
+      excon (>= 0.47.0)
+      multi_json
     erubis (2.7.0)
     excon (0.91.0)
     heroics (0.1.2)
@@ -52,6 +57,7 @@ PLATFORMS
 
 DEPENDENCIES
   ci-queue
+  cutlass
   dead_end
   excon
   heroku_hatchet
@@ -65,7 +71,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 3.0.3p157
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ id = "heroku/ruby"
 version = "0.1.4"
 name = "Ruby"
 homepage = "https://github.com/heroku/heroku-buildpack-ruby"
-ruby_version = "2.7.5"
+ruby_version = "3.0.3"
 
 [publish]
 
@@ -13,11 +13,11 @@ ruby_version = "2.7.5"
 files = ["spec/"]
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.7.5.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-3.0.3.tgz"
 dir = "vendor/ruby/heroku-18"
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.7.5.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-3.0.3.tgz"
 dir = "vendor/ruby/heroku-20"
 
 [[stacks]]

--- a/changelogs/unreleased/ruby_303_default.md
+++ b/changelogs/unreleased/ruby_303_default.md
@@ -1,0 +1,3 @@
+## Default Ruby version for new apps is now 3.0.3
+
+The [default Ruby version for new Ruby applications is 3.0.3](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.

--- a/hatchet.json
+++ b/hatchet.json
@@ -13,12 +13,10 @@
     "sharpstone/git_gemspec",
     "sharpstone/no_lockfile",
     "sharpstone/sqlite3_gemfile",
-    "sharpstone/nokogiri_160",
-    "sharpstone/bundle-ruby-version-not-in-lockfile"
+    "sharpstone/nokogiri_160"
   ],
   "ruby": [
     "sharpstone/ruby_version_does_not_exist",
-    "sharpstone/cd_ruby",
     "sharpstone/ruby_193_jruby_173",
     "sharpstone/ruby_193_jruby_176",
     "sharpstone/ruby_193_jruby_17161_jdk7",

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -20,9 +20,9 @@
 - - "./repos/ci/heroku-ci-json-example"
   - 4e5410a7381f486ba3df7739e02e52f32fdd4dda
 - - "./repos/ci/rails5_ruby_schema_format"
-  - d76be86c66ae8f45ec611fb2c4d8eb3adac0ad4b
+  - 8b8a3a7850bdba29bdefc70c0f80f35a9e6c96ae
 - - "./repos/ci/rails5_sql_schema_format"
-  - df48237c57f89bb3629937ae6b1d6af070100ed3
+  - ee81b300a1019b47bbcaec0a512932df7dc23bc0
 - - "./repos/ci/ruby_no_rails_test"
   - 3916137106d59b008b67d738abe6a1438f8fbde6
 - - "./repos/heroku/ruby-getting-started"
@@ -30,7 +30,7 @@
 - - "./repos/jruby/jruby_naether"
   - 4a11f8af5a3cca21f3659394e5bbac3cca9b6a2c
 - - "./repos/node/minimal_webpacker"
-  - bca8b8169c553a0f62f0263b621cf3a5813e4023
+  - 9d55c0ee923824829305eb23e23b7ff98d2ee3ba
 - - "./repos/rack/default_ruby"
   - master
 - - "./repos/rack/mri_187_nokogiri"
@@ -46,7 +46,7 @@
 - - "./repos/rails_versions/active_storage_non_local"
   - 86dddf0127043abba1cb2890590a1d38f111edbd
 - - "./repos/rails_versions/rails-jsbundling"
-  - 34bd25cef7c09758b3e7763a5d4be6dc94364606
+  - f2c1455efb5892208b08a4a964e7f8e692b9b6f9
 - - "./repos/rails_versions/rails3_default_ruby"
   - a6b44db674c0d3538633989295e2cfd5e8e1ba0d
 - - "./repos/rails_versions/rails42_default_ruby"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -1,8 +1,6 @@
 ---
 - - "./repos/bundler/bad_gemfile_on_platform"
   - 5dd45c83631f58d121afb48b513016cc9e2d3432
-- - "./repos/bundler/bundle-ruby-version-not-in-lockfile"
-  - 5c8219d8bbdc8faa6a98781867b9fce25a6f2abb
 - - "./repos/bundler/git_gemspec"
   - 7755e19caf122e1373bce73ffe9b333e9411d732
 - - "./repos/bundler/no_lockfile"
@@ -75,8 +73,6 @@
   - 6e4662c44b49e2c3c9429f00e7e7f4708142b03f
 - - "./repos/ruby/bad_ruby_version"
   - 7bf3470265a87ea6361640aa4bfce6ce3b743520
-- - "./repos/ruby/cd_ruby"
-  - 88df7181e301d25a8da992107747acff62670327
 - - "./repos/ruby/empty-procfile"
   - 7cae0aae424c2028b81b5d37ee24d42db8e545b9
 - - "./repos/ruby/jruby-minimal"

--- a/lib/language_pack/rack.rb
+++ b/lib/language_pack/rack.rb
@@ -34,8 +34,8 @@ class LanguagePack::Rack < LanguagePack::Ruby
 private
 
   # sets up the profile.d script for this buildpack
-  def setup_profiled(*args)
-    super(*args)
+  def setup_profiled(**args)
+    super(**args)
     set_env_default "RACK_ENV", "production"
   end
 

--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -89,8 +89,8 @@ private
   end
 
   # sets up the profile.d script for this buildpack
-  def setup_profiled(*args)
-    super(*args)
+  def setup_profiled(**args)
+    super(**args)
     default_env_vars.each do |key, value|
       set_env_default key, value
     end

--- a/lib/language_pack/rails41.rb
+++ b/lib/language_pack/rails41.rb
@@ -13,8 +13,8 @@ class LanguagePack::Rails41 < LanguagePack::Rails4
     return is_rails4
   end
 
-  def setup_profiled(*args)
-    super(*args)
+  def setup_profiled(**args)
+    super(**args)
     set_env_default "SECRET_KEY_BASE", app_secret
   end
 

--- a/lib/language_pack/rails42.rb
+++ b/lib/language_pack/rails42.rb
@@ -12,8 +12,8 @@ class LanguagePack::Rails42 < LanguagePack::Rails41
     return is_rails42
   end
 
-  def setup_profiled(*args)
-    super(*args)
+  def setup_profiled(**args)
+    super(**args)
     set_env_default "RAILS_SERVE_STATIC_FILES", "enabled"
   end
 

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -12,8 +12,8 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
     return is_rails
   end
 
-  def setup_profiled(*args)
-    super(*args)
+  def setup_profiled(**args)
+    super(**args)
     set_env_default "RAILS_LOG_TO_STDOUT", "enabled"
   end
 

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,7 +12,7 @@ module LanguagePack
       end
     end
 
-    DEFAULT_VERSION_NUMBER = "2.7.5".freeze
+    DEFAULT_VERSION_NUMBER = "3.0.3".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}".freeze

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -11,14 +11,24 @@ describe "CI" do
   end
 
   it "Works with Rails 5 ruby schema apps" do
-    Hatchet::Runner.new("rails5_ruby_schema_format").run_ci do |test_run|
-      expect(test_run.output).to match("db:schema:load_if_ruby completed")
+    Hatchet::Runner.new("rails5_ruby_schema_format").tap do |app|
+      app.before_deploy do
+        Pathname("Gemfile").write("ruby '2.7.5'", mode: "a")
+      end
+      app.run_ci do |test_run|
+        expect(test_run.output).to match("db:schema:load_if_ruby completed")
+      end
     end
   end
 
   it "Works with Rails 5 SQL schema apps" do
-    Hatchet::Runner.new("rails5_sql_schema_format").run_ci do |test_run|
-      expect(test_run.output).to match("db:structure:load_if_sql completed")
+    Hatchet::Runner.new("rails5_sql_schema_format").tap do |app|
+      app.before_deploy do
+        Pathname("Gemfile").write("ruby '2.7.5'", mode: "a")
+      end
+      app.run_ci do |test_run|
+        expect(test_run.output).to match("db:structure:load_if_sql completed")
+      end
     end
   end
 

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -54,28 +54,21 @@ describe "Ruby versions" do
       end
     end
   end
-
-  it "should deploy jruby with the naether gem" do
-    app = Hatchet::Runner.new("jruby_naether", stack: DEFAULT_STACK)
-    app.deploy do |app|
-      expect(app.output).to match("Installing naether")
-      expect(app.output).not_to include("An error occurred while installing naether")
-    end
-  end
 end
 
 describe "Upgrading ruby apps" do
-  it "works when changing from default version" do
+  it "works when changing versions" do
     app = Hatchet::Runner.new("default_ruby", stack: DEFAULT_STACK)
     app.deploy do |app|
       expect(app.run("env | grep MALLOC_ARENA_MAX")).to match("MALLOC_ARENA_MAX=2")
       expect(app.run("env | grep DISABLE_SPRING")).to match("DISABLE_SPRING=1")
 
-      run!(%Q{echo "ruby '2.5.1'" >> Gemfile})
+      # Deploy again
+      run!(%Q{echo "ruby '2.7.5'" >> Gemfile})
       run!("git add -A; git commit -m update-ruby")
       app.push!
-      expect(app.output).to match("2.5.1")
-      expect(app.run("ruby -v")).to match("2.5.1")
+      expect(app.output).to match("2.7.5")
+      expect(app.run("ruby -v")).to match("2.7.5")
       expect(app.output).to match("Ruby version change detected")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,27 @@ ENV['RACK_ENV'] = 'test'
 
 DEFAULT_STACK = 'heroku-18'
 
+
+def hatchet_path(path = "")
+  Pathname(__FILE__).join("../../repos").expand_path.join(path)
+end
+
+puts hatchet_path
+
+require 'cutlass'
+
+RUBY_BUILDPACK = Cutlass::LocalBuildpack.new(directory: Pathname(__dir__).join(".."))
+Cutlass.config do |config|
+  config.default_builder = "heroku/buildpacks:20"
+
+  # Where do your test fixtures live?
+  config.default_repo_dirs = hatchet_path("").children
+
+  # Where does your buildpack live?
+  # Can be a directory or a Cutlass:LocalBuildpack instance
+  config.default_buildpack_paths = [RUBY_BUILDPACK]
+end
+
 RSpec.configure do |config|
   config.filter_run focused: true unless ENV['IS_RUNNING_ON_CI']
   config.run_all_when_everything_filtered = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ ENV["HATCHET_BUILDPACK_BASE"] ||= "https://github.com/heroku/heroku-buildpack-ru
 
 ENV['RACK_ENV'] = 'test'
 
-DEFAULT_STACK = 'heroku-18'
+DEFAULT_STACK = 'heroku-20'
 
 
 def hatchet_path(path = "")


### PR DESCRIPTION
## Default Ruby version

Our unstated policy is to use the latest patch version of the prior significant release. Since 3.1.0 came out in December 25th 2021 the prior version is 3.0.3.

## CircleCI Ruby version
 
I'm unable to get RVM working with 3.0.3 for some reason on circleci. We need an exact ruby version, not just any 3.0.x version so their images won't work. I'm switching over to ruby-install and chruby for total control. I first tried installing via apt-get and for some reason it couldn't find them even after running an apt-get update.

This is gnarly, but it works and gives me a lot of control. It's frustrating to have to go down this route, but I feel good about the final solution

## CircleCI docker setup

Cutlass interfaces with docker through the API and needs a different setup otherwise it fails with error:

```
       stderr: ERROR: downloading buildpack from docker://cutlass_local_buildpack_21223a55e82b762fde3c: unsupported protocol docker in URI docker://cutlass_local_buildpack_21223a55e82b762fde3c
     # /home/circleci/.gem/ruby/3.0.3/gems/cutlass-0.3.0/lib/cutlass/pack_build.rb:96:in `call_pack'
     # /home/circleci/.gem/ruby/3.0.3/gems/cutlass-0.3.0/lib/cutlass/pack_build.rb:73:in `call'
     # /home/circleci/.gem/ruby/3.0.3/gems/cutlass-0.3.0/lib/cutlass/app.rb:118:in `pack_build'
     # ./spec/cnb/basic_local_pack_spec.rb:88:in `block (3 levels) in <top (required)>'
```


## Ruby 3 syntax

I hit some issues with kwargs and super. Using `**` instead of `*` in the repo itself.

## CNB runner

The home-brew cnb runner was failing and I don't know why. Switching to cutlass fixed the issues. It wasn't worth it to investigate more.

## Fixtures

Some of the fixtures needed to be updated to work with 3.0.x. Some of them needed to be pinned to a non-default version of Ruby as they don't support Ruby 3.0.x