### PR TITLE
Rollback bundler change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Main (unreleased)
 
+## v239 (2022/03/02)
+
+* Rollback bundler 2.x change. Bundler 2.x is now back at 2.2.33 (https://github.com/heroku/heroku-buildpack-ruby/pull/1281)
+
 ## v238 (2022/03/02)
 
 * Bundler 2.x is now 2.3.7 (https://github.com/heroku/heroku-buildpack-ruby/pull/1276)

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.3.7"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.2.33"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v238"
+    BUILDPACK_VERSION = "v239"
   end
 end


### PR DESCRIPTION
Bundler 2.3.7 caused issues:

- https://github.com/rubygems/rubygems/issues/5351
- https://github.com/heroku/heroku-buildpack-ruby/issues/1280 


Internal (private) tickets:

- https://heroku.support/1083230
- https://heroku.support/1081495
- https://heroku.support/1082829


I've already rolled back the build pack deploy via the buildpack CLI. This commit is intended to represent the currently deployed software accurately in the codebase.