### PR TITLE
Split bootstrap version from default version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           version: 0.24.0
       - restore_cache:
           keys:
-            - v3-ruby-3.0.3
+            - v3-ruby-3.1.1
 
       - run:
           name: Install ruby-install
@@ -32,23 +32,23 @@ jobs:
       - run:
           name: Ruby install
           command: |
-              ruby-install ruby 3.0.3 --no-reinstall
+              ruby-install ruby 3.1.1 --no-reinstall
 
       - run:
           name: Set chruby defaults
           command: |
             echo 'source /usr/local/share/chruby/chruby.sh' >> $BASH_ENV
-            echo 'chruby ruby-3.0.3' >> $BASH_ENV
+            echo 'chruby ruby-3.1.1' >> $BASH_ENV
 
       - save_cache:
-          key: v3-ruby-3.0.3
+          key: v3-ruby-3.1.1
           paths:
             - "~/.rubies"
 
       - run:
           command: |
             rvm implode --force
-            chruby 3.0.3
+            chruby 3.1.1
 
             gem install bundler -v 2.2.32 --no-document
             bundle config deployment 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Add support for heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1289)
+
 ## v239 (2022/03/02)
 
 * Rollback bundler 2.x change. Bundler 2.x is now back at 2.2.33 (https://github.com/heroku/heroku-buildpack-ruby/pull/1281)

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.3'
+ruby '3.1.1'
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.1.1p18
 
 BUNDLED WITH
-   2.2.32
+   2.3.10

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,7 +21,7 @@ url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-
 dir = "vendor/ruby/heroku-20"
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-3.1.1.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-22/ruby-3.1.1.tgz"
 dir = "vendor/ruby/heroku-22"
 
 [[stacks]]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ id = "heroku/ruby"
 version = "0.1.4"
 name = "Ruby"
 homepage = "https://github.com/heroku/heroku-buildpack-ruby"
-ruby_version = "3.0.3"
+ruby_version = "3.1.1"
 
 [publish]
 
@@ -13,18 +13,25 @@ ruby_version = "3.0.3"
 files = ["spec/"]
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-3.0.3.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-3.1.1.tgz"
 dir = "vendor/ruby/heroku-18"
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-3.0.3.tgz"
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-3.1.1.tgz"
 dir = "vendor/ruby/heroku-20"
+
+[[publish.Vendor]]
+url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-3.1.1.tgz"
+dir = "vendor/ruby/heroku-22"
 
 [[stacks]]
 id = "heroku-18"
 
 [[stacks]]
 id = "heroku-20"
+
+[[stacks]]
+id = "heroku-22"
 
 [metadata]
 

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,6 +12,7 @@ module LanguagePack
       end
     end
 
+    BOOTSTRAP_VERSION_NUMBER = "3.1.1".freeze
     DEFAULT_VERSION_NUMBER = "3.0.3".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze

--- a/spec/helpers/config_spec.rb
+++ b/spec/helpers/config_spec.rb
@@ -1,17 +1,22 @@
 require 'spec_helper'
 
 describe "Boot Strap Config" do
-  it "matches the default ruby version" do
+  it "matches toml config" do
     require 'toml-rb'
     config = TomlRB.load_file("buildpack.toml")
     bootstrap_version = config["buildpack"]["ruby_version"]
-    expect(bootstrap_version).to eq(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+    expect(bootstrap_version).to eq(LanguagePack::RubyVersion::BOOTSTRAP_VERSION_NUMBER)
 
     urls = config["publish"]["Vendor"].map {|h| h["url"] if h["dir"] != "." }.compact
     urls.each do |url|
       expect(url.include?(bootstrap_version)).to be_truthy, "expected #{url.inspect} to include #{bootstrap_version.inspect} but it did not"
     end
 
-    expect(`ruby -v`).to match(Regexp.escape(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER))
+    expect(`ruby -v`).to match(Regexp.escape(LanguagePack::RubyVersion::BOOTSTRAP_VERSION_NUMBER))
+
+    bootstrap_version = Gem::Version.new(LanguagePack::RubyVersion::BOOTSTRAP_VERSION_NUMBER)
+    default_version = Gem::Version.new(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+
+    expect(bootstrap_version).to be >= default_version
   end
 end


### PR DESCRIPTION
Currently the bootstrapped version of Ruby is coupled to the default version we give customers who do not specify a version. 

With heroku-22 (based on Ubuntu 22.04) we cannot use the current default (3.0.3) because it cannot compile for heroku-22 https://bugs.ruby-lang.org/issues/18658.

This change provides a second mechanism for specifying the bootstrapped version.

GUS-W-10343881