### PR TITLE
Enable heroku-22 download presence check

### DIFF
--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -16,7 +16,7 @@
 #    puts download.exists? #=> true
 #    puts download.valid_stack_list #=> ['cedar-14']
 class LanguagePack::Helpers::DownloadPresence
-  STACKS = ['heroku-18', 'heroku-20']
+  STACKS = ['heroku-18', 'heroku-20', 'heroku-22']
 
   def initialize(path, stacks: STACKS)
     @path = path

--- a/spec/helpers/download_presence_spec.rb
+++ b/spec/helpers/download_presence_spec.rb
@@ -69,7 +69,7 @@ describe LanguagePack::Helpers::DownloadPresence do
 
   it "detects default ruby version" do
     download = LanguagePack::Helpers::DownloadPresence.new(
-      "#{LanguagePack::RubyVersion::DEFAULT_VERSION}.tgz",
+      "ruby-3.1.1.tgz",
     )
 
     download.call
@@ -84,7 +84,7 @@ describe LanguagePack::Helpers::DownloadPresence do
     )
 
     download.call
-    
+
     expect(download.supported_stack?(current_stack: "unknown-stack")).to be_falsey
     expect(download.next_stack(current_stack: "unknown-stack")).to be_nil
     expect(download.exists_on_next_stack?(current_stack:"unknown-stack")).to be_falsey


### PR DESCRIPTION
Adding this does two things. It turns on the download check for anyone trying to deploy to heroku-22. This will suggest a different stack if a binary is not found. For example if a customer wants to use 2.5.4 on heroku-22 it would suggest they try to deploy to heroku-18 or heroku-20 instead as heroku-22 doesn't have that binary.

In theory it could also affect customers on other stacks trying to use a version of Ruby not available on their stack (but present on heroku-22). If that happens they'll see heroku-22 in their stack suggestions. While it's technically a possibility the only supported stacks now are heroku-18 and heroku-20 and they have all the binaries (and more) that heroku-22 has.

GUS-W-10343881