### PR TITLE
v241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Main (unreleased)
 
+## v241 (2022/06/01)
+
+* Download presence check now includes heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1290)
+
 ## v240 (2022/04/05)
 
 * Add support for heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1289)

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v240"
+    BUILDPACK_VERSION = "v241"
   end
 end

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -2,9 +2,9 @@ require_relative "../spec_helper"
 
 describe "Stack Changes" do
   xit "should reinstall gems on stack change" do
-    Hatchet::Runner.new('default_ruby', stack: "heroku-18").deploy do |app|
-      app.update_stack("heroku-20")
-      run!('git commit --allow-empty -m "heroku-20 migrate"')
+    Hatchet::Runner.new('default_ruby', stack: "heroku-20").deploy do |app|
+      app.update_stack("heroku-22")
+      run!('git commit --allow-empty -m "heroku-22 migrate"')
 
       app.push!
 
@@ -19,7 +19,6 @@ describe "Stack Changes" do
       run!(%Q{git commit --allow-empty -m "cedar migrate"})
 
       app.push!
-      puts app.output
       expect(app.output).to match("Using rack")
     end
   end


### PR DESCRIPTION
We shouldn't release this until GA

```
$ heroku whoami
 ›   Warning: heroku update available from 7.60.1 to 7.60.2.
***********REDACTED*****************@gmail.com
$ heroku stack:set heroku-22
 ›   Warning: heroku update available from 7.60.1 to 7.60.2.
Setting stack to heroku-22... !
 ▸    Switching to the heroku-22 stack is not supported. Please consider using heroku-20 instead: https://devcenter.heroku.com/articles/stack
```
