### PR TITLE
Remove Ruby dependency on bin/release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+## v241 (2022/06/06)
+
 - `bin/release` is re-written in bash (https://github.com/heroku/heroku-buildpack-ruby/pull/1308)
 
 ## v240 (2022/04/05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+- `bin/release` is re-written in bash (https://github.com/heroku/heroku-buildpack-ruby/pull/1308)
+
 ## v240 (2022/04/05)
 
 * Add support for heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1289)

--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,10 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-require 'pathname'
+# fail hard
+set -o pipefail
+# fail harder
+set -eu
 
-release = Pathname.new(ARGV.first).join("tmp/heroku-buildpack-release-step.yml")
-puts release.read if release.exist?
+BUILD_DIR=${1:-}
+
+cat "$BUILD_DIR/tmp/heroku-buildpack-release-step.yml"

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v240"
+    BUILDPACK_VERSION = "v241"
   end
 end

--- a/spec/cnb/basic_local_pack_spec.rb
+++ b/spec/cnb/basic_local_pack_spec.rb
@@ -88,7 +88,7 @@ describe "cnb" do
       app.pack_build
       expect(app.stdout).to match("Compiling Ruby/Rails")
 
-      expect(app.run("ruby -v").stdout).to match("2.7.4")
+      expect(app.run("ruby -v").stdout).to match("3.1.2")
     end
   end
 end


### PR DESCRIPTION
On heroku-22 there is no longer a system Ruby so we cannot depend on it. We can either bootstrap as we do in `bin/compile` or use bash. Considering this logic is trivial to represent in bash that's what we will do.