### PR TITLE
Make `bin/release` handle a missing release file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Main (unreleased)
 
+* Ensure `bin/release` exits zero if `tmp/heroku-buildpack-release-step.yml` does not exist (https://github.com/heroku/heroku-buildpack-ruby/pull/1309)
+
 ## v241 (2022/06/06)
 
-- `bin/release` is re-written in bash (https://github.com/heroku/heroku-buildpack-ruby/pull/1308)
+* `bin/release` is re-written in bash, so it supports Heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1308)
+* Download presence check now includes heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1290)
 
 ## v240 (2022/04/05)
 
-* Add support for heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1289)
+* Add initial support for heroku-22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1289)
 * Bundler 2.x is now 2.3.10 (https://github.com/heroku/heroku-buildpack-ruby/pull/1296)
 
 ## v239 (2022/03/02)

--- a/bin/release
+++ b/bin/release
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-# fail hard
-set -o pipefail
-# fail harder
-set -eu
+set -euo pipefail
 
-BUILD_DIR=${1:-}
+BUILD_DIR="${1:-}"
+RELEASE_FILE="${BUILD_DIR}/tmp/heroku-buildpack-release-step.yml"
 
-cat "$BUILD_DIR/tmp/heroku-buildpack-release-step.yml"
+# Whilst the release file is always written by the buildpack, some apps use
+# third-party slug cleaner buildpacks to remove this and other files, so we
+# cannot assume it still exists by the time the release step runs.
+if [[ -f "${RELEASE_FILE}" ]]; then
+  cat "${RELEASE_FILE}"
+fi


### PR DESCRIPTION
Whilst the `tmp/heroku-buildpack-release-step.yml` file is always written by the buildpack during `bin/compile`, some apps use third-party slug cleaner buildpacks to remove this and other files, during their later `bin/compile` steps.

This restores the `bin/release` behaviour prior to #1308, whereby the file being missing (at the time of the release step) is not treated as an error.

This unblocks us adjusting the build system to make non-zero `bin/release` exit codes fatal, since otherwise too many existing apps would start failing.

Longer term if the Ruby buildpack wanted to ensure slug cleaner buildpacks did not accidentally break the features supported by `bin/release`, the release output file could be renamed from `tmp/heroku-buildpack-release-step.yml` to something else (so it evades cleanup), then for bonus points, `bin/release` would clean that file up itself, so that it didn't end up in the slug. However such a change would be need to be rolled out carefully, in case people were depending on the presence of `tmp/heroku-buildpack-release-step.yml`, so is out of scope for this PR.

I've also added a missing changelog entry from #1290, and clarified some of the earlier Heroku-22 related changelog entries, so that it's clearer that earlier buildpack releases aren't fully compatible with Heroku-22, and the latest version is required.

GUS-W-11256291.