### PR TITLE
Switch away from deprecated path-based S3 URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Switch away from deprecated path-based S3 URLs (https://github.com/heroku/heroku-buildpack-ruby/pull/1311)
+
 ## v242 (2022/06/07)
 
 * Ensure `bin/release` exits zero if `tmp/heroku-buildpack-release-step.yml` does not exist (https://github.com/heroku/heroku-buildpack-ruby/pull/1309)

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ ENV["BUILDPACK_LOG_FILE"] ||= "tmp/buildpack.log"
 require_relative 'lib/rake/deploy_check'
 require_relative 'lib/rake/tarballer'
 
+S3_BUCKET_REGION = "us-east-1"
 S3_BUCKET_NAME  = "heroku-buildpack-ruby"
 
 def s3_tools_dir
@@ -148,7 +149,7 @@ task "ruby:manifest" do
   require 'rexml/document'
   require 'yaml'
 
-  document = REXML::Document.new(`curl https://#{S3_BUCKET_NAME}.s3.amazonaws.com`)
+  document = REXML::Document.new(`curl https://#{S3_BUCKET_NAME}.s3.#{S3_BUCKET_REGION}.amazonaws.com`)
   rubies   = document.elements.to_a("//Contents/Key").map {|node| node.text }.select {|text| text.match(/^(ruby|rbx|jruby)-\\\\d+\\\\.\\\\d+\\\\.\\\\d+(-p\\\\d+)?/) }
 
   Dir.mktmpdir("ruby_versions-") do |tmpdir|

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if detect_needs_java "$BUILD_DIR"; then
 
 EOM
 
-  compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
+  compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
 fi
 
 $heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_compile $@

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -81,7 +81,7 @@ detect_needs_java()
 #
 # Example:
 #
-#   compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
+#   compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
 #
 compile_buildpack_v2()
 {

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -26,7 +26,7 @@ curl_retry_on_18() {
 regex=".*ruby_version = [\'\"]([0-9]+\.[0-9]+\.[0-9]+)[\'\"].*"
 if [[ $(cat "$BIN_DIR/../buildpack.toml") =~ $regex ]]
   then
-    heroku_buildpack_ruby_url="https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
+    heroku_buildpack_ruby_url="https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
   else
     echo "Could not detect ruby version to bootstrap"
     exit 1

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -25,7 +25,7 @@ if detect_needs_java "$BUILD_DIR"; then
 
 EOM
 
-  compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
+  compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
 fi
 
 $heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_test-compile $@

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -13,15 +13,15 @@ ruby_version = "3.1.2"
 files = ["spec/"]
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-3.1.2.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-18/ruby-3.1.2.tgz"
 dir = "vendor/ruby/heroku-18"
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-3.1.2.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-20/ruby-3.1.2.tgz"
 dir = "vendor/ruby/heroku-20"
 
 [[publish.Vendor]]
-url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-22/ruby-3.1.2.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/ruby-3.1.2.tgz"
 dir = "vendor/ruby/heroku-22"
 
 [[stacks]]

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -17,7 +17,7 @@ class LanguagePack::Base
   include LanguagePack::ShellHelpers
   extend LanguagePack::ShellHelpers
 
-  VENDOR_URL           = ENV['BUILDPACK_VENDOR_URL'] || "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
+  VENDOR_URL           = ENV['BUILDPACK_VENDOR_URL'] || "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com"
   DEFAULT_LEGACY_STACK = "cedar"
   ROOT_DIR             = File.expand_path("../../..", __FILE__)
 

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -5,7 +5,7 @@ class LanguagePack::Helpers::Nodebin
     version = "16.13.1"
     {
       "number" => version,
-      "url"    => "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"
+      "url"    => "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"
     }
   end
 
@@ -13,7 +13,7 @@ class LanguagePack::Helpers::Nodebin
     version = "1.22.17"
     {
       "number" => version,
-      "url"    => "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v#{version}.tar.gz"
+      "url"    => "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v#{version}.tar.gz"
     }
   end
 

--- a/lib/language_pack/installers/rbx_installer.rb
+++ b/lib/language_pack/installers/rbx_installer.rb
@@ -4,7 +4,7 @@ require "language_pack/shell_helpers"
 class LanguagePack::Installers::RbxInstaller
   include LanguagePack::ShellHelpers, LanguagePack::Installers::RubyInstaller
 
-  BASE_URL = "https://rubinius-binaries-rubinius-com.s3.amazonaws.com/ubuntu/14.04/x86_64/"
+  BASE_URL = "https://rubinius-binaries-rubinius-com.s3.us-west-2.amazonaws.com/ubuntu/14.04/x86_64/"
 
   def initialize(stack)
     @fetcher = LanguagePack::Fetcher.new(BASE_URL)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -646,7 +646,7 @@ EOF
 
   # vendors individual binary into the slug
   # @param [String] name of the binary package from S3.
-  #   Example: https://s3.amazonaws.com/language-pack-ruby/node-0.4.7.tgz, where name is "node-0.4.7"
+  #   Example: https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/node-0.4.7.tgz, where name is "node-0.4.7"
   def install_binary(name)
     topic "Installing #{name}"
     bin_dir = "bin"


### PR DESCRIPTION
S3 URLs where the bucket name is part of the URL path are deprecated.

Instead, it's recommended to use the virtual-hosted style references, where the bucket name is part of the domain. 

The latter allows AWS to use DNS to direct requests directly to the appropriate region's S3 endpoint, rather than having to route via the global S3 endpoint (which AWS describe as being a single point of failure/harder to scale etc).

There is a small chance this may also help with some of the S3 reliability issues seen in [heroku/builder](https://github.com/heroku/builder) Circle CI runs - however even if it doesn't, at least we'll no longer be using the deprecated URLs/endpoints.

See:
https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.