### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Adjust curl retry and connection timeout handling (https://github.com/heroku/heroku-buildpack-ruby/pull/1312)
+
 ## v242 (2022/06/07)
 
 * Ensure `bin/release` exits zero if `tmp/heroku-buildpack-release-step.yml` does not exist (https://github.com/heroku/heroku-buildpack-ruby/pull/1309)

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -110,7 +110,7 @@ compile_buildpack_v2()
 
     if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then
       mkdir -p "$dir"
-      curl_retry_on_18 -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
+      curl_retry_on_18 -s --fail --retry 3 --retry-connrefused --connect-timeout ${CURL_CONNECT_TIMEOUT:-3} "$url" | tar xvz -C "$dir" >/dev/null 2>&1
     else
       git clone "$url" "$dir" >/dev/null 2>&1
     fi

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -34,7 +34,7 @@ fi
 
 mkdir -p "$RUBY_BOOTSTRAP_DIR"
 
-curl_retry_on_18 --fail --silent --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url" || {
+curl_retry_on_18 --fail --retry 3 --retry-connrefused --connect-timeout ${CURL_CONNECT_TIMEOUT:-3} --silent --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url" || {
 cat<<EOF
   Failed to download a Ruby executable for bootstrapping!
 

--- a/lib/language_pack/helpers/plugin_installer.rb
+++ b/lib/language_pack/helpers/plugin_installer.rb
@@ -30,8 +30,12 @@ module LanguagePack
         return true if directory.exist?
         directory.mkpath
         Dir.chdir(directory) do |dir|
-          run("curl #{vendor_url}/#{name}.tgz -s -o - | tar xzf -")
+          run("curl #{vendor_url}/#{name}.tgz -s --fail --retry 3 --retry-connrefused --connect-timeout #{curl_connect_timeout_in_seconds} -o - | tar xzf -")
         end
+      end
+
+      def curl_connect_timeout_in_seconds
+        env('CURL_CONNECT_TIMEOUT') || 3
       end
     end
   end


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For the connection timeouts, I've ensured they are configurable via `CURL_CONNECT_TIMEOUT`, like elsewhere in the buildpack.

Note: Whilst `curl_retry_on_18` does retries, this is only for exit code 18 (partial downloads, which can't be handled by curl's own retry feature), so retries via curl itself are needed too, and it's fine to have this duplication (see also https://github.com/heroku/heroku-buildpack-php/commit/6936331d25a87d14f6dc701c74703da8eeb40247).

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.