### PR TITLE
Bumped Bundler to 2.3.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Bump Bundler 2 wrapper to 2.3.36 (https://github.com/heroku/heroku-buildpack-ruby/pull/1340)
+
 ## v245 (2022/11/16)
 
 * Bump Bundler 2 wrapper to 2.3.25 (https://github.com/heroku/heroku-buildpack-ruby/pull/1337)

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.3.25"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.3.36"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
Bumping Bundler to 2.3.36 which is the default version shipped with Ruby 3.1.3.

This means we aren't using a lower version than our local/CI environments when pushing to Heroku. 