### PR TITLE
Bumped Bundler to 2.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Bump Bundler 2 wrapper to 2.3.26 (https://github.com/heroku/heroku-buildpack-ruby/pull/1341)
+
 ## v245 (2022/11/16)
 
 * Bump Bundler 2 wrapper to 2.3.25 (https://github.com/heroku/heroku-buildpack-ruby/pull/1337)

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.3.25"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.3.26"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
Bumping Bundler to 2.3.26 which seems to be the default version shipped with Ruby 3.1.3.

This bump means we aren't using a lower version in 3.1.3 apps, albeit a patch version of 2.3.25, than our local/CI environments when pushing to Heroku.