### PR TITLE
Bump default Node.js and Yarn versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## v246 (2022/11/29)
 
-* Default Node.js version now 16.18.11
-* Default Yarn version now 1.22.19
+* Default Node.js version now 16.18.11 (https://github.com/heroku/heroku-buildpack-ruby/pull/1342)
+* Default Yarn version now 1.22.19 (https://github.com/heroku/heroku-buildpack-ruby/pull/1342)
 
 ## v245 (2022/11/16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v246 (2022/11/29)
 
-* Default Node.js version now 16.18.11 (https://github.com/heroku/heroku-buildpack-ruby/pull/1342)
+* Default Node.js version now 16.18.1 (https://github.com/heroku/heroku-buildpack-ruby/pull/1342)
 * Default Yarn version now 1.22.19 (https://github.com/heroku/heroku-buildpack-ruby/pull/1342)
 
 ## v245 (2022/11/16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Main (unreleased)
 
+## v246 (2022/11/29)
+
+* Default Node.js version now 16.18.11
+* Default Yarn version now 1.22.19
+
 ## v245 (2022/11/16)
 
 * Bump Bundler 2 wrapper to 2.3.25 (https://github.com/heroku/heroku-buildpack-ruby/pull/1337)

--- a/changelogs/v246/node_defaults.md
+++ b/changelogs/v246/node_defaults.md
@@ -1,0 +1,10 @@
+## Ruby apps now default to Node version 16.18.1 and Yarn version 1.22.19
+
+Applications using the `heroku/ruby` buildpack that do not already have `node`
+and/or `yarn` installed by another buildpack (such as the `heroku/nodejs`
+buildpack) will now receive:
+
+- Node.js version 16.18.1 (was previously 16.13.1)
+- Yarn version 1.22.19 (was previously 1.22.17)
+
+These versions and instructions on how to specify a specific version of these binaries can be found on the [installed binaries section of the Heroku Ruby Support page](https://devcenter.heroku.com/articles/ruby-support#installed-binaries).

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class LanguagePack::Helpers::Nodebin
   def self.hardcoded_node_lts
-    version = "16.13.1"
+    version = "16.18.1"
     {
       "number" => version,
       "url"    => "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"
@@ -10,7 +10,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_yarn
-    version = "1.22.17"
+    version = "1.22.19"
     {
       "number" => version,
       "url"    => "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v#{version}.tar.gz"

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v245"
+    BUILDPACK_VERSION = "v246"
   end
 end


### PR DESCRIPTION
In #1331, the Node.js version change to 18.x is likely to cause issues for folks running on `heroku-18` (as mentioned in https://github.com/heroku/heroku-buildpack-ruby/pull/1331#pullrequestreview-1174488149). This is an alternative update, which should bring both the default `yarn` and `node` installations to the most recent patch without negatively impacting users on `heroku-18`. Node.js 16 is a maintenance LTS, so should be fine to use for a bit longer. Longer term, we may want to conditionally select Node.js 18 for folks on `heroku-20`+.