### PR TITLE
Release Jruby binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Main (unreleased)
 
+## v251 (2023/02/03)
+
+* Jruby 9.3.10.0 is available
+
+## v250 (2022/12/25)
+
+* Ruby 3.2.0 is available
+
 ## v249 (2022/12/16)
 
 * Apps with the environment variable `HEROKU_SKIP_DATABASE_PROVISION=1` set will no longer receive a database on the first push to a new Heroku app. This environment variable interface is not standard across other buildpacks and may be deprecated via warnings in the build output and changed in the future.

--- a/changelogs/v250/ruby-320.md
+++ b/changelogs/v250/ruby-320.md
@@ -1,0 +1,7 @@
+# Ruby version 3.2.0 is now available
+
+The following Ruby versions are now available on the Heroku platform:
+
+- Ruby 3.2.0
+
+You can see the latest versions on the [Ruby support page](https://devcenter.heroku.com/articles/ruby-support).

--- a/lib/language_pack/version.rb
+++ b/lib/language_pack/version.rb
@@ -2,6 +2,6 @@ require "language_pack/base"
 
 module LanguagePack
   class LanguagePack::Base
-    BUILDPACK_VERSION = "v249"
+    BUILDPACK_VERSION = "v251"
   end
 end


### PR DESCRIPTION
Jruby 9.3.10.0 is out https://github.com/heroku/docker-heroku-jruby-builder/pull/17