### PR TITLE
Switch Hatchet app cleaner to Ruby 3.1

### DIFF
--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: "3.1"
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.


### PR DESCRIPTION
Since this repo's `Gemfile` requires Ruby 3.1.

Resolves:

```
Your Ruby version is 2.7.7, but your Gemfile specified 3.1.2
```

From:
https://github.com/heroku/heroku-buildpack-ruby/actions/runs/4354507220/jobs/7609892161