### PR TITLE
Relax Ruby version constraint in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.2'
+ruby '>= 3.1', '< 3.3'
 
 group :development, :test do
   gem "toml-rb"


### PR DESCRIPTION
So that the Hatchet app cleaner can use latest Ruby 3.1.

Resolves:

```
Your Ruby version is 3.1.3, but your Gemfile specified 3.1.2
```

From:
https://github.com/heroku/heroku-buildpack-ruby/actions/runs/4355145552/jobs/7611367502

Follow-up to #1366 and #1368.

GUS-W-12629391.