### PR TITLE
Exclude development-only files from packaged buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+- Exclude development-only files from the packaged buildpack
+
 ## v260 (2023/10/23)
 
 - JRuby 9.4.4.0 is now available

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -10,7 +10,17 @@ ruby_version = "3.1.4"
 [publish]
 
 [publish.Ignore]
-files = ["spec/"]
+files = [
+  "changelogs/",
+  "spec/",
+  "Gemfile",
+  "Gemfile.lock",
+  "Rakefile",
+  "app.json",
+  "hatchet.json",
+  "hatchet.lock",
+  "package.toml",
+]
 
 [[publish.Vendor]]
 url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-20/ruby-3.1.4.tgz"


### PR DESCRIPTION
Since these files/directories are not needed at build time.