### PR TITLE
Use Node.js Active LTS as default version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+* Default Node.js version now 20.9.0
+
 ## v260 (2023/10/23)
 
 - JRuby 9.4.4.0 is now available

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -2,7 +2,7 @@ require 'json'
 
 class LanguagePack::Helpers::Nodebin
   def self.hardcoded_node_lts
-    version = "16.18.1"
+    version = "20.9.0"
     {
       "number" => version,
       "url"    => "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"


### PR DESCRIPTION
As of [2023-10-24](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-10-24-version-2090-iron-lts-richardlau), Node.js 20.x is now the LTS version.

[W-14390811](https://gus.lightning.force.com/lightning/r/a07EE00001dRrFWYA0/view)