### PR TITLE
Update bundler from 2.3.25 to 2.4.22

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.3.25"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.4.22"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
There are some breaking changes, so this should be considered a major version upgrade. There are also some security and performance fixes.

The breaking changes are:
https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#breaking-changes
> Remove Travis CI from gem skeleton
> Drop support for Ruby 2.3, 2.4, 2.5 and RubyGems 2.5, 2.6, 2.7
> Completely remove "auto-sudo" feature