### PR TITLE
feat: allows to skip node installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+- Apps with the environment variable `HEROKU_SKIP_NODE_INSTALL=1` set will no longer install auto-install nodejs and yarn.
+
 ## v262 (2023/11/08)
 
 - Warn when relying on default Node.js or Yarn versions (https://github.com/heroku/heroku-buildpack-ruby/pull/1401)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -1013,7 +1013,7 @@ params = CGI.parse(uri.query || "")
   # @note execjs will blow up if no JS RUNTIME is detected and is loaded.
   # @return [Array] the node.js binary path if we need it or an empty Array
   def add_node_js_binary
-    return [] if node_js_preinstalled?
+    return [] if node_js_preinstalled? || env("HEROKU_SKIP_NODE_INSTALL")
 
     if Pathname(build_path).join("package.json").exist? ||
          bundler.has_gem?('execjs') ||
@@ -1045,7 +1045,7 @@ params = CGI.parse(uri.query || "")
   end
 
   def add_yarn_binary
-    return [] if yarn_preinstalled?
+    return [] if yarn_preinstalled? || env("HEROKU_SKIP_NODE_INSTALL")
 
     if Pathname(build_path).join("yarn.lock").exist? || bundler.has_gem?('webpacker')
 


### PR DESCRIPTION
In order to use Bun with Rails, will be great to avoid redundant Node and Yarn installations.