### PR TITLE
Allow custom vendored Ruby URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Main (unreleased)
 
-- Fix BUILDPACK_VENDOR_URL support (https://github.com/heroku/heroku-buildpack-ruby/pull/1409)
+- Fix BUILDPACK_VENDOR_URL support (https://github.com/heroku/heroku-buildpack-ruby/pull/1406)
 
 ## v262 (2023/11/08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main (unreleased)
 
+- Fix BUILDPACK_VENDOR_URL support (https://github.com/heroku/heroku-buildpack-ruby/pull/1409)
+
 ## v262 (2023/11/08)
 
 - Warn when relying on default Node.js or Yarn versions (https://github.com/heroku/heroku-buildpack-ruby/pull/1401)

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -26,7 +26,7 @@ curl_retry_on_18() {
 regex=".*ruby_version = [\'\"]([0-9]+\.[0-9]+\.[0-9]+)[\'\"].*"
 if [[ $(cat "$BIN_DIR/../buildpack.toml") =~ $regex ]]
   then
-    heroku_buildpack_ruby_url="https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
+    heroku_buildpack_ruby_url="${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
   else
     echo "Could not detect ruby version to bootstrap"
     exit 1


### PR DESCRIPTION
Lets us provide our own custom set of vendored Ruby runtimes.

Useful for things like building Ruby on different architectures than what Heroku supports, or with different compile flags.

Currently in use on our fork of this repo, but we'd like to merge it upstream.

Fixes #1164.