### PR TITLE
Allow custom vendored Node URL

### DIFF
--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -18,7 +18,11 @@ class LanguagePack::Helpers::NodeInstaller
     # clean up un-used files. Instead we untar in a temp directory which
     # helps us avoid accidentally deleting code out of the user's slug by mistake.
     Dir.mktmpdir do |dir|
-      node_bin = "#{binary_path}/bin/node"
+      if ENV.include?('BUILDPACK_NODEJS_VENDOR_URL')
+        node_bin = "./bin/node"
+      else
+        node_bin = "#{binary_path}/bin/node"
+      end
 
       Dir.chdir(dir) do
         @fetcher.fetch_untar(@url, node_bin)

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -7,7 +7,7 @@ class LanguagePack::Helpers::Nodebin
   def self.hardcoded_node_lts
     {
       "number" => NODE_VERSION,
-      "url"    => "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v#{NODE_VERSION}-linux-x64.tar.gz"
+      "url"    => ENV['BUILDPACK_NODEJS_VENDOR_URL']&.gsub("{NODE_VERSION}", NODE_VERSION) || "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v#{NODE_VERSION}-linux-x64.tar.gz"
     }
   end
 


### PR DESCRIPTION
Follow-up to https://github.com/heroku/heroku-buildpack-ruby/pull/1406

Lets us ship custom builds, targeting different platforms than the Heroku default.

This is slightly more complicated than the Ruby change, as the URL contains a lot of platform-specific information, as well as interpolates the Node version.

My solution is to allow for a variable in the URL that gets substituted with the version.

This allows for dynamic lookups just like normal, and avoids hardcoding to a single version.