### PR TITLE
Use the new "Prepare release" GitHub Actions workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,25 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
+jobs:
+  prepare-release:
+    uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-prepare-release.yml@latest
+    secrets: inherit
+    with:
+      custom_update_command: |
+        sed --in-place --regexp-extended \
+          --expression "s/v${OLD_VERSION}/v${NEW_VERSION}/" \
+          lib/language_pack/version.rb
+
+        if compgen -G 'changelogs/unreleased/*.md' > /dev/null; then
+          # The unreleased changelogs directory contains a `.gitkeep` file, so we have to
+          # copy the markdown files individually instead of renaming the directory.
+          NEW_CHANGELOG_DIR="changelogs/v${NEW_VERSION}/"
+          mkdir -p "${NEW_CHANGELOG_DIR}"
+          mv changelogs/unreleased/*.md "${NEW_CHANGELOG_DIR}"
+        fi


### PR DESCRIPTION
We now have a new reusable GitHub Actions workflow for preparing a new classic buildpack release:
https://github.com/heroku/languages-github-actions/blob/main/.github/workflows/_classic-buildpack-prepare-release.yml

This workflow works the same as the CNB version, except it does not need any version bump input, since we only every increment  classic buildpack versions by one.

This buildpack has a couple of additional update steps required for releases (such as editing a constant in `lib/language_pack/version.rb` and moving any unreleased changelogs to a versioned directory), which are performed using the optional `custom_update_command` input to the shared workflow.

This PR also depends upon #1416 landing first, so that the changelog is compatible with the workflow's version replacement regexes.

GUS-W-14901972.