### PR TITLE
Warn when using SENSIBLE_DEFAULTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Officially deprecate SENSIBLE_DEFAULTS environment variable (https://github.com/heroku/heroku-buildpack-ruby/pull/1420)
 
 ## [v265] - 2024-01-22
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -252,6 +252,20 @@ WARNING
   end
 
   def set_default_web_concurrency
+    warn(<<~WARNING)
+      Your application is using an undocumented feature SENSIBLE_DEFAULTS
+
+      This feature is not supported and may be removed at any time. Please remove the SENSIBLE_DEFAULTS environment variable from your app.
+
+      $ heroku config:unset SENSIBLE_DEFAULTS
+
+      To configure your application's web concurrency, use the WEB_CONCURRENCY environment variable following this documentation:
+
+      - https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration
+      - https://devcenter.heroku.com/articles/h12-request-timeout-in-ruby-mri#puma-pool-usage
+      - https://help.heroku.com/88G3XLA6/what-is-an-acceptable-amount-of-dyno-load
+    WARNING
+
     <<-EOF
 case $(ulimit -u) in
 256)

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -296,11 +296,4 @@ describe "WEB_CONCURRENCY.sh" do
       expect(app.run("echo $WEB_CONCURRENCY", :heroku => {:env => "WEB_CONCURRENCY=0"}).strip).to eq("0")
     end
   end
-
-  it "has defaults set with SENSIBLE_DEFAULTS on" do
-    config = { "SENSIBLE_DEFAULTS" => "1"}
-    Hatchet::Runner.new('default_ruby', stack: DEFAULT_STACK, config: config).deploy do |app|
-      expect(app.run("env")).to match("WEB_CONCURRENCY=")
-    end
-  end
 end


### PR DESCRIPTION
This feature provided a default WEB_CONCURRENCY value when SENSIBLE_DEFAULTS environment variable was set. This feature was experimental and never stabilized. It's not documented on devcenter and should not be relied on.

There are cascading complications in setting a default WEB_CONCURRENCY value:

- A static default is difficult to determine without more information from runtime. 
- Multiple build packs have conflicting defaults for setting WEB_CONCURRENCY. For example, if an app is deploying with the Ruby buildpack and then they add the python buildpack after it, the WEB_CONCURRENCY defaults from python would be applied instead of Ruby.
- Changes in WEB_CONCURRENCY in the buildpack are not picked up by apps unless they deploy.