### PR TITLE
Fix prepare release script

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,8 +12,10 @@ jobs:
     secrets: inherit
     with:
       custom_update_command: |
+        set -euo pipefail
+
         sed --in-place --regexp-extended \
-          --expression "s/v${OLD_VERSION}/v${NEW_VERSION}/" \
+          --expression "s/v${EXISTING_VERSION}/v${NEW_VERSION}/" \
           lib/language_pack/version.rb
 
         if compgen -G 'changelogs/unreleased/*.md' > /dev/null; then


### PR DESCRIPTION
There's no OLD_VERSION it is EXISTING_VERSION https://github.com/heroku/languages-github-actions?tab=readme-ov-file#inputs-2.