### PR TITLE
Heroku-24 and multi-arch (arm/amd) - Stacked 3/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Heroku-24 stack initial support. Includes multi-architecture (arm64/amd64) logic that has not been tested on the platform (https://github.com/heroku/heroku-buildpack-ruby/pull/1439)
 - Remove unused Rubinius and Ruby 1.9.2 codepaths (https://github.com/heroku/heroku-buildpack-ruby/pull/1440)
 
 ## [v267] - 2024-02-28

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -7,10 +7,11 @@ module LanguagePack
 
     include ShellHelpers
 
-    def initialize(host_url, stack: nil)
+    def initialize(host_url, stack: nil, arch: nil)
       @host_url = Pathname.new(host_url)
       # File.basename prevents accidental directory traversal
       @host_url += File.basename(stack) if stack
+      @host_url += File.basename(arch) if arch
     end
 
     def exists?(path, max_attempts = 1)

--- a/lib/language_pack/helpers/download_presence.rb
+++ b/lib/language_pack/helpers/download_presence.rb
@@ -18,13 +18,17 @@
 class LanguagePack::Helpers::DownloadPresence
   STACKS = ['heroku-20', 'heroku-22']
 
-  def initialize(file_name:, stacks: STACKS)
+  def initialize(file_name:, arch: , multi_arch_stacks:, stacks: STACKS )
     @file_name = file_name
     @stacks = stacks
     @fetchers = []
     @threads = []
     @stacks.each do |stack|
-      @fetchers << LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: stack)
+      if multi_arch_stacks.include?(stack)
+        @fetchers << LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: stack, arch: arch)
+      else
+        @fetchers << LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: stack)
+      end
     end
   end
 

--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -8,6 +8,7 @@
 #   outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
 #     current_ruby_version: ruby_version,
 #     fetcher: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: "heroku-22")
+#     fetcher: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: "heroku-22", arch: "amd64")
 #   )
 #
 #   outdated.call

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -10,8 +10,12 @@ class LanguagePack::Installers::HerokuRubyInstaller
   include LanguagePack::ShellHelpers
   attr_reader :fetcher
 
-  def initialize(stack: )
-    @fetcher = LanguagePack::Fetcher.new(BASE_URL, stack: stack)
+  def initialize(stack: , multi_arch_stacks: , arch: )
+    if multi_arch_stacks.include?(stack)
+      @fetcher = LanguagePack::Fetcher.new(BASE_URL, stack: stack, arch: arch)
+    else
+      @fetcher = LanguagePack::Fetcher.new(BASE_URL, stack: stack)
+    end
   end
 
   def install(ruby_version, install_dir)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -514,11 +514,15 @@ EOF
     return false unless ruby_version
 
     installer = LanguagePack::Installers::HerokuRubyInstaller.new(
+      multi_arch_stacks: MULTI_ARCH_STACKS,
       stack: @stack,
+      arch: @arch
     )
 
     @ruby_download_check = LanguagePack::Helpers::DownloadPresence.new(
+      multi_arch_stacks: MULTI_ARCH_STACKS,
       file_name: ruby_version.file_name,
+      arch: @arch
     )
     @ruby_download_check.call
 

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -6,6 +6,38 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: stack)
   }
 
+  it "handles amd ↗️ architecture on heroku-24" do
+    ruby_version = LanguagePack::RubyVersion.new("ruby-3.1.0")
+    fetcher = LanguagePack::Fetcher.new(
+      LanguagePack::Base::VENDOR_URL,
+      stack: "heroku-24",
+      arch: "amd64"
+    )
+    outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
+      current_ruby_version: ruby_version,
+      fetcher: fetcher
+    )
+
+    outdated.call
+    expect(outdated.suggested_ruby_minor_version).to eq("3.1.4")
+  end
+
+  it "handles arm 💪 architecture on heroku-24" do
+    ruby_version = LanguagePack::RubyVersion.new("ruby-3.1.0")
+    fetcher = LanguagePack::Fetcher.new(
+      LanguagePack::Base::VENDOR_URL,
+      stack: "heroku-24",
+      arch: "arm64"
+    )
+    outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
+      current_ruby_version: ruby_version,
+      fetcher: fetcher
+    )
+
+    outdated.call
+    expect(outdated.suggested_ruby_minor_version).to eq("3.1.4")
+  end
+
   it "finds the latest version on a stack" do
     ruby_version = LanguagePack::RubyVersion.new("ruby-2.2.5")
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(

--- a/spec/installers/heroku_ruby_installer_spec.rb
+++ b/spec/installers/heroku_ruby_installer_spec.rb
@@ -1,9 +1,13 @@
 require "spec_helper"
 
 describe LanguagePack::Installers::HerokuRubyInstaller do
-  let(:installer)    { LanguagePack::Installers::HerokuRubyInstaller.new(
-    stack: "cedar-14"
-  ) }
+  let(:installer) {
+    LanguagePack::Installers::HerokuRubyInstaller.new(
+      multi_arch_stacks: [],
+      stack: "cedar-14",
+      arch: nil,
+    )
+  }
   let(:ruby_version) { LanguagePack::RubyVersion.new("ruby-2.3.3") }
 
   describe "#fetch_unpack" do


### PR DESCRIPTION
Heroku-24 base image supports two architectures amd64 and arm64. We've built binaries for these two architectures https://github.com/heroku/docker-heroku-ruby-builder/pull/38. Effectively this means that the s3 bucket that holds the Ruby binaries has an additional folder. Previously files were at `<stack>/ruby-<version>.tgz` now they are at `<stack>/<arch>/ruby-<version>.tgz` but only for `heroku-24` and future stacks moving forward.

To support multiple architectures, the buildpack needs to detect the current architecture and whether or not the current stack supports multiple architectures.

Beyond downloading binaries, the buildpack is aware of the S3 structure to travers version numbers in order to warn customers when a newer version of a ruby version is available. We also warn customers if their current Ruby version is not available on the next stack. This behavior is implemented and tested in this PR, however we're not turning on warnings for `heroku-24` yet as customers cannot currently use it.