### PR TITLE
Introduce shell check on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    # Avoid duplicate builds on PRs.
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run ShellCheck bin top level
+        run: |
+            shellcheck bin/support/bash_functions.sh bin/support/download_ruby -x &&
+            shellcheck bin/build bin/compile bin/detect bin/release bin/test bin/test-compile -x

--- a/bin/build
+++ b/bin/build
@@ -2,17 +2,17 @@
 
 LAYERS_DIR=$1
 PLATFORM_DIR=$2
-ENV_DIR="$PLATFORM_DIR/env"
+_ENV_DIR="$PLATFORM_DIR/env"
 PLAN=$3
 APP_DIR=$(pwd)
-BIN_DIR=$(cd $(dirname $0); pwd)
-BUILDPACK_DIR=$(dirname $BIN_DIR)
+BIN_DIR=$(cd "$(dirname "$0")" || exit; pwd) # absolute path
+BUILDPACK_DIR=$(dirname "$BIN_DIR")
 
 # legacy buildpack uses $STACK
 export STACK=$CNB_STACK_ID
 
+# shellcheck source=bin/support/bash_functions.sh
 source "$BIN_DIR/support/bash_functions.sh"
-heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
 
 cat<<EOF 1>&2
     The CNB implementation in this buildpack is no longer maintained
@@ -22,4 +22,8 @@ cat<<EOF 1>&2
     The Heroku Ruby CNB is now at https://github.com/heroku/buildpacks-ruby. See https://github.com/heroku/buildpacks for more information on using the Heroku CNB builder. To avoid interruptions switch to the new CNB as soon as possible.
 EOF
 
-$heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_build $APP_DIR $LAYERS_DIR $PLATFORM_DIR $PLAN
+bootstrap_ruby_dir=$(install_bootstrap_ruby "$BIN_DIR" "$BUILDPACK_DIR")
+export PATH="$bootstrap_ruby_dir/bin/:$PATH"
+unset GEM_PATH
+
+"$bootstrap_ruby_dir"/bin/ruby "$BIN_DIR/support/ruby_build" "$APP_DIR" "$LAYERS_DIR" "$PLATFORM_DIR" "$PLAN"

--- a/bin/compile
+++ b/bin/compile
@@ -5,11 +5,15 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-BIN_DIR=$(cd $(dirname $0); pwd)
-BUILDPACK_DIR=$(dirname $BIN_DIR)
+BIN_DIR=$(cd "$(dirname "$0")" || exit; pwd) # absolute path
+BUILDPACK_DIR=$(dirname "$BIN_DIR")
 
+# shellcheck source=bin/support/bash_functions.sh
 source "$BIN_DIR/support/bash_functions.sh"
-heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
+
+bootstrap_ruby_dir=$(install_bootstrap_ruby "$BIN_DIR" "$BUILDPACK_DIR")
+export PATH="$bootstrap_ruby_dir/bin/:$PATH"
+unset GEM_PATH
 
 if detect_needs_java "$BUILD_DIR"; then
   cat <<EOM
@@ -28,4 +32,4 @@ EOM
   compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
 fi
 
-$heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_compile $@
+"$bootstrap_ruby_dir"/bin/ruby "$BIN_DIR/support/ruby_compile" "$@"

--- a/bin/detect
+++ b/bin/detect
@@ -4,9 +4,8 @@ if [ -z "$CNB_STACK_ID" ]; then
   # v2 API
   APP_DIR=$1
 else
-  PLATFORM_DIR=$1
-  PLAN=$2
-  # working is the cwd now
+  _PLATFORM_DIR=$1
+  _PLAN=$2
   # v3 API
   APP_DIR=$(pwd)
 fi

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -12,6 +12,9 @@ set -eu
 BIN_DIR=$1
 RUBY_BOOTSTRAP_DIR=$2
 
+# Stack is set by codon, listed here so shellcheck knows about it
+STACK=${STACK:-}
+
 curl_retry_on_18() {
   local ec=18;
   local attempts=0;
@@ -28,13 +31,14 @@ if [[ $(cat "$BIN_DIR/../buildpack.toml") =~ $regex ]]
   then
     heroku_buildpack_ruby_url="${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
   else
+    heroku_buildpack_ruby_url=""
     echo "Could not detect ruby version to bootstrap"
     exit 1
 fi
 
 mkdir -p "$RUBY_BOOTSTRAP_DIR"
 
-curl_retry_on_18 --fail --retry 3 --retry-connrefused --connect-timeout ${CURL_CONNECT_TIMEOUT:-3} --silent --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url" || {
+curl_retry_on_18 --fail --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" --silent --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url" || {
 cat<<EOF
   Failed to download a Ruby executable for bootstrapping!
 

--- a/bin/test
+++ b/bin/test
@@ -2,10 +2,14 @@
 # The actual `bin/test-compile` code lives in `bin/ruby_test-compile`. This file instead
 # bootstraps the ruby needed and then executes `bin/ruby_test-compile`
 
-BIN_DIR=$(cd $(dirname $0); pwd)
-BUILDPACK_DIR=$(dirname $BIN_DIR)
+BIN_DIR=$(cd "$(dirname "$0")" || exit; pwd) # absolute path
+BUILDPACK_DIR=$(dirname "$BIN_DIR")
 
+# shellcheck source=bin/support/bash_functions.sh
 source "$BIN_DIR/support/bash_functions.sh"
-heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
 
-$heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_test $@
+bootstrap_ruby_dir=$(install_bootstrap_ruby "$BIN_DIR" "$BUILDPACK_DIR")
+export PATH="$bootstrap_ruby_dir/bin/:$PATH"
+unset GEM_PATH
+
+"$bootstrap_ruby_dir"/bin/ruby "$BIN_DIR/support/ruby_test" "$@"

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -5,11 +5,15 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-BIN_DIR=$(cd $(dirname $0); pwd)
-BUILDPACK_DIR=$(dirname $BIN_DIR)
+BIN_DIR=$(cd "$(dirname "$0")" || exit; pwd) # absolute path
+BUILDPACK_DIR=$(dirname "$BIN_DIR")
 
+# shellcheck source=bin/support/bash_functions.sh
 source "$BIN_DIR/support/bash_functions.sh"
-heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
+
+bootstrap_ruby_dir=$(install_bootstrap_ruby "$BIN_DIR" "$BUILDPACK_DIR")
+export PATH="$bootstrap_ruby_dir/bin/:$PATH"
+unset GEM_PATH
 
 if detect_needs_java "$BUILD_DIR"; then
   cat <<EOM
@@ -28,4 +32,4 @@ EOM
   compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
 fi
 
-$heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_test-compile $@
+"$bootstrap_ruby_dir"/bin/ruby "$BIN_DIR/support/ruby_test-compile" "$@"


### PR DESCRIPTION
Adding shellcheck and updating bash scripts. I need this for heroku-24 support as I need to modify bash files to add in multi-arch bootstrapping capabilities and I don't want to do it without linting.