### PR TITLE
Deprecate beta CNB support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Deprecate CNB support, CNB users should use [heroku/buildpacks-ruby](https://github.com/heroku/buildpacks-ruby) instead (https://github.com/heroku/heroku-buildpack-ruby/pull/1445)
+- Deprecate CNB support in this buildpack; CNB support for Ruby is provided by [heroku/buildpacks-ruby](https://github.com/heroku/buildpacks-ruby) instead (https://github.com/heroku/heroku-buildpack-ruby/pull/1445)
 
 ## [v268] - 2024-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Deprecate CNB support, CNB users should use [heroku/buildpacks-ruby](https://github.com/heroku/buildpacks-ruby) instead (https://github.com/heroku/heroku-buildpack-ruby/pull/1445)
 
 ## [v268] - 2024-04-17
 

--- a/bin/build
+++ b/bin/build
@@ -15,7 +15,7 @@ source "$BIN_DIR/support/bash_functions.sh"
 heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
 
 cat<<EOF 1>&2
-    CNB no longer maintained
+    The CNB implementation in this buildpack is no longer maintained
 
     The heroku/heroku-ruby-buildpack previously implemented the Cloud Native Buildpack \(CNB\) spec beta support, however this functionality is no longer supported or maintained.
 

--- a/bin/build
+++ b/bin/build
@@ -8,10 +8,18 @@ APP_DIR=$(pwd)
 BIN_DIR=$(cd $(dirname $0); pwd)
 BUILDPACK_DIR=$(dirname $BIN_DIR)
 
-# legacy buildpack uses $STACK 
+# legacy buildpack uses $STACK
 export STACK=$CNB_STACK_ID
 
 source "$BIN_DIR/support/bash_functions.sh"
 heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
+
+cat<<EOF 1>&2
+    CNB no longer maintained
+
+    The heroku/heroku-ruby-buildpack previously implemented the Cloud Native Buildpack \(CNB\) spec beta support, however this functionality is no longer supported or maintained.
+
+    The Heroku Ruby CNB is now at https://github.com/heroku/buildpacks-ruby. See https://github.com/heroku/buildpacks for more information on using the Heroku CNB builder. To avoid interruptions switch to the new CNB as soon as possible.
+EOF
 
 $heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_build $APP_DIR $LAYERS_DIR $PLATFORM_DIR $PLAN


### PR DESCRIPTION
CNB support was introduced into this buildpack as an experiment. The experiment is over, anyone wanting to use the official CNB (still in "preview" support) should use https://github.com/heroku/buildpacks-ruby