### PR TITLE
Fix heroku-24 bootstrap ruby support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix Heroku-24 Ruby buildpack bootstrapping logic (https://github.com/heroku/heroku-buildpack-ruby/pull/1446)
 - Deprecate CNB support in this buildpack; CNB support for Ruby is provided by [heroku/buildpacks-ruby](https://github.com/heroku/buildpacks-ruby) instead (https://github.com/heroku/heroku-buildpack-ruby/pull/1445)
 
 ## [v268] - 2024-04-17

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -30,7 +30,14 @@ install_bootstrap_ruby()
 {
   local bin_dir=$1
   local buildpack_dir=$2
-  local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK"
+
+  # Multi-arch aware stack support
+  if [ "$STACK" == "heroku-24" ]; then
+    local arch=dpkg --print-architecture
+    local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK/$arch"
+  else
+    local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK"
+  fi
 
   # The -d flag checks to see if a file exists and is a directory.
   # This directory may be non-empty if a previous compile has

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -33,7 +33,7 @@ install_bootstrap_ruby()
 
   # Multi-arch aware stack support
   if [ "$STACK" == "heroku-24" ]; then
-    local arch=dpkg --print-architecture
+    local arch=$(dpkg --print-architecture)
     local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK/$arch"
   else
     local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK"

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -33,7 +33,8 @@ install_bootstrap_ruby()
 
   # Multi-arch aware stack support
   if [ "$STACK" == "heroku-24" ]; then
-    local arch=$(dpkg --print-architecture)
+    local arch
+    arch=$(dpkg --print-architecture)
     local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK/$arch"
   else
     local heroku_buildpack_ruby_dir="$buildpack_dir/vendor/ruby/$STACK"

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -30,7 +30,7 @@ ruby_url() {
   local version=$2
 
   if [ "$stack" == "heroku-24" ]; then
-    local arch=dpkg --print-architecture
+    local arch=$(dpkg --print-architecture)
     echo "${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$stack/$arch/ruby-$version.tgz"
   else
     echo "${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$stack/ruby-$version.tgz"

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -25,11 +25,23 @@ curl_retry_on_18() {
   return $ec
 }
 
+ruby_url() {
+  local stack=$1
+  local version=$2
+
+  if [ "$stack" == "heroku-24" ]; then
+    local arch=dpkg --print-architecture
+    echo "${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$stack/$arch/ruby-$version.tgz"
+  else
+    echo "${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$stack/ruby-$version.tgz"
+  fi
+}
+
 # Pull ruby version out of buildpack.toml to be used with bootstrapping
 regex=".*ruby_version = [\'\"]([0-9]+\.[0-9]+\.[0-9]+)[\'\"].*"
 if [[ $(cat "$BIN_DIR/../buildpack.toml") =~ $regex ]]
   then
-    heroku_buildpack_ruby_url="${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$STACK/ruby-${BASH_REMATCH[1]}.tgz"
+    heroku_buildpack_ruby_url=$(ruby_url "$STACK" "${BASH_REMATCH[1]}")
   else
     heroku_buildpack_ruby_url=""
     echo "Could not detect ruby version to bootstrap"

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -30,7 +30,8 @@ ruby_url() {
   local version=$2
 
   if [ "$stack" == "heroku-24" ]; then
-    local arch=$(dpkg --print-architecture)
+    local arch
+    arch=$(dpkg --print-architecture)
     echo "${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$stack/$arch/ruby-$version.tgz"
   else
     echo "${BUILDPACK_VENDOR_URL:-https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com}/$stack/ruby-$version.tgz"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -34,10 +34,6 @@ dir = "vendor/ruby/heroku-22"
 url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/amd64/ruby-3.1.4.tgz"
 dir = "vendor/ruby/amd64/heroku-24"
 
-[[publish.Vendor]]
-url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/arm64/ruby-3.1.4.tgz"
-dir = "vendor/ruby/arm64/heroku-24"
-
 [[stacks]]
 id = "heroku-20"
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -30,6 +30,14 @@ dir = "vendor/ruby/heroku-20"
 url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/ruby-3.1.4.tgz"
 dir = "vendor/ruby/heroku-22"
 
+[[publish.Vendor]]
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/amd64/ruby-3.1.4.tgz"
+dir = "vendor/ruby/amd64/heroku-24"
+
+[[publish.Vendor]]
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/arm64/ruby-3.1.4.tgz"
+dir = "vendor/ruby/arm64/heroku-24"
+
 [[stacks]]
 id = "heroku-20"
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -31,7 +31,7 @@ url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/ruby-3
 dir = "vendor/ruby/heroku-22"
 
 [[publish.Vendor]]
-url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/amd64/ruby-3.1.4.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-24/amd64/ruby-3.1.4.tgz"
 dir = "vendor/ruby/amd64/heroku-24"
 
 [[stacks]]

--- a/spec/helpers/config_spec.rb
+++ b/spec/helpers/config_spec.rb
@@ -19,4 +19,21 @@ describe "Boot Strap Config" do
 
     expect(bootstrap_version).to be >= default_version
   end
+
+  it "doesn't contain unexpected entries" do
+    require 'toml-rb'
+    config = TomlRB.load_file("buildpack.toml")
+
+    urls = config["publish"]["Vendor"].map {|h| h["url"] if h["dir"] != "." }.compact
+    heroku_20 = urls.find_all {|url| url.include?("heroku-20") }
+    expect(heroku_20.length).to eq(1)
+
+    heroku_22 = urls.find_all {|url| url.include?("heroku-22") }
+    expect(heroku_22.length).to eq(1)
+
+    heroku_24 = urls.find_all {|url| url.include?("heroku-24") }
+    expect(heroku_24.length).to eq(1)
+
+    expect(urls.length).to eq(3)
+  end
 end


### PR DESCRIPTION
The Ruby buildpack needs Ruby to run. For the heroku-24 stack the location of ruby binaries changed to include an architecture specifier (amd64/arm64) but the logic for bootstrapping a Ruby version was not updated.