### PR TITLE
With Propshaft migration from Sprockets version retrieval causes issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix issue with sprockets reference being nil when
+  propshaft gem is used instead (https://github.com/heroku/heroku-buildpack-ruby/pull/1452)
 
 ## [v270] - 2024-04-23
 

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -134,7 +134,9 @@ WARNING
   def sprocket_version_upgrade_needed
     # Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3760
     sprockets_version = bundler.gem_version('sprockets')
-    if sprockets_version < Gem::Version.new("2.12.5")
+    if sprockets_version.nil?
+      return false
+    elsif sprockets_version < Gem::Version.new("2.12.5")
       return "2.12.5"
     elsif sprockets_version > Gem::Version.new("3") &&
           sprockets_version < Gem::Version.new("3.7.2")


### PR DESCRIPTION
Hi!

My deployments were crashing on heroku after switching from sprockets to propshaft. Here is a small change that fixed this issue for me, and will not affect sprockets enabled rails deployments.

<img width="896" alt="image" src="https://github.com/heroku/heroku-buildpack-ruby/assets/2532265/155423b2-4231-4914-ae52-b6f42f3f30bf">

Thanks,