### PR TITLE
Let bundler >= 2.2 handle windows platform

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -222,6 +222,10 @@ class LanguagePack::Helpers::BundlerWrapper
     Gem::Version.new(@version) < Gem::Version.new("2.1.4")
   end
 
+  def supports_multiple_platforms?
+    Gem::Version.new(@version) >= Gem::Version.new("2.2")
+  end
+
   def bundler_version_escape_valve!
     topic("Removing BUNDLED WITH version in the Gemfile.lock")
     contents = File.read(@gemfile_lock_path, mode: "rt")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -756,7 +756,7 @@ BUNDLE
         WARNING
       end
 
-      if bundler.windows_gemfile_lock?
+      if !bundler.supports_multiple_platforms? && bundler.windows_gemfile_lock?
         log("bundle", "has_windows_gemfile_lock")
 
         File.unlink("Gemfile.lock")


### PR DESCRIPTION
Fixes #1157

Because it has support for multiple platforms in Gemfile.lock. So deleting Gemfile.lock when one of the platforms is windows is not good. Bundler's error message tells the user how to handle it.
```
Your bundle only supports platforms ["mingw"] but your local platform is x86_64-linux. Add the current platform to the lockfile with
`bundle lock --add-platform x86_64-linux` and try again.
```

It would be nice with a spec for it, but I did not have time for it