### PR TITLE
Default Ruby version to 3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Remove experimental CNB support. For official CNB support use [heroku/buildpacks-ruby](https://github.com/heroku/buildpacks-ruby) instead. (https://github.com/heroku/heroku-buildpack-ruby/pull/1464)
+- Default Ruby version is now 3.1.6 (https://github.com/heroku/heroku-buildpack-ruby/pull/1466)
+- Ruby 3.3.3 is now available
 
 ## [v271] - 2024-06-03
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.1.4p223
+   ruby 3.1.6p260
 
 BUNDLED WITH
-   2.5.8
+   2.5.11

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "3.1.4"
+ruby_version = "3.1.6"
 
 [publish]
 
@@ -17,13 +17,13 @@ files = [
 ]
 
 [[publish.Vendor]]
-url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-20/ruby-3.1.4.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-20/ruby-3.1.6.tgz"
 dir = "vendor/ruby/heroku-20"
 
 [[publish.Vendor]]
-url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/ruby-3.1.4.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/ruby-3.1.6.tgz"
 dir = "vendor/ruby/heroku-22"
 
 [[publish.Vendor]]
-url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-24/amd64/ruby-3.1.4.tgz"
+url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-24/amd64/ruby-3.1.6.tgz"
 dir = "vendor/ruby/amd64/heroku-24"

--- a/changelogs/unreleased/default_ruby.md
+++ b/changelogs/unreleased/default_ruby.md
@@ -1,0 +1,3 @@
+## Default Ruby version for new apps is now 3.1.6
+
+The [default Ruby version for new Ruby applications is 3.1.6](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,8 +12,8 @@ module LanguagePack
       end
     end
 
-    BOOTSTRAP_VERSION_NUMBER = "3.1.4".freeze
-    DEFAULT_VERSION_NUMBER = "3.1.4".freeze
+    BOOTSTRAP_VERSION_NUMBER = "3.1.6".freeze
+    DEFAULT_VERSION_NUMBER = "3.1.6".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}".freeze


### PR DESCRIPTION
Default Ruby version to 3.1.6 and a commit for Ruby 3.3.3 release https://www.ruby-lang.org/en/news/2024/06/12/ruby-3-3-3-released/