### PR TITLE
add a test to check that it runs on heroku-24

### DIFF
--- a/spec/hatchet/getting_started_spec.rb
+++ b/spec/hatchet/getting_started_spec.rb
@@ -6,4 +6,10 @@ describe "Heroku ruby getting started" do
       expect(app.run("ls tmp/cache/assets")).to_not match("sprockets")
     end
   end
+
+  it "works on Heroku-24" do
+    Hatchet::Runner.new("ruby-getting-started", stack: "heroku-24").deploy do |app|
+      expect(app.run("which ruby").strip).to eq("/app/bin/ruby")
+    end
+  end
 end


### PR DESCRIPTION
The heroku classic ruby buildpack supports the new heroku-24 but does not have Hatchet integration tests for it. Adding a spec to getting started to ensure that the stack is supported as expected.