### PR TITLE
Let bundler >= 2.2 handle windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Native Gemfile.lock support for Windows Ruby users with Bundler 2.2+ (https://github.com/heroku/heroku-buildpack-ruby/pull/1469)
 
 ## [v272] - 2024-06-13
 

--- a/changelogs/unreleased/windows_gemfile.md
+++ b/changelogs/unreleased/windows_gemfile.md
@@ -12,7 +12,7 @@ Ruby applications that use Windows and Bundler 2.2+ will no longer have their `G
 > git commit -m "Upgrade bundler"
 ```
 
-This change is reflected in the [Deploying a Ruby Project Generated on Windows](https://devcenter.heroku.com/articles/bundler-windows-gemfile) Devcenter article. More information on the history of the behavior can be found [on this GitHub issue](https://github.com/heroku/heroku-buildpack-ruby/issues/1157).
+This change is reflected in the [Deploying a Ruby Project Generated on Windows](https://devcenter.heroku.com/articles/bundler-windows-gemfile) Dev Center article. More information on the history of the behavior can be found [on this GitHub issue](https://github.com/heroku/heroku-buildpack-ruby/issues/1157).
 
 <!--
 

--- a/changelogs/unreleased/windows_gemfile.md
+++ b/changelogs/unreleased/windows_gemfile.md
@@ -1,0 +1,67 @@
+## Native Gemfile.lock support for Windows Ruby users with Bundler 2.2+
+
+Ruby applications that use Windows and Bundler 2.2+ will no longer have their `Gemfile.lock` deleted and re-generated on deployment. Instead, they will rely on Bundler 2.2+'s support for multiple platforms to correctly resolve dependencies. We recommend any Windows Ruby user to upgrade their Bundler version in the `Gemfile.lock` to Bundler 2.2+ to take advantage of this behavior:
+
+> note
+> The leading `>` indicates a command prompt and should not be copied.
+
+```
+> gem install bundler
+> bundle update --bundler
+> git add Gemfile.lock
+> git commit -m "Upgrade bundler"
+```
+
+This change is reflected in the [Deploying a Ruby Project Generated on Windows](https://devcenter.heroku.com/articles/bundler-windows-gemfile) Devcenter article. More information on the history of the behavior can be found [on this GitHub issue](https://github.com/heroku/heroku-buildpack-ruby/issues/1157).
+
+<!--
+
+https://devcenter.heroku.com/admin/articles/315/edit
+
+# Using Bundler
+
+To use, install bundler run:
+
+> note
+> Commands are prefixed with `>` to indicate they should be run in a command prompt, do not copy the `>` character.
+
+```term
+> gem install bundler
+```
+
+Create a file named `Gemfile` in the root of your app specifying what gems are required to run it:
+
+```ruby
+source "https://rubygems.org"
+
+gem 'sinatra', '4.0'
+```
+
+This file should be added to the git repository since it is part of the app. You should also add the `.bundle` directory to your `.gitignore` file. Once you have added the `Gemfile`, it makes it easy for other developers to get their environment ready to run the app:
+
+```term
+> bundle install
+```
+
+This command ensures that all gems specified in the `Gemfile` are available for your application. Running `bundle install` also generates a `Gemfile.lock`, which should be added to your git repository. The `Gemfile.lock` ensures that deployed versions of gems on Heroku match the version installed locally on your development machine.
+
+>warning
+>If your `Gemfile.lock` specifies a bundler version prior to 2.2 and the `PLATFORMS` section of your `Gemfile.lock` contains Windows entries, such as `mswin` or `mingw`, then the `Gemfile.lock` file will be ignored on Heroku. We recommend upgrading to Bundler 2.2 or later.
+
+## Windows support with Bundler 2.2 and later
+
+Heroku supports deploying applications developed on Windows, but [production dynos will be run on a different operating system](https://devcenter.heroku.com/articles/stack)). To ensure that your Heroku production application installs the same versions of gems you are using locally for development on your Windows machine, we recommend updating your application to Bundler 2.2 or later. You can upgrade your bundler version by running the following commands:
+
+```
+> gem install bundler
+> bundle update --bundler
+> git add Gemfile.lock
+> git commit -m "Upgrade bundler"
+```
+
+Windows applications using bundler 2.2+ will rely on bundler's support for multiple platforms to find and install an appropriate version.
+
+## Windows support with bundler before 2.2
+
+If your application cannot upgrade to bundler 2.2 or later, then when you deploy, the `Gemfile.lock` file will be deleted and regenerated. More information about [this behavior can be found on the Ruby buildpack's GitHub repository](https://github.com/heroku/heroku-buildpack-ruby/issues/1157).
+-->

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -222,6 +222,8 @@ class LanguagePack::Helpers::BundlerWrapper
     Gem::Version.new(@version) < Gem::Version.new("2.1.4")
   end
 
+  # Bundler 2.2 introduced support for multiple "platforms" in the Gemfile.lock
+  # For more information see https://github.com/heroku/heroku-buildpack-ruby/issues/1157
   def supports_multiple_platforms?
     Gem::Version.new(@version) >= Gem::Version.new("2.2")
   end

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -222,6 +222,10 @@ class LanguagePack::Helpers::BundlerWrapper
     Gem::Version.new(@version) < Gem::Version.new("2.1.4")
   end
 
+  def supports_multiple_platforms?
+    Gem::Version.new(@version) >= Gem::Version.new("2.2")
+  end
+
   def bundler_version_escape_valve!
     topic("Removing BUNDLED WITH version in the Gemfile.lock")
     contents = File.read(@gemfile_lock_path, mode: "rt")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -693,7 +693,7 @@ BUNDLE
         WARNING
       end
 
-      if bundler.windows_gemfile_lock?
+      if !bundler.supports_multiple_platforms? && bundler.windows_gemfile_lock?
         log("bundle", "has_windows_gemfile_lock")
 
         File.unlink("Gemfile.lock")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -693,20 +693,33 @@ BUNDLE
         WARNING
       end
 
-      if !bundler.supports_multiple_platforms? && bundler.windows_gemfile_lock?
-        log("bundle", "has_windows_gemfile_lock")
+      if bundler.windows_gemfile_lock?
+        if bundler.supports_multiple_platforms?
+          puts "Windows `Gemfile.lock` detected, bundler #{@bundler.version} supports multiple platforms, no action taken."
+        else
+            File.unlink("Gemfile.lock")
+            ENV.delete("BUNDLE_DEPLOYMENT")
 
-        File.unlink("Gemfile.lock")
-        ENV.delete("BUNDLE_DEPLOYMENT")
+            warn(<<~WARNING, inline: true)
+              Removing `Gemfile.lock` because it was generated on Windows.
 
-        warn(<<~WARNING, inline: true)
-          Removing `Gemfile.lock` because it was generated on Windows.
-          Bundler will do a full resolve so native gems are handled properly.
-          This may result in unexpected gem versions being used in your app.
-          In rare occasions Bundler may not be able to resolve your dependencies at all.
+              Bundler will do a full resolve so native gems are handled properly.
+              This may result in unexpected gem versions being used in your app.
+              In rare occasions Bundler may not be able to resolve your dependencies at all.
 
-          https://devcenter.heroku.com/articles/bundler-windows-gemfile
-        WARNING
+              Upgrade to bundler version 2.2 or higher to skip this behavior and use built in support
+              for multiple platforms. Running these commands below (after the `>`) in a command prompt
+              should resolve this warning:
+
+                > gem install bundler
+                > bundle update --bundler
+                > git add Gemfile.lock
+                > git commit -m "Upgrade bundler"
+
+              For more information see:
+                https://devcenter.heroku.com/articles/bundler-windows-gemfile
+            WARNING
+        end
       end
 
       bundle_command = String.new("")

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -45,6 +45,28 @@ describe "Bundler version detection" do
   end
 end
 
+describe "Multiple platform detection" do
+  it "reports true on bundler 2.2+" do
+    Dir.mktmpdir do |dir|
+      gemfile = Pathname(dir).join("Gemfile")
+      lockfile = Pathname(dir).join("Gemfile.lock").tap {|p| p.write("BUNDLED WITH\n   2.5.7") }
+
+      bundler = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: gemfile)
+      expect(bundler.supports_multiple_platforms?).to be_truthy
+    end
+  end
+
+  it "reports false on bundler prior to 2.2" do
+    Dir.mktmpdir do |dir|
+      gemfile = Pathname(dir).join("Gemfile")
+      lockfile = Pathname(dir).join("Gemfile.lock").tap {|p| p.write("BUNDLED WITH\n   1.15.2") }
+
+      bundler = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: gemfile)
+      expect(bundler.supports_multiple_platforms?).to be_falsey
+    end
+  end
+end
+
 describe "BundlerWrapper mutates rubyopt" do
   before(:each) do
     if ENV['RUBYOPT']


### PR DESCRIPTION
Building on https://github.com/heroku/heroku-buildpack-ruby/pull/1458

Tests and documents Windows bundler 2.2+ behavior.