### PR TITLE
Add platform information to windows support docs

### DIFF
--- a/changelogs/unreleased/windows_gemfile.md
+++ b/changelogs/unreleased/windows_gemfile.md
@@ -8,6 +8,9 @@ Ruby applications that use Windows and Bundler 2.2+ will no longer have their `G
 ```
 > gem install bundler
 > bundle update --bundler
+> bundle lock --add-platform ruby
+> bundle lock --add-platform x86_64-linux
+> bundle install
 > git add Gemfile.lock
 > git commit -m "Upgrade bundler"
 ```
@@ -55,11 +58,14 @@ Heroku supports deploying applications developed on Windows, but [production dyn
 ```
 > gem install bundler
 > bundle update --bundler
+> bundle lock --add-platform ruby
+> bundle lock --add-platform x86_64-linux
+> bundle install
 > git add Gemfile.lock
 > git commit -m "Upgrade bundler"
 ```
 
-Windows applications using bundler 2.2+ will rely on bundler's support for multiple platforms to find and install an appropriate version.
+After running these commands, Windows applications using bundler 2.2+ will rely on bundler's support for multiple platforms to find and install an appropriate version.
 
 ## Windows support with bundler before 2.2
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -695,7 +695,7 @@ BUNDLE
 
       if bundler.windows_gemfile_lock?
         if bundler.supports_multiple_platforms?
-          puts "Windows `Gemfile.lock` detected, bundler #{@bundler.version} supports multiple platforms, no action taken."
+          puts "Windows `Gemfile.lock` detected, bundler #{bundler.version} supports multiple platforms, no action taken."
         else
             File.unlink("Gemfile.lock")
             ENV.delete("BUNDLE_DEPLOYMENT")

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -713,6 +713,9 @@ BUNDLE
 
                 > gem install bundler
                 > bundle update --bundler
+                > bundle lock --add-platform ruby
+                > bundle lock --add-platform x86_64-linux
+                > bundle install
                 > git add Gemfile.lock
                 > git commit -m "Upgrade bundler"
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -695,7 +695,7 @@ BUNDLE
 
       if bundler.windows_gemfile_lock?
         if bundler.supports_multiple_platforms?
-          puts "Windows `Gemfile.lock` detected, bundler #{bundler.version} supports multiple platforms, no action taken."
+          puts "Windows platform detected, preserving `Gemfile.lock` (#{bundler.version} >= 2.2)"
         else
             File.unlink("Gemfile.lock")
             ENV.delete("BUNDLE_DEPLOYMENT")

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -1,6 +1,40 @@
 require_relative '../spec_helper'
 
 describe "Ruby apps" do
+  describe "with mingw platform" do
+    it "is detected as a Windows app" do
+      Hatchet::Runner.new("default_ruby").tap do |app|
+        app.before_deploy do
+          Pathname("Gemfile").write(<<~'EOF')
+            source "https://rubygems.org"
+
+            gem "rake"
+          EOF
+
+          Pathname("Gemfile.lock").write(<<~'EOF')
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                rake (13.2.1)
+
+            PLATFORMS
+              x86-mingw32
+              ruby
+
+            DEPENDENCIES
+              rake
+
+            BUNDLED WITH
+               2.5.9
+          EOF
+        end
+
+        app.deploy do
+          expect(app.output).to include("Windows platform detected, preserving `Gemfile.lock`")
+        end
+      end
+    end
+  end
 
   # https://github.com/heroku/heroku-buildpack-ruby/issues/1025
   describe "bin/rake binstub" do


### PR DESCRIPTION
Update windows docs to specify how to add Heroku's platform to the Gemfile.lock. In https://github.com/heroku/heroku-buildpack-ruby/pull/1469 the behavior changed for Windows users. However if they're depending on a platform specific gem and they don't have the `x86_64-linux` platform locked then their dependency resolution will not use that information and their deploy will fail with a message saying to run those commands. 

By adding the instructions into the descanter article, warning message, and changelog entry there's a better chance windows users will succeed on their first deploy after https://github.com/heroku/heroku-buildpack-ruby/pull/1469 

## Commands breakdown

Install the latest bundler version at the system level:

```
> gem install bundler
```

Update the current project to explicitly use the latest version of bundler:

```
> bundle update --bundler
```

Ensure that both `ruby` and `x86_64-linux` platforms are specified in the `Gemfile.lock`:

```
> bundle lock --add-platform ruby
> bundle lock --add-platform x86_64-linux
```

Ensure bundler has resolved dependencies with all platforms in mind:

```
> bundle install
```

Commit the results to git:

```
> git add Gemfile.lock
> git commit -m "Upgrade bundler"
```