### PR TITLE
Use `--update=none` instead of `-n` for `copy` in `cache.rb`

### DIFF
--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -58,7 +58,7 @@ class LanguagePack::Cache
     return unless @cache_base
 
     dest ||= path
-    copy (@cache_base + path), dest, '-a -n'
+    copy (@cache_base + path), dest, '-a --update=none'
   end
 
   # copy cache contents


### PR DESCRIPTION
Fixes #1485.

As per the man page (https://man7.org/linux/man-pages/man1/cp.1.html):

<img width="599" alt="image" src="https://github.com/user-attachments/assets/390f23d3-0cba-4fe2-99c4-8f07042d4c45">

<img width="511" alt="image" src="https://github.com/user-attachments/assets/1a86849d-bcad-47c4-85eb-4f2d2b3669bf">

<img width="641" alt="image" src="https://github.com/user-attachments/assets/5337243d-3932-49ea-8411-9f110f572b9a">