### PR TITLE
Ruby 3.2.5 is now available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Ruby 3.2.5 is now available (https://github.com/heroku/heroku-buildpack-ruby/pull/1488)
 
 ## [v277] - 2024-07-11
 

--- a/changelogs/unreleased/ruby_3.2.5.md
+++ b/changelogs/unreleased/ruby_3.2.5.md
@@ -1,0 +1,10 @@
+## Ruby version 3.2.5 is now available
+
+[Ruby v3.2.5](/articles/ruby-support#ruby-versions) is now available on Heroku. To run
+your app using this version of Ruby, add the following `ruby` directive to your Gemfile:
+
+```ruby
+ruby "3.2.5"
+```
+
+For more information on [Ruby 3.2.5, you can view the release announcement](https://www.ruby-lang.org/en/news/).


### PR DESCRIPTION
Released here: https://github.com/heroku/docker-heroku-ruby-builder/actions/runs/10252602472