### PR TITLE
Add Rails 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add detection support for Rails 8 (https://github.com/heroku/heroku-buildpack-ruby/pull/1498)
 
 ## [v278] - 2024-08-05
 

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -12,7 +12,7 @@ module LanguagePack
   def self.detect(*args)
     Dir.chdir(args.first)
 
-    pack = [ NoLockfile, Rails7, Rails6, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
+    pack = [ NoLockfile, Rails8, Rails7, Rails6, Rails5, Rails42, Rails41, Rails4, Rails3, Rails2, Rack, Ruby ].detect do |klass|
       klass.use?
     end
 
@@ -44,4 +44,5 @@ require "language_pack/rails42"
 require "language_pack/rails5"
 require "language_pack/rails6"
 require "language_pack/rails7"
+require "language_pack/rails8"
 require "language_pack/no_lockfile"

--- a/lib/language_pack/rails7.rb
+++ b/lib/language_pack/rails7.rb
@@ -8,8 +8,7 @@ class LanguagePack::Rails7 < LanguagePack::Rails6
     rails_version = bundler.gem_version('railties')
     return false unless rails_version
     is_rails = rails_version >= Gem::Version.new('7.a') &&
-      rails_version < Gem::Version.new('8.0.0')
+      rails_version < Gem::Version.new('8.a')
     return is_rails
   end
 end
-

--- a/lib/language_pack/rails8.rb
+++ b/lib/language_pack/rails8.rb
@@ -1,0 +1,14 @@
+require 'securerandom'
+require "language_pack"
+require "language_pack/rails7"
+
+class LanguagePack::Rails8 < LanguagePack::Rails7
+  # @return [Boolean] true if it's a Rails 8.x app
+  def self.use?
+    rails_version = bundler.gem_version('railties')
+    return false unless rails_version
+    is_rails = rails_version >= Gem::Version.new('8.a') &&
+      rails_version < Gem::Version.new('9.a')
+    return is_rails
+  end
+end

--- a/spec/hatchet/rails7_spec.rb
+++ b/spec/hatchet/rails7_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-describe "Rails 6" do
+describe "Rails 7" do
   it "should detect successfully" do
     Hatchet::App.new('rails-jsbundling').in_directory_fork do
       expect(LanguagePack::Rails6.use?).to eq(false)

--- a/spec/hatchet/rails8_spec.rb
+++ b/spec/hatchet/rails8_spec.rb
@@ -1,0 +1,4 @@
+require_relative '../spec_helper'
+
+describe "Rails 8" do
+end


### PR DESCRIPTION
Pulling in https://github.com/heroku/heroku-buildpack-ruby/pull/1490 for testing and modification. Removes the original tests as they're using Rails 7 fixtures. Adds a changelog entry