### PR TITLE
Update Node.js default to 22.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Default Node.js version no 22.11.0
+- Default Node.js version now 22.11.0 (https://github.com/heroku/heroku-buildpack-ruby/pull/1503)
+- Default Yarn version now 1.22.22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1503)
 - Add detection support for Rails 8 (https://github.com/heroku/heroku-buildpack-ruby/pull/1498)
 - Support Node.js on ARM builds (https://github.com/heroku/heroku-buildpack-ruby/pull/1499)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Default Node.js version no 22.11.0
 - Add detection support for Rails 8 (https://github.com/heroku/heroku-buildpack-ruby/pull/1498)
 - Support Node.js on ARM builds (https://github.com/heroku/heroku-buildpack-ruby/pull/1499)
 

--- a/changelogs/unreleased/node-yarn.md
+++ b/changelogs/unreleased/node-yarn.md
@@ -1,0 +1,8 @@
+## Ruby apps now default to Node version 22.11.0 and Yarn version 1.22.22
+
+Applications using the `heroku/ruby` buildpack that do not have a version of Node installed by another buildpack (such as the `heroku/nodejs` buildpack) will now receive:
+
+- Node version 22.11.0
+- Yarn version 1.22.22
+
+These versions and instructions on how to specify a specific version of these binaries can be found on the [installed binaries section of the Heroku Ruby Support page](https://devcenter.heroku.com/articles/ruby-support#installed-binaries).

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 class LanguagePack::Helpers::Nodebin
-  NODE_VERSION = "22.110"
+  NODE_VERSION = "22.11.0"
   YARN_VERSION = "1.22.22"
 
   def self.hardcoded_node_lts(arch: )

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -1,8 +1,8 @@
 require 'json'
 
 class LanguagePack::Helpers::Nodebin
-  NODE_VERSION = "20.9.0"
-  YARN_VERSION = "1.22.19"
+  NODE_VERSION = "22.110"
+  YARN_VERSION = "1.22.22"
 
   def self.hardcoded_node_lts(arch: )
     arch = "x64" if arch == "amd64"


### PR DESCRIPTION
Node.js 22.x is now the Active LTS release line as of 10-29-2024 ([source](https://github.com/nodejs/Release)). In accordance with Heroku's Node.js support policy, it should be the default version.

The same change for Node.js 20: #1397