### PR TITLE
Ruby v3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add detection support for Rails 8 (https://github.com/heroku/heroku-buildpack-ruby/pull/1498)
 - Support Node.js on ARM builds (https://github.com/heroku/heroku-buildpack-ruby/pull/1499)
 
+## [v280] - 2024-11-01
+
+- Ruby 3.2.6 is now available (https://github.com/heroku/heroku-buildpack-ruby/pull/1504)
+
 ## [v280] - 2024-10-08
 
 - Ruby 3.4.0 is now available (https://github.com/heroku/heroku-buildpack-ruby/pull/1496)


### PR DESCRIPTION

    ## Ruby version 3.2.6 is now available
    
    [Ruby v3.2.6](/articles/ruby-support#ruby-versions) is now available on Heroku. To run
    your app using this version of Ruby, add the following `ruby` directive to your Gemfile:
    
    ```ruby
    ruby "3.2.6"
    ```
    
    For more information on [Ruby 3.2.6, you can view the release announcement](https://www.ruby-lang.org/en/news/).
