### PR TITLE
Fix tests not executing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem "parallel_tests"
   gem 'rspec-retry'
   gem 'json'
-  gem 'ci-queue'
+  gem 'ci-queue', github: "schneems/ci-queue", branch: "schneems/allow-hosted-redis"
   gem 'redis'
   gem 'dead_end'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
-    ci-queue (0.55.0)
+    ci-queue (0.58.0)
     citrus (3.0.2)
     connection_pool (2.4.1)
     dead_end (4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,15 @@
+GIT
+  remote: https://github.com/schneems/ci-queue.git
+  revision: 285353ba8bc58e1b2ed02dedf55730400c27e32b
+  branch: schneems/allow-hosted-redis
+  specs:
+    ci-queue (0.58.0)
+      logger
+
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
-    ci-queue (0.58.0)
     citrus (3.0.2)
     connection_pool (2.4.1)
     dead_end (4.0.0)
@@ -23,6 +30,7 @@ GEM
       thor (~> 1)
       threaded (~> 0)
     json (2.7.2)
+    logger (1.6.1)
     moneta (1.0.0)
     multi_json (1.15.0)
     parallel (1.25.1)
@@ -57,7 +65,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ci-queue
+  ci-queue!
   dead_end
   excon
   heroku_hatchet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       rate_throttle_client (~> 0.1.0)
     rake (13.2.1)
     rate_throttle_client (0.1.2)
-    redis (5.2.0)
+    redis (5.3.0)
       redis-client (>= 0.22.0)
     redis-client (0.22.2)
       connection_pool

--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
       },
       "scripts": {
         "test-setup": "bundle exec rake hatchet:setup_ci",
-        "test": "bundle exec rspec-queue --max-requeues=3 --timeout 180 --queue $REDIS_URL || { cat log/test_order.log;  $(exit 1); }"
+        "test": "bundle exec rspec-queue --max-requeues=3 --timeout 180 --queue $REDIS_URL --format documentation || { cat log/test_order.log;  $(exit 1); }"
       },
       "buildpacks": [
         {


### PR DESCRIPTION
Fix #1505 by bypassing redis connection SSL verification.

In #1505 debugging found that trying to connect to a Redis instance with a self-signed certificate via `ci-queue` would result in no tests being run but the output returning a zero exit code (indicating success). This behavior was reported in https://github.com/Shopify/ci-queue/issues/292 where they shared that it's intentional to handle flaky test workers (shopify scale is much larger than my 16 node setup here).

This PR uses a branch of the ci-queue gem that disables SSL validation by default (allowing connecting to redis servers with self-signed certificates). Differences are here https://github.com/Shopify/ci-queue/compare/main...schneems:ci-queue:schneems/allow-hosted-redis.

The result is that when using these problem versions https://github.com/heroku/heroku-buildpack-ruby/issues/1516 is that the suite now executes correctly and reports a failure for the problem versions:

<img width="395" alt="image" src="https://github.com/user-attachments/assets/731dcaac-be25-4a79-a29d-5cc70b21a0d6">

After validating that CI behavior I rebased against main which should be green. I'll work towards upstreaming that feature, but in the short term this enables our CI to correctly run tests and report failures.