### PR TITLE
Roll back node & yarn updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ## [v282] - 2024-11-08
 
-- Default Node.js version now 22.11.0 (https://github.com/heroku/heroku-buildpack-ruby/pull/1503)
-- Default Yarn version now 1.22.22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1503)
+- [Rolled back] Default Node.js version now 22.11.0 (https://github.com/heroku/heroku-buildpack-ruby/pull/1503)
+- [Rolled back] Default Yarn version now 1.22.22 (https://github.com/heroku/heroku-buildpack-ruby/pull/1503)
 
 ## [v281] - 2024-11-07
 

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -1,8 +1,8 @@
 require 'json'
 
 class LanguagePack::Helpers::Nodebin
-  NODE_VERSION = "22.11.0"
-  YARN_VERSION = "1.22.22"
+  NODE_VERSION = "20.9.0"
+  YARN_VERSION = "1.22.19"
 
   def self.hardcoded_node_lts(arch: )
     arch = "x64" if arch == "amd64"


### PR DESCRIPTION
There's an issue with the way that yarn is packaged that caused #1516 due to behavior introduced in #1503. This commit reverts to the old node/yarn versions until we can fix the underlying bug.