### PR TITLE
Fix build timeouts with node/yarn by setting UV_USE_IO_URING=0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Default `UV_USE_IO_URING=0` due to build timeouts [context](https://github.com/heroku/heroku-buildpack-nodejs/pull/1347) (https://github.com/heroku/heroku-buildpack-ruby/pull/1523)
 
 ## [v284] - 2024-11-15
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -965,7 +965,6 @@ params = CGI.parse(uri.query || "")
       old_version = @metadata.fetch("default_node_version") { version }
 
       ENV["UV_USE_IO_URING"] ||= "0"
-      set_env_default "UV_USE_IO_URING", "0"
 
       if version != version
         warn(<<~WARNING, inline: true)
@@ -998,7 +997,6 @@ params = CGI.parse(uri.query || "")
       old_version = @metadata.fetch("default_yarn_version") { version }
 
       ENV["UV_USE_IO_URING"] ||= "0"
-      set_env_default "UV_USE_IO_URING", "0"
 
       if version != version
         warn(<<~WARNING, inline: true)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -964,7 +964,10 @@ params = CGI.parse(uri.query || "")
       version = @node_installer.version
       old_version = @metadata.fetch("default_node_version") { version }
 
+      # Make available for `rake assets:precompile` and other sub-shells
       ENV["UV_USE_IO_URING"] ||= "0"
+      # Make available to future buildpacks (export), but not runtime (profile.d)
+      set_export_default "UV_USE_IO_URING", "0"
 
       if version != version
         warn(<<~WARNING, inline: true)
@@ -996,7 +999,10 @@ params = CGI.parse(uri.query || "")
       version = @yarn_installer.version
       old_version = @metadata.fetch("default_yarn_version") { version }
 
+      # Make available for `rake assets:precompile` and other sub-shells
       ENV["UV_USE_IO_URING"] ||= "0"
+      # Make available to future buildpacks (export), but not runtime (profile.d)
+      set_export_default "UV_USE_IO_URING", "0"
 
       if version != version
         warn(<<~WARNING, inline: true)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -964,6 +964,9 @@ params = CGI.parse(uri.query || "")
       version = @node_installer.version
       old_version = @metadata.fetch("default_node_version") { version }
 
+      ENV["UV_USE_IO_URING"] ||= "0"
+      set_env_default "UV_USE_IO_URING", "0"
+
       if version != version
         warn(<<~WARNING, inline: true)
           Default version of Node.js changed (#{old_version} to #{version})
@@ -993,6 +996,9 @@ params = CGI.parse(uri.query || "")
 
       version = @yarn_installer.version
       old_version = @metadata.fetch("default_yarn_version") { version }
+
+      ENV["UV_USE_IO_URING"] ||= "0"
+      set_env_default "UV_USE_IO_URING", "0"
 
       if version != version
         warn(<<~WARNING, inline: true)


### PR DESCRIPTION
Default `UV_USE_IO_URING=0` due to build timeouts This mirrors a change by the nodejs buildpack: https://github.com/heroku/heroku-buildpack-nodejs/pull/1347

The Ruby buildpack needs this because we can install node/yarn without the `heroku/nodejs` buildpack, however this behavior triggers a warning and is generally advised against.