### PR TITLE
Use non-forked ci-queue gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem "parallel_tests"
   gem 'rspec-retry'
   gem 'json'
-  gem 'ci-queue', github: "schneems/ci-queue", branch: "schneems/allow-hosted-redis"
+  gem 'ci-queue'
   gem 'redis'
   gem 'dead_end'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,9 @@
-GIT
-  remote: https://github.com/schneems/ci-queue.git
-  revision: 285353ba8bc58e1b2ed02dedf55730400c27e32b
-  branch: schneems/allow-hosted-redis
-  specs:
-    ci-queue (0.58.0)
-      logger
-
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
+    ci-queue (0.59.0)
+      logger
     citrus (3.0.2)
     connection_pool (2.4.1)
     dead_end (4.0.0)
@@ -30,7 +24,7 @@ GEM
       thor (~> 1)
       threaded (~> 0)
     json (2.7.2)
-    logger (1.6.1)
+    logger (1.6.2)
     moneta (1.0.0)
     multi_json (1.15.0)
     parallel (1.25.1)
@@ -65,7 +59,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ci-queue!
+  ci-queue
   dead_end
   excon
   heroku_hatchet


### PR DESCRIPTION
Should work on hosted redis now https://github.com/Shopify/ci-queue/pull/294