### PR TITLE
Stage Ruby 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Ruby 3.4.0 is now available (https://github.com/heroku/heroku-buildpack-ruby/pull/1531)
+- Ruby 3.4.1 is now available (https://github.com/heroku/heroku-buildpack-ruby/pull/1531)
 
 ## [v286] - 2024-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Ruby 3.4.0 is now available (https://github.com/heroku/heroku-buildpack-ruby/pull/1531)
 
 ## [v286] - 2024-12-13
 

--- a/changelogs/unreleased/ruby_3.4.0.md
+++ b/changelogs/unreleased/ruby_3.4.0.md
@@ -1,0 +1,9 @@
+## Ruby version 3.4.0 is now available
+
+[Ruby v3.4.0](/articles/ruby-support-reference#ruby-versions) is now available on Heroku. To run your app using this version of Ruby, add the following `ruby` directive to your Gemfile:
+
+```ruby
+ruby "3.4.0"
+```
+
+For more information on [Ruby 3.4.0, you can view the release announcement](https://www.ruby-lang.org/en/news/).


### PR DESCRIPTION
Ruby 3.4.0 will be released on Christmas. This PR is for pre-approval. It will be held for merge until December 25th, 2024.