### PR TITLE
Update default Ruby version to 3.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Default Ruby version is now 3.3.7 (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
+- Default bundler version (when no version present in the `Gemfile.lock`) is now bundler `2.3.x` which is currently `2.3.25` (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
 
 ## [v288] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Default Ruby version is now 3.3.6 (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
 
 ## [v288] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Default Ruby version is now 3.3.6 (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
+- Default Ruby version is now 3.3.7 (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
 
 ## [v288] - 2025-01-06
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '>= 3.1', '< 3.3'
+ruby "3.3.6"
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.6"
+ruby "3.3.7"
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.1.6p260
+   ruby 3.3.6p260
 
 BUNDLED WITH
    2.5.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.3.6p260
+   ruby 3.3.7p260
 
 BUNDLED WITH
    2.5.11

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "3.1.6"
+ruby_version = "3.3.6"
 
 [publish.Ignore]
 files = [

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "3.3.6"
+ruby_version = "3.3.7"
 
 [publish.Ignore]
 files = [

--- a/changelogs/unreleased/bundler_default.md
+++ b/changelogs/unreleased/bundler_default.md
@@ -1,0 +1,13 @@
+## Ruby applications with no specified bundler versions now receive Bundler 2.x
+
+Previously applications with no `BUNDLED WITH` in their `Gemfile.lock` would receive bundler `1.x`. They will now receive the new [default bundler version](https://devcenter.heroku.com/articles/ruby-support-reference#default-bundler-version) `2.3.x`.
+
+It is strongly recommended that you have both a `RUBY VERSION` and `BUNDLED WITH` version listed in your `Gemfile.lock`. If you do not have those values, you can generate them and commit them to git:
+
+```
+$ bundle update --ruby
+$ git add Gemfile.lock
+$ git commit -m "Update Gemfile.lock"
+```
+
+Applications without these values specified in the `Gemfile.lock` may break unexpectedly when the defaults change.

--- a/changelogs/unreleased/default_ruby.md
+++ b/changelogs/unreleased/default_ruby.md
@@ -1,0 +1,3 @@
+## Default Ruby version for new apps is now 3.3.6
+
+The [default Ruby version for new Ruby applications is 3.3.6](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.

--- a/changelogs/unreleased/default_ruby.md
+++ b/changelogs/unreleased/default_ruby.md
@@ -1,3 +1,3 @@
-## Default Ruby version for new apps is now 3.3.6
+## Default Ruby version for new apps is now 3.3.7
 
-The [default Ruby version for new Ruby applications is 3.3.6](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.
+The [default Ruby version for new Ruby applications is 3.3.7](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.

--- a/hatchet.json
+++ b/hatchet.json
@@ -50,9 +50,9 @@
     "sharpstone/minimal_webpacker"
   ],
   "ci": [
-    "sharpstone/rails5_ruby_schema_format",
+    "sharpstone/rails_8_ruby_schema",
     "sharpstone/heroku-ci-json-example",
-    "sharpstone/rails5_sql_schema_format",
+    "sharpstone/rails_8_sql_schema",
     "sharpstone/ruby_no_rails_test",
     "sharpstone/activerecord_rake_tasks_does_not_exist"
   ]

--- a/hatchet.json
+++ b/hatchet.json
@@ -26,7 +26,9 @@
     "sharpstone/rails4_windows_mri193",
     "sharpstone/rails42_default_ruby",
     "sharpstone/rails61",
-    "sharpstone/rails-jsbundling"
+    "sharpstone/rails-jsbundling",
+    "sharpstone/rails_8_ruby_schema",
+    "sharpstone/rails_8_sql_schema"
   ],
   "heroku": [
     "heroku/ruby-getting-started"
@@ -35,9 +37,7 @@
     "sharpstone/minimal_webpacker"
   ],
   "ci": [
-    "sharpstone/rails_8_ruby_schema",
     "sharpstone/heroku-ci-json-example",
-    "sharpstone/rails_8_sql_schema",
     "sharpstone/ruby_no_rails_test"
   ]
 }

--- a/hatchet.json
+++ b/hatchet.json
@@ -4,41 +4,26 @@
     "sharpstone/asset_precompile_pass",
     "sharpstone/asset_precompile_not_found",
     "sharpstone/no_rakefile",
-    "sharpstone/bad_rakefile",
-    "sharpstone/default_with_rakefile"
+    "sharpstone/bad_rakefile"
   ],
   "bundler": [
-    "sharpstone/problem_gemfile_version",
     "sharpstone/git_gemspec",
     "sharpstone/no_lockfile",
-    "sharpstone/sqlite3_gemfile",
-    "sharpstone/nokogiri_160"
+    "sharpstone/sqlite3_gemfile"
   ],
   "ruby": [
     "sharpstone/ruby_version_does_not_exist",
-    "sharpstone/ruby_193_jruby_17161_jdk7",
-    "sharpstone/ruby_25",
     "sharpstone/jruby-minimal",
     "sharpstone/empty-procfile",
-    "sharpstone/bad_ruby_version",
-    "sharpstone/activerecord41_scaffold",
-    "sharpstone/libpq_connection_error"
-  ],
-  "jruby": [
-    "sharpstone/jruby_naether"
+    "sharpstone/bad_ruby_version"
   ],
   "rack": [
-    "sharpstone/default_ruby",
-    "sharpstone/mri_187_nokogiri",
-    "sharpstone/mri_192"
+    "sharpstone/default_ruby"
   ],
   "rails_versions": [
     "sharpstone/rails_lts_23_default_ruby",
     "sharpstone/rails4_windows_mri193",
     "sharpstone/rails42_default_ruby",
-    "sharpstone/active_storage_non_local",
-    "sharpstone/active_storage_local",
-    "sharpstone/sprockets_asset_compile_true",
     "sharpstone/rails61",
     "sharpstone/rails-jsbundling"
   ],
@@ -52,7 +37,6 @@
     "sharpstone/rails_8_ruby_schema",
     "sharpstone/heroku-ci-json-example",
     "sharpstone/rails_8_sql_schema",
-    "sharpstone/ruby_no_rails_test",
-    "sharpstone/activerecord_rake_tasks_does_not_exist"
+    "sharpstone/ruby_no_rails_test"
   ]
 }

--- a/hatchet.json
+++ b/hatchet.json
@@ -22,6 +22,7 @@
   ],
   "rails_versions": [
     "sharpstone/rails_lts_23_default_ruby",
+    "sharpstone/rails3_default_ruby",
     "sharpstone/rails4_windows_mri193",
     "sharpstone/rails42_default_ruby",
     "sharpstone/rails61",

--- a/hatchet.json
+++ b/hatchet.json
@@ -34,7 +34,6 @@
   ],
   "rails_versions": [
     "sharpstone/rails_lts_23_default_ruby",
-    "sharpstone/rails3_default_ruby",
     "sharpstone/rails4_windows_mri193",
     "sharpstone/rails42_default_ruby",
     "sharpstone/active_storage_non_local",

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -3,14 +3,8 @@
   - 7755e19caf122e1373bce73ffe9b333e9411d732
 - - "./repos/bundler/no_lockfile"
   - 1947ce9a9c276d5df1c323b2ad78d1d85c7ab4c0
-- - "./repos/bundler/nokogiri_160"
-  - d9a761776be43e1c685f98ef13c6ef1ee0292267
-- - "./repos/bundler/problem_gemfile_version"
-  - abc25a7b582a720b99148a1c8753d0d7452254bb
 - - "./repos/bundler/sqlite3_gemfile"
   - 116db685f54dae18f703b3beb90e64fdbddb048d
-- - "./repos/ci/activerecord_rake_tasks_does_not_exist"
-  - a6b711be6921cf7a0aa4e31269c37965799ea110
 - - "./repos/ci/heroku-ci-json-example"
   - 4e5410a7381f486ba3df7739e02e52f32fdd4dda
 - - "./repos/ci/rails_8_ruby_schema"
@@ -21,20 +15,10 @@
   - 3916137106d59b008b67d738abe6a1438f8fbde6
 - - "./repos/heroku/ruby-getting-started"
   - main
-- - "./repos/jruby/jruby_naether"
-  - 4a11f8af5a3cca21f3659394e5bbac3cca9b6a2c
 - - "./repos/node/minimal_webpacker"
-  - 9152fec98df59a0bf8a5478ed428841ee135acbb
+  - d659577a612b12ddb44ce34e28124c025ecb22f3
 - - "./repos/rack/default_ruby"
   - master
-- - "./repos/rack/mri_187_nokogiri"
-  - 3fcce9c85bf560dba285cc385ae9845729195826
-- - "./repos/rack/mri_192"
-  - ef6b5ccf8aa2a8f5e3745934e3580dc0bd2d6d4b
-- - "./repos/rails_versions/active_storage_local"
-  - 18853ba7dda61745995740b4ca6f5f90bbd8afba
-- - "./repos/rails_versions/active_storage_non_local"
-  - 86dddf0127043abba1cb2890590a1d38f111edbd
 - - "./repos/rails_versions/rails-jsbundling"
   - c58178e061d9846386ca34ea31c99f6e6bb8dbf7
 - - "./repos/rails_versions/rails3_default_ruby"
@@ -44,11 +28,9 @@
 - - "./repos/rails_versions/rails4_windows_mri193"
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"
-  - e896f51e679eaf2204aa4fab6d038103fc622aed
+  - 03de843ba5151eee8eebcfca00317b090a8fb1bc
 - - "./repos/rails_versions/rails_lts_23_default_ruby"
-  - 7178b2f97d3b2b3170b390d997dcb212dd52cd30
-- - "./repos/rails_versions/sprockets_asset_compile_true"
-  - 6f3aa208046a5c79e84fc272f52f5ebb7b775755
+  - f3597fd6f0887763eb65ec2f83a5e9a5155d5625
 - - "./repos/rake/asset_precompile_fail"
   - 16f7834331d6bb3fc5c284130b14eb1ff74d99d5
 - - "./repos/rake/asset_precompile_not_found"
@@ -57,8 +39,6 @@
   - ce976c727d9f477957c499f39f4cf9603c378103
 - - "./repos/rake/bad_rakefile"
   - 3cb9c7bf6494c59bd25fa74c2aa4531119e12a46
-- - "./repos/rake/default_with_rakefile"
-  - c6e0c4db8dcccb47e11d496e17adbc2dafc80dd8
 - - "./repos/rake/no_rakefile"
   - d2ec2084b825218418dac54bd6276ac896b31cdd
 - - "./repos/ruby/activerecord41_scaffold"
@@ -71,8 +51,6 @@
   - f79860bc2866449fe065484f1542aaadd3f7cfd2
 - - "./repos/ruby/libpq_connection_error"
   - c211c245f09d8335a520cd7a0b5360897d4988eb
-- - "./repos/ruby/ruby_193_jruby_17161_jdk7"
-  - c1b632f8a96cf9b902f5cdcd7a190d46544a8144
 - - "./repos/ruby/ruby_25"
   - 0cb3df80d55b61e9417f2ac00adb06e15ae37982
 - - "./repos/ruby/ruby_version_does_not_exist"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -22,7 +22,7 @@
 - - "./repos/rails_versions/rails-jsbundling"
   - c58178e061d9846386ca34ea31c99f6e6bb8dbf7
 - - "./repos/rails_versions/rails3_default_ruby"
-  - 984b6d02353519251c2d1e885bf8914a2584f26at
+  - 984b6d02353519251c2d1e885bf8914a2584f26a
 - - "./repos/rails_versions/rails42_default_ruby"
   - fbdaf031823f09d1514ec1d55dcb04ca2f4264ca
 - - "./repos/rails_versions/rails4_windows_mri193"
@@ -41,17 +41,11 @@
   - 3cb9c7bf6494c59bd25fa74c2aa4531119e12a46
 - - "./repos/rake/no_rakefile"
   - d2ec2084b825218418dac54bd6276ac896b31cdd
-- - "./repos/ruby/activerecord41_scaffold"
-  - 6e4662c44b49e2c3c9429f00e7e7f4708142b03f
 - - "./repos/ruby/bad_ruby_version"
   - 7bf3470265a87ea6361640aa4bfce6ce3b743520
 - - "./repos/ruby/empty-procfile"
   - 7cae0aae424c2028b81b5d37ee24d42db8e545b9
 - - "./repos/ruby/jruby-minimal"
   - f79860bc2866449fe065484f1542aaadd3f7cfd2
-- - "./repos/ruby/libpq_connection_error"
-  - c211c245f09d8335a520cd7a0b5360897d4988eb
-- - "./repos/ruby/ruby_25"
-  - 0cb3df80d55b61e9417f2ac00adb06e15ae37982
 - - "./repos/ruby/ruby_version_does_not_exist"
   - 9b6ad8e3b4fa7850393a5f232bb40ff3cd414d8b

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -12,7 +12,7 @@
 - - "./repos/ci/rails_8_sql_schema"
   - e00d7b7b9cf95fb0a3aceb3c945025e5d20dec90
 - - "./repos/ci/ruby_no_rails_test"
-  - 3916137106d59b008b67d738abe6a1438f8fbde6
+  - c5925ab061f65433ec5dcbc890975f580e74c5ce
 - - "./repos/heroku/ruby-getting-started"
   - main
 - - "./repos/node/minimal_webpacker"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -7,10 +7,6 @@
   - 116db685f54dae18f703b3beb90e64fdbddb048d
 - - "./repos/ci/heroku-ci-json-example"
   - 728cc99c8e80290cc07441d61a8bcd4596e696fb
-- - "./repos/ci/rails_8_ruby_schema"
-  - 32a4dce6c43834752dd9f263c41290a4ff168795
-- - "./repos/ci/rails_8_sql_schema"
-  - e00d7b7b9cf95fb0a3aceb3c945025e5d20dec90
 - - "./repos/ci/ruby_no_rails_test"
   - c5925ab061f65433ec5dcbc890975f580e74c5ce
 - - "./repos/heroku/ruby-getting-started"
@@ -29,6 +25,10 @@
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"
   - bcd505482b66ceb2da3fae19bbc13a208bf5f08e
+- - "./repos/rails_versions/rails_8_ruby_schema"
+  - 3c2466b2176ff9ee074bdd4d3f97ae8785a850c2
+- - "./repos/rails_versions/rails_8_sql_schema"
+  - 4da54ce6f267e6cfc8f9de3f68d45ea06b927739
 - - "./repos/rails_versions/rails_lts_23_default_ruby"
   - f3597fd6f0887763eb65ec2f83a5e9a5155d5625
 - - "./repos/rake/asset_precompile_fail"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -26,9 +26,9 @@
 - - "./repos/rails_versions/rails61"
   - 47828a3e8c79b7869ca0d9a3afa4be065fa46e96
 - - "./repos/rails_versions/rails_8_ruby_schema"
-  - 3c2466b2176ff9ee074bdd4d3f97ae8785a850c2
+  - a993a3f00c8e09f733bc3b783f7e37148d0af1d4
 - - "./repos/rails_versions/rails_8_sql_schema"
-  - 4da54ce6f267e6cfc8f9de3f68d45ea06b927739
+  - d5089812196931e858a97119de1640a86825a272
 - - "./repos/rails_versions/rails_lts_23_default_ruby"
   - f3597fd6f0887763eb65ec2f83a5e9a5155d5625
 - - "./repos/rake/asset_precompile_fail"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -24,7 +24,7 @@
 - - "./repos/rails_versions/rails4_windows_mri193"
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"
-  - b9b3f3c205800dde9aeeba4912400d07b2f90ad7
+  - 47828a3e8c79b7869ca0d9a3afa4be065fa46e96
 - - "./repos/rails_versions/rails_8_ruby_schema"
   - 3c2466b2176ff9ee074bdd4d3f97ae8785a850c2
 - - "./repos/rails_versions/rails_8_sql_schema"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -28,7 +28,7 @@
 - - "./repos/rails_versions/rails4_windows_mri193"
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"
-  - 03de843ba5151eee8eebcfca00317b090a8fb1bc
+  - bcd505482b66ceb2da3fae19bbc13a208bf5f08e
 - - "./repos/rails_versions/rails_lts_23_default_ruby"
   - f3597fd6f0887763eb65ec2f83a5e9a5155d5625
 - - "./repos/rake/asset_precompile_fail"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -38,9 +38,9 @@
 - - "./repos/rails_versions/rails-jsbundling"
   - c58178e061d9846386ca34ea31c99f6e6bb8dbf7
 - - "./repos/rails_versions/rails3_default_ruby"
-  - a6b44db674c0d3538633989295e2cfd5e8e1ba0d
+  - 984b6d02353519251c2d1e885bf8914a2584f26at
 - - "./repos/rails_versions/rails42_default_ruby"
-  - dfa0f0133dafa62064968ea2efb6432f54350138
+  - e90f232432e46a4c04ff30b970e11e7a39d9489f
 - - "./repos/rails_versions/rails4_windows_mri193"
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -24,7 +24,7 @@
 - - "./repos/rails_versions/rails4_windows_mri193"
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"
-  - bcd505482b66ceb2da3fae19bbc13a208bf5f08e
+  - b9b3f3c205800dde9aeeba4912400d07b2f90ad7
 - - "./repos/rails_versions/rails_8_ruby_schema"
   - 3c2466b2176ff9ee074bdd4d3f97ae8785a850c2
 - - "./repos/rails_versions/rails_8_sql_schema"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -13,10 +13,10 @@
   - a6b711be6921cf7a0aa4e31269c37965799ea110
 - - "./repos/ci/heroku-ci-json-example"
   - 4e5410a7381f486ba3df7739e02e52f32fdd4dda
-- - "./repos/ci/rails5_ruby_schema_format"
-  - 8b8a3a7850bdba29bdefc70c0f80f35a9e6c96ae
-- - "./repos/ci/rails5_sql_schema_format"
-  - ee81b300a1019b47bbcaec0a512932df7dc23bc0
+- - "./repos/ci/rails_8_ruby_schema"
+  - 32a4dce6c43834752dd9f263c41290a4ff168795
+- - "./repos/ci/rails_8_sql_schema"
+  - e00d7b7b9cf95fb0a3aceb3c945025e5d20dec90
 - - "./repos/ci/ruby_no_rails_test"
   - 3916137106d59b008b67d738abe6a1438f8fbde6
 - - "./repos/heroku/ruby-getting-started"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -20,7 +20,7 @@
 - - "./repos/rack/default_ruby"
   - master
 - - "./repos/rails_versions/rails-jsbundling"
-  - c58178e061d9846386ca34ea31c99f6e6bb8dbf7
+  - 50e9fdf7c3a37623c676989ddebac4ee5349734b
 - - "./repos/rails_versions/rails3_default_ruby"
   - 984b6d02353519251c2d1e885bf8914a2584f26a
 - - "./repos/rails_versions/rails42_default_ruby"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -6,7 +6,7 @@
 - - "./repos/bundler/sqlite3_gemfile"
   - 116db685f54dae18f703b3beb90e64fdbddb048d
 - - "./repos/ci/heroku-ci-json-example"
-  - 4e5410a7381f486ba3df7739e02e52f32fdd4dda
+  - 728cc99c8e80290cc07441d61a8bcd4596e696fb
 - - "./repos/ci/rails_8_ruby_schema"
   - 32a4dce6c43834752dd9f263c41290a4ff168795
 - - "./repos/ci/rails_8_sql_schema"
@@ -24,7 +24,7 @@
 - - "./repos/rails_versions/rails3_default_ruby"
   - 984b6d02353519251c2d1e885bf8914a2584f26at
 - - "./repos/rails_versions/rails42_default_ruby"
-  - e90f232432e46a4c04ff30b970e11e7a39d9489f
+  - fbdaf031823f09d1514ec1d55dcb04ca2f4264ca
 - - "./repos/rails_versions/rails4_windows_mri193"
   - f4c7b6209835050468bbb87827acf652b8f4d8ce
 - - "./repos/rails_versions/rails61"

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -112,7 +112,7 @@ class LanguagePack::Base
 
   def write_release_yaml
     release = build_release
-    FileUtils.mkdir("tmp") unless File.exists?("tmp")
+    FileUtils.mkdir("tmp") unless File.exist?("tmp")
     File.open("tmp/heroku-buildpack-release-step.yml", 'w') do |f|
       f.write(release.to_yaml)
     end

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -87,6 +87,6 @@ class LanguagePack::Cache
   def exists?(path)
     return unless @cache_base
 
-    File.exists?(@cache_base + path)
+    File.exist?(@cache_base + path)
   end
 end

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -28,7 +28,7 @@ module LanguagePack
 
     def fetch_untar(path, files_to_extract = nil, strip_components: 0)
       curl = curl_command("#{@host_url.join(path)} -s -o")
-      tar_cmd = ["tar zxf - #{files_to_extract}", "--strip #{strip_components}"]
+      tar_cmd = ["tar", "--strip-components=#{strip_components}", "-xzf", "- #{files_to_extract}"]
       run! "#{curl} - | #{tar_cmd.join(" ")}",
         error_class: FetchError,
         max_attempts: 3

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -42,6 +42,10 @@ class LanguagePack::Helpers::BundlerWrapper
   BLESSED_BUNDLER_VERSIONS["2.4"] = "2.4.22"
   BLESSED_BUNDLER_VERSIONS["2.5"] = "2.5.23"
   BLESSED_BUNDLER_VERSIONS["2.6"] = "2.6.2"
+
+  DEFAULT_VERSION = BLESSED_BUNDLER_VERSIONS["2.3"]
+
+  # Convert arbitrary `<Major>.<Minor>.x` versions
   BLESSED_BUNDLER_VERSIONS.default_proc = Proc.new do |hash, key|
     if Gem::Version.new(key).segments.first == 1
       hash["1"]
@@ -65,7 +69,7 @@ class LanguagePack::Helpers::BundlerWrapper
       minor = version_match[:minor]
       BLESSED_BUNDLER_VERSIONS["#{major}.#{minor}"]
     else
-      BLESSED_BUNDLER_VERSIONS["1"]
+      DEFAULT_VERSION
     end
   end
 

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -95,7 +95,7 @@ class LanguagePack::Helpers::BundlerWrapper
       msg << "\n"
       msg << "```\n"
       msg << "BUNDLED WITH\n"
-      msg << "   #{version_hash["1"]}\n"
+      msg << "   #{DEFAULT_VERSION}\n"
       msg << "```\n"
       super msg
     end

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -239,7 +239,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   private
   def fetch_bundler
-    return true if Dir.exists?(bundler_path)
+    return true if Dir.exist?(bundler_path)
 
     topic("Installing bundler #{@version}")
     bundler_version_escape_valve!

--- a/lib/language_pack/metadata.rb
+++ b/lib/language_pack/metadata.rb
@@ -26,7 +26,7 @@ class LanguagePack::Metadata
 
   def exists?(key)
     full_key = "#{FOLDER}/#{key}"
-    File.exists?(full_key) && !Dir.exists?(full_key)
+    File.exist?(full_key) && !Dir.exists?(full_key)
   end
   alias_method :include?, :exists?
 

--- a/lib/language_pack/metadata.rb
+++ b/lib/language_pack/metadata.rb
@@ -26,7 +26,7 @@ class LanguagePack::Metadata
 
   def exists?(key)
     full_key = "#{FOLDER}/#{key}"
-    File.exist?(full_key) && !Dir.exists?(full_key)
+    File.exist?(full_key) && !Dir.exist?(full_key)
   end
   alias_method :include?, :exists?
 

--- a/lib/language_pack/no_lockfile.rb
+++ b/lib/language_pack/no_lockfile.rb
@@ -3,7 +3,7 @@ require "language_pack/ruby"
 
 class LanguagePack::NoLockfile < LanguagePack::Ruby
   def self.use?
-    !File.exists?("Gemfile.lock")
+    !File.exist?("Gemfile.lock")
   end
 
   def name

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -169,7 +169,7 @@ WARNING
   # runs the tasks for the Rails 3.1 asset pipeline
   def run_assets_precompile_rake_task
     log("assets_precompile") do
-      if File.exists?("public/assets/manifest.yml")
+      if File.exist?("public/assets/manifest.yml")
         puts "Detected manifest.yml, assuming assets were compiled locally"
         return true
       end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -629,7 +629,7 @@ EOF
   # users should be using `bundle pack` instead.
   # https://github.com/heroku/heroku-buildpack-ruby/issues/21
   def remove_vendor_bundle
-    if File.exists?("vendor/bundle")
+    if File.exist?("vendor/bundle")
       warn(<<-WARNING)
 Removing `vendor/bundle`.
 Checking in `vendor/bundle` is not supported. Please remove this directory
@@ -1130,7 +1130,7 @@ params = CGI.parse(uri.query || "")
     end
 
     # fix bug from v37 deploy
-    if File.exists?("#{path}/vendor/ruby_version")
+    if File.exist?("#{path}/vendor/ruby_version")
       puts "Broken cache detected. Purging build cache."
       cache.clear("vendor")
       FileUtils.rm_rf("#{path}/vendor/ruby_version")
@@ -1148,7 +1148,7 @@ MESSAGE
     end
 
     # fix git gemspec bug from Bundler 1.3.0+ upgrade
-    if File.exists?(bundler_cache) && !metadata.include?(:bundler_version) && !run("find #{path}/vendor/bundle/*/*/bundler/gems/*/ -name *.gemspec").include?("No such file or directory")
+    if File.exist?(bundler_cache) && !metadata.include?(:bundler_version) && !run("find #{path}/vendor/bundle/*/*/bundler/gems/*/ -name *.gemspec").include?("No such file or directory")
       return [false, "Old bundler cache detected. Clearing bundler cache."]
     end
 
@@ -1220,7 +1220,7 @@ MESSAGE
     end
 
     # fix bug from v37 deploy
-    if File.exists?("vendor/ruby_version")
+    if File.exist?("vendor/ruby_version")
       puts "Broken cache detected. Purging build cache."
       cache.clear("vendor")
       FileUtils.rm_rf("vendor/ruby_version")
@@ -1237,7 +1237,7 @@ MESSAGE
     end
 
     # fix git gemspec bug from Bundler 1.3.0+ upgrade
-    if File.exists?(bundler_cache) && !@metadata.exists?(bundler_version_cache) && !run("find vendor/bundle/*/*/bundler/gems/*/ -name *.gemspec").include?("No such file or directory")
+    if File.exist?(bundler_cache) && !@metadata.exists?(bundler_version_cache) && !run("find vendor/bundle/*/*/bundler/gems/*/ -name *.gemspec").include?("No such file or directory")
       puts "Old bundler cache detected. Clearing bundler cache."
       purge_bundler_cache
     end

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,8 +12,8 @@ module LanguagePack
       end
     end
 
-    BOOTSTRAP_VERSION_NUMBER = "3.1.6".freeze
-    DEFAULT_VERSION_NUMBER = "3.1.6".freeze
+    BOOTSTRAP_VERSION_NUMBER = "3.3.6".freeze
+    DEFAULT_VERSION_NUMBER = "3.3.6".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}".freeze

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,8 +12,8 @@ module LanguagePack
       end
     end
 
-    BOOTSTRAP_VERSION_NUMBER = "3.3.6".freeze
-    DEFAULT_VERSION_NUMBER = "3.3.6".freeze
+    BOOTSTRAP_VERSION_NUMBER = "3.3.7".freeze
+    DEFAULT_VERSION_NUMBER = "3.3.7".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze
     LEGACY_VERSION         = "ruby-#{LEGACY_VERSION_NUMBER}".freeze

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -255,7 +255,7 @@ module LanguagePack
       end
 
       $stdout.flush
-    rescue ArgumentError => e
+    rescue ArgumentError, Encoding::CompatibilityError => e
       error_message = e.message
       raise e if error_message !~ /invalid byte sequence/
 

--- a/lib/language_pack/test/rails7.rb
+++ b/lib/language_pack/test/rails7.rb
@@ -4,6 +4,6 @@ class LanguagePack::Rails7
   # Rails removed the db:schema:load_if_ruby and `db:structure:load_if_sql` tasks
   # they've been replaced by `db:schema:load` instead
   def db_prepare_test_rake_tasks
-    ["db:schema:load", "db:migrate"].map {|name| rake.task(name) }
+    ["db:schema:load", "db:migrate"].map { |name| rake.task(name) }
   end
 end

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -9,29 +9,4 @@ describe "Bundler" do
       end
     end
   end
-
-  it "deploys with version 1.x" do
-    abi_version = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER.dup
-    abi_version[-1] = "0" # turn 2.6.6 into 2.6.0
-    pending("Must enable HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
-
-    Hatchet::Runner.new("default_ruby").tap do |app|
-      app.before_deploy do
-        run!(%Q{printf "\nBUNDLED WITH\n   1.0.1\n" >> Gemfile.lock})
-      end
-      app.deploy do
-        expect(app.output).to match("Installing dependencies using bundler 1.")
-        expect(app.output).to match("BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE=1")
-
-        # app.run_multi("ls vendor/bundle/ruby/#{abi_version}/gems") do |ls_output|
-        #   expect(ls_output).to match("rake-")
-        # end
-
-        app.run("which -a rake") do |which_rake|
-          expect(which_rake).to include("/app/vendor/bundle/bin/rake")
-          expect(which_rake).to include("/app/vendor/bundle/ruby/#{abi_version}/bin/rake")
-        end
-      end
-    end
-  end
 end

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -49,7 +49,7 @@ describe "CI" do
       end
 
       app.run_ci do |test_run|
-        expect(test_run.output).to match("db:structure:load completed")
+        expect(test_run.output).to match("db:schema:load completed")
       end
     end
   end

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -18,7 +18,7 @@ describe "CI" do
             "environments": {
               "test": {
                 "addons":[
-                  "heroku-postgresql"
+                  "heroku-postgresql:in-dyno"
                 ]
               }
             }
@@ -40,7 +40,7 @@ describe "CI" do
             "environments": {
               "test": {
                 "addons":[
-                  "heroku-postgresql"
+                  "heroku-postgresql:in-dyno"
                 ]
               }
             }

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -12,6 +12,20 @@ describe "CI" do
 
   it "Works with Rails 5 ruby schema apps" do
     Hatchet::Runner.new("rails_8_ruby_schema", stack: "heroku-24").tap do |app|
+      app.before_deploy do
+        Pathname("app.json").write(<<~EOF)
+          {
+            "environments": {
+              "test": {
+                "addons":[
+                  "heroku-postgresql"
+                ]
+              }
+            }
+          }
+        EOF
+      end
+
       app.run_ci do |test_run|
         expect(test_run.output).to match("db:schema:load_if_ruby completed")
       end
@@ -20,6 +34,20 @@ describe "CI" do
 
   it "Works with Rails 5 SQL schema apps" do
     Hatchet::Runner.new("rails_8_sql_schema", stack: "heroku-24").tap do |app|
+      app.before_deploy do
+        Pathname("app.json").write(<<~EOF)
+          {
+            "environments": {
+              "test": {
+                "addons":[
+                  "heroku-postgresql"
+                ]
+              }
+            }
+          }
+        EOF
+      end
+
       app.run_ci do |test_run|
         expect(test_run.output).to match("db:structure:load_if_sql completed")
       end

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -10,7 +10,7 @@ describe "CI" do
     end
   end
 
-  it "Works with Rails 5 ruby schema apps" do
+  it "Works with Rails: ruby schema apps" do
     Hatchet::Runner.new("rails_8_ruby_schema", stack: "heroku-24").tap do |app|
       app.before_deploy do
         Pathname("app.json").write(<<~EOF)
@@ -27,12 +27,12 @@ describe "CI" do
       end
 
       app.run_ci do |test_run|
-        expect(test_run.output).to match("db:schema:load_if_ruby completed")
+        expect(test_run.output).to match("db:schema:load completed")
       end
     end
   end
 
-  it "Works with Rails 5 SQL schema apps" do
+  it "Works with Rails: SQL schema apps" do
     Hatchet::Runner.new("rails_8_sql_schema", stack: "heroku-24").tap do |app|
       app.before_deploy do
         Pathname("app.json").write(<<~EOF)
@@ -49,7 +49,7 @@ describe "CI" do
       end
 
       app.run_ci do |test_run|
-        expect(test_run.output).to match("db:structure:load_if_sql completed")
+        expect(test_run.output).to match("db:structure:load completed")
       end
     end
   end

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -65,12 +65,12 @@ describe "CI" do
   it "Uses the cache" do
     runner = Hatchet::Runner.new("ruby_no_rails_test")
     runner.run_ci do |test_run|
-      expect(test_run.output).to match("Fetching rake")
+      fetching_rake = "Fetching rake"
+      expect(test_run.output).to match(fetching_rake)
 
       test_run.run_again
 
-      expect(test_run.output).to match("Using rake")
-      expect(test_run.output).to_not match("Fetching rake")
+      expect(test_run.output).to_not match(fetching_rake)
     end
   end
 end

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -11,10 +11,7 @@ describe "CI" do
   end
 
   it "Works with Rails 5 ruby schema apps" do
-    Hatchet::Runner.new("rails5_ruby_schema_format", stack: "heroku-20").tap do |app|
-      app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.5'", mode: "a")
-      end
+    Hatchet::Runner.new("rails_8_ruby_schema", stack: "heroku-24").tap do |app|
       app.run_ci do |test_run|
         expect(test_run.output).to match("db:schema:load_if_ruby completed")
       end
@@ -22,10 +19,7 @@ describe "CI" do
   end
 
   it "Works with Rails 5 SQL schema apps" do
-    Hatchet::Runner.new("rails5_sql_schema_format", stack: "heroku-20").tap do |app|
-      app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.5'", mode: "a")
-      end
+    Hatchet::Runner.new("rails_8_sql_schema", stack: "heroku-24").tap do |app|
       app.run_ci do |test_run|
         expect(test_run.output).to match("db:structure:load_if_sql completed")
       end

--- a/spec/hatchet/rails23_spec.rb
+++ b/spec/hatchet/rails23_spec.rb
@@ -5,10 +5,6 @@ describe "Rails 2.3.x" do
     skip("Need RAILS_LTS_CREDS env var set") unless ENV["RAILS_LTS_CREDS"]
 
     Hatchet::Runner.new('rails_lts_23_default_ruby', config: rails_lts_config, stack: rails_lts_stack).tap do |app|
-      app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
-      end
-
       app.deploy do
         # assert deploy is successful
       end

--- a/spec/hatchet/rails3_spec.rb
+++ b/spec/hatchet/rails3_spec.rb
@@ -6,7 +6,8 @@ describe "Rails 3.x" do
 
     Hatchet::Runner.new("rails3_default_ruby", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
       app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
+        set_lts_ruby_version
+        set_bundler_version(version: :default)
       end
 
       app.deploy do

--- a/spec/hatchet/rails4_spec.rb
+++ b/spec/hatchet/rails4_spec.rb
@@ -6,7 +6,8 @@ describe "Rails 4.x" do
 
     Hatchet::Runner.new("rails42_default_ruby", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
       app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
+        set_lts_ruby_version
+        set_bundler_version(version: :default)
       end
       app.deploy do
         # it Don't over-write database.yml
@@ -24,7 +25,8 @@ describe "Rails 4.x" do
 
     Hatchet::Runner.new("rails42_default_ruby", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
       app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
+        set_lts_ruby_version
+        set_bundler_version(version: :default)
         Pathname("public/assets/manifest-ccf61eade4793995271564a4767ce6b6.json").tap {|p| p.dirname.mkpath; FileUtils.touch(p) }
       end
 
@@ -39,7 +41,8 @@ describe "Rails 4.x" do
 
     Hatchet::Runner.new("rails42_default_ruby", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
       app.before_deploy do
-        Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
+        set_lts_ruby_version
+        set_bundler_version(version: :default)
         Pathname("public/assets/.sprockets-manifest-040763ccc5036260c52c6adcf77d73f7.json").tap {|p| p.dirname.mkpath; FileUtils.touch(p) }
       end
 

--- a/spec/hatchet/rails6_spec.rb
+++ b/spec/hatchet/rails6_spec.rb
@@ -15,9 +15,6 @@ describe "Rails 6" do
       # Test Clean task does not get called if it does not exist
       # This file will only have the `assets:precompile` task in it, but not `assets:clean`
       run! %Q{echo 'task "assets:precompile" do ; end' > Rakefile}
-
-      set_lts_ruby_version
-      set_bundler_version(version: :default)
     end
 
     Hatchet::Runner.new('rails61', before_deploy: before_deploy, config: rails_lts_config, stack: rails_lts_stack).deploy do |app|

--- a/spec/hatchet/rails6_spec.rb
+++ b/spec/hatchet/rails6_spec.rb
@@ -15,9 +15,12 @@ describe "Rails 6" do
       # Test Clean task does not get called if it does not exist
       # This file will only have the `assets:precompile` task in it, but not `assets:clean`
       run! %Q{echo 'task "assets:precompile" do ; end' > Rakefile}
+
+      set_lts_ruby_version
+      set_bundler_version(version: :default)
     end
 
-    Hatchet::Runner.new('rails61', before_deploy: before_deploy).deploy do |app|
+    Hatchet::Runner.new('rails61', before_deploy: before_deploy, config: rails_lts_config, stack: rails_lts_stack).deploy do |app|
       expect(app.output).to match("Fetching railties 6")
 
       expect(app.output).to match("rake assets:precompile")

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -1,17 +1,5 @@
 require_relative '../spec_helper'
 
-describe "Ruby Versions on cedar-14" do
-  it "should deploy jruby 1.7.16.1 (jdk 7) properly on cedar-14 with sys props file" do
-    pending("Port this to a more recent stack")
-
-    app = Hatchet::Runner.new("ruby_193_jruby_17161_jdk7", stack: "cedar-14")
-    app.deploy do |app|
-      expect(app.output).to match("Installing JVM: openjdk-7")
-      expect(app.output).not_to include("OpenJDK 64-Bit Server VM warning")
-    end
-  end
-end
-
 describe "Ruby versions" do
   it "should deploy jdk on heroku-24" do
     Hatchet::Runner.new("default_ruby", stack: "heroku-24").tap do |app|

--- a/spec/hatchet/rubies_spec.rb
+++ b/spec/hatchet/rubies_spec.rb
@@ -50,17 +50,20 @@ end
 
 describe "Upgrading ruby apps" do
   it "works when changing versions" do
+    version = "3.3.1"
+    expect(version).to_not eq(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
     app = Hatchet::Runner.new("default_ruby", stack: DEFAULT_STACK)
     app.deploy do |app|
+      # default version
       expect(app.run("env | grep MALLOC_ARENA_MAX")).to match("MALLOC_ARENA_MAX=2")
       expect(app.run("env | grep DISABLE_SPRING")).to match("DISABLE_SPRING=1")
 
       # Deploy again
-      run!(%Q{echo "ruby '2.7.5'" >> Gemfile})
+      run!(%Q{echo "ruby '#{version}'" >> Gemfile})
       run!("git add -A; git commit -m update-ruby")
       app.push!
-      expect(app.output).to match("2.7.5")
-      expect(app.run("ruby -v")).to match("2.7.5")
+      expect(app.output).to match(version)
+      expect(app.run("ruby -v")).to match(version)
       expect(app.output).to match("Ruby version change detected")
     end
   end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -209,7 +209,7 @@ describe "Ruby apps" do
 
       Hatchet::Runner.new('default_ruby', stack: DEFAULT_STACK).tap do |app|
         app.before_deploy do
-          Pathname("Gemfile").write(<<~'EOF')
+          Pathname("Gemfile").write(<<~EOF)
             source "https://rubygems.org"
 
             ruby "#{version}"

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -155,8 +155,6 @@ describe "Ruby apps" do
           Pathname("Gemfile").write(<<~'EOF')
             source "https://rubygems.org"
 
-            ruby "~> 3.0.0"
-
             gem "rake"
           EOF
 
@@ -172,12 +170,6 @@ describe "Ruby apps" do
 
             DEPENDENCIES
               rake
-
-            RUBY VERSION
-              ruby 3.0.3p157
-
-            BUNDLED WITH
-               2.3.7
           EOF
 
           Pathname("Rakefile").write(<<~'EOF')
@@ -212,8 +204,6 @@ describe "Ruby apps" do
           Pathname("Gemfile").write(<<~'EOF')
             source "https://rubygems.org"
 
-            ruby "~> 3.0.0"
-
             gem "sinatra"
           EOF
 
@@ -240,9 +230,6 @@ describe "Ruby apps" do
 
             DEPENDENCIES
               sinatra
-
-            BUNDLED WITH
-               2.3.7
           EOF
 
         end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -170,6 +170,9 @@ describe "Ruby apps" do
 
             DEPENDENCIES
               rake
+
+            RUBY VERSION
+               3.3.1p0
           EOF
 
           Pathname("Rakefile").write(<<~'EOF')
@@ -189,7 +192,9 @@ describe "Ruby apps" do
         end
 
         app.deploy do |app|
-          expect(app.output).to match("cd version ruby 3.0.3")
+          expected = "3.3.1"
+          expect(expected).to_not eq(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+          expect(app.output).to match("cd version ruby #{expected}")
 
           expect(app.run("which ruby").strip).to eq("/app/bin/ruby")
         end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -204,10 +204,15 @@ describe "Ruby apps" do
 
   describe "bundler ruby version matcher" do
     it "installs a version even when not present in the Gemfile.lock" do
+      version = "3.3.1"
+      expect(version).to_not eq(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+
       Hatchet::Runner.new('default_ruby', stack: DEFAULT_STACK).tap do |app|
         app.before_deploy do
           Pathname("Gemfile").write(<<~'EOF')
             source "https://rubygems.org"
+
+            ruby "#{version}"
 
             gem "sinatra"
           EOF
@@ -241,8 +246,8 @@ describe "Ruby apps" do
 
         app.deploy do |app|
           # Intentionally different than the default ruby version
-          expect(app.output).to         match("3.0.0")
-          expect(app.run("ruby -v")).to match("3.0.0")
+          expect(app.output).to         match("#{version}")
+          expect(app.run("ruby -v")).to match("#{version}")
         end
       end
     end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -256,16 +256,6 @@ describe "Ruby apps" do
     end
   end
 
-  describe "Rake detection" do
-    context "Ruby 1.9+" do
-      it "runs a rake task if the gem exists" do
-        Hatchet::Runner.new('default_with_rakefile').deploy do |app, heroku|
-          expect(app.output).to include("foo")
-        end
-      end
-    end
-  end
-
   describe "database configuration" do
     context "no active record" do
       it "writes a heroku specific database.yml" do
@@ -279,8 +269,14 @@ describe "Ruby apps" do
 
     context "active record 4.1+" do
       it "doesn't write a heroku specific database.yml" do
-        Hatchet::Runner.new("activerecord41_scaffold").deploy do |app, heroku|
-          expect(app.output).not_to include("Writing config/database.yml to read from DATABASE_URL")
+        Hatchet::Runner.new("activerecord41_scaffold", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
+          app.before_deploy do
+            Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
+          end
+
+          app.deploy do
+            expect(app.output).not_to include("Writing config/database.yml to read from DATABASE_URL")
+          end
         end
       end
     end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -172,7 +172,7 @@ describe "Ruby apps" do
               rake
 
             RUBY VERSION
-               3.3.1p0
+              ruby 3.3.1p0
           EOF
 
           Pathname("Rakefile").write(<<~'EOF')

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -269,11 +269,7 @@ describe "Ruby apps" do
 
     context "active record 4.1+" do
       it "doesn't write a heroku specific database.yml" do
-        Hatchet::Runner.new("activerecord41_scaffold", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
-          app.before_deploy do
-            Pathname("Gemfile").write("ruby '2.7.2'", mode: "a")
-          end
-
+        Hatchet::Runner.new("rails61", config: rails_lts_config, stack: rails_lts_stack).tap do |app|
           app.deploy do
             expect(app.output).not_to include("Writing config/database.yml to read from DATABASE_URL")
           end

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -112,6 +112,7 @@ describe "BundlerWrapper mutates rubyopt" do
 
   it "detects windows gemfiles" do
     Hatchet::App.new("rails4_windows_mri193").in_directory_fork do |dir|
+      require "bundler"
       Bundler.with_unbundled_env do
         expect(@bundler.install.windows_gemfile_lock?).to be_truthy
       end
@@ -121,6 +122,7 @@ describe "BundlerWrapper mutates rubyopt" do
   describe "when executing bundler" do
     it "handles JRuby pre gemfiles" do
       Hatchet::App.new("jruby-minimal").in_directory_fork do |dir|
+        require "bundler"
         Bundler.with_unbundled_env do
           @bundler.install
 

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -119,19 +119,6 @@ describe "BundlerWrapper mutates rubyopt" do
   end
 
   describe "when executing bundler" do
-    it "handles apps with ruby versions locked in Gemfile.lock" do
-      Hatchet::App.new("problem_gemfile_version").in_directory_fork do |dir|
-        Bundler.with_unbundled_env do
-          @bundler.install
-
-          expect(@bundler.ruby_version).to include("ruby-2.5.1")
-
-          ruby_version = LanguagePack::RubyVersion.new(@bundler.ruby_version, is_new: true)
-          expect(ruby_version.version_for_download).to include("ruby-2.5.1")
-        end
-      end
-    end
-
     it "handles JRuby pre gemfiles" do
       Hatchet::App.new("jruby-minimal").in_directory_fork do |dir|
         Bundler.with_unbundled_env do

--- a/spec/helpers/fetcher_spec.rb
+++ b/spec/helpers/fetcher_spec.rb
@@ -1,14 +1,19 @@
 require 'spec_helper'
 
 describe "Fetches" do
-  it "bundler" do
-    Dir.mktmpdir do |dir|
-      Dir.chdir(dir) do
-        FileUtils.touch("Gemfile.lock")
+  LanguagePack::Helpers::BundlerWrapper::BLESSED_BUNDLER_VERSIONS.each do |_, version|
+    it "bundler #{version}" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          lockfile = Pathname("Gemfile.lock")
+          FileUtils.touch(lockfile)
+          lockfile.write("BUNDLED WITH\n   #{version}")
 
-        fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
-        fetcher.fetch_untar("#{LanguagePack::Helpers::BundlerWrapper.new.dir_name}.tgz")
-        expect(`ls bin`).to match("bundle")
+          fetcher = LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL)
+          fetcher.fetch_untar("bundler/#{LanguagePack::Helpers::BundlerWrapper.new.dir_name}.tgz")
+
+          expect(run!("ls bin")).to match("bundle")
+        end
       end
     end
   end

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -19,11 +19,11 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     )
 
     outdated.call
-    expect(outdated.suggested_ruby_minor_version).to eq("3.1.6")
+    expect(outdated.suggested_ruby_minor_version).to eq("3.3.6")
   end
 
   it "handles arm 💪 architecture on heroku-24" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-3.1.0")
+    ruby_version = LanguagePack::RubyVersion.new("ruby-3.3.0")
     fetcher = LanguagePack::Fetcher.new(
       LanguagePack::Base::VENDOR_URL,
       stack: "heroku-24",
@@ -35,7 +35,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     )
 
     outdated.call
-    expect(outdated.suggested_ruby_minor_version).to eq("3.1.6")
+    expect(outdated.suggested_ruby_minor_version).to eq("3.3.6")
   end
 
   it "finds the latest version on a stack" do

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -19,7 +19,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     )
 
     outdated.call
-    expect(outdated.suggested_ruby_minor_version).to eq("3.3.6")
+    expect(outdated.suggested_ruby_minor_version).to eq("3.3.7")
   end
 
   it "handles arm 💪 architecture on heroku-24" do
@@ -35,7 +35,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     )
 
     outdated.call
-    expect(outdated.suggested_ruby_minor_version).to eq("3.3.6")
+    expect(outdated.suggested_ruby_minor_version).to eq("3.3.7")
   end
 
   it "finds the latest version on a stack" do

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -19,7 +19,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     )
 
     outdated.call
-    expect(outdated.suggested_ruby_minor_version).to eq("3.3.7")
+    expect(outdated.suggested_ruby_minor_version).to eq("3.1.6")
   end
 
   it "handles arm 💪 architecture on heroku-24" do

--- a/spec/helpers/rails_runner_spec.rb
+++ b/spec/helpers/rails_runner_spec.rb
@@ -29,7 +29,7 @@ describe "Rails Runner" do
 
   it "calls run through child object" do
     rails_runner  = LanguagePack::Helpers::RailsRunner.new
-    def rails_runner.call; @called ||= 0 ; @called += 1; end
+    def rails_runner.call; @called ||= 0 ; @called += 1; "" end
     def rails_runner.called; @called; end
 
     local_storage = rails_runner.detect("active_storage.service")

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -62,6 +62,7 @@ describe "RubyVersion" do
 
   it "correctly sets default ruby versions" do
     Hatchet::App.new("default_ruby").in_directory_fork do |dir|
+      require 'bundler'
       Bundler.with_unbundled_env do
         ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
         version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
@@ -77,6 +78,7 @@ describe "RubyVersion" do
 
   it "detects Ruby from Gemfile.lock" do
     Hatchet::App.new("default_ruby").in_directory_fork do |_|
+      require 'bundler'
       dir = Pathname(Dir.pwd)
       Bundler.with_unbundled_env do
         dir.join("Gemfile").write(<<~EOF)
@@ -118,6 +120,7 @@ describe "RubyVersion" do
 
   it "detects non mri engines" do
     Hatchet::App.new("default_ruby").in_directory_fork do |_|
+      require 'bundler'
       dir = Pathname(Dir.pwd)
       Bundler.with_unbundled_env do
         dir.join("Gemfile").write(<<~EOF)

--- a/spec/helpers/shell_spec.rb
+++ b/spec/helpers/shell_spec.rb
@@ -87,7 +87,7 @@ describe "ShellHelpers" do
         def sh.mcount(*args); @error_caught = true; end
 
         bad_lines = File.read("spec/fixtures/invalid_encoding.log")
-        expect { sh.puts(bad_lines) }.to raise_error(ArgumentError)
+        expect { sh.puts(bad_lines) }.to raise_error(Encoding::CompatibilityError)
 
         error_caught = sh.instance_variable_get(:"@error_caught")
         expect(error_caught).to eq(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,22 @@ def fixture_path(path)
   Pathname.new(__FILE__).join("../fixtures").expand_path.join(path)
 end
 
+def set_lts_ruby_version
+  Pathname("Gemfile").write("ruby '3.3.6'", mode: "a")
+end
+
+def set_bundler_version(version: )
+  gemfile_lock = Pathname("Gemfile.lock").read
+
+  if version == :default
+    version = ""
+  else
+    version = "BUNDLED WITH\n   #{version}"
+  end
+  gemfile_lock.gsub!(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.(?<minor>\d+)\.\d+/m, version)
+  Pathname("Gemfile.lock").write(gemfile_lock)
+end
+
 def rails_lts_config
   { 'BUNDLE_GEMS__RAILSLTS__COM' => ENV["RAILS_LTS_CREDS"] }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ ENV["HATCHET_BUILDPACK_BASE"] ||= "https://github.com/heroku/heroku-buildpack-ru
 
 ENV['RACK_ENV'] = 'test'
 
-DEFAULT_STACK = 'heroku-20'
+DEFAULT_STACK = 'heroku-24'
 
 
 def hatchet_path(path = "")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ def rails_lts_config
 end
 
 def rails_lts_stack
-  "heroku-20"
+  "heroku-22"
 end
 
 def hatchet_path(path = "")


### PR DESCRIPTION
The latest Ruby is now 3.4.x. Our ideal default policy is to use the latest release of the prior year's version. This PR updates to the latest Ruby 3.3.x version which is 3.3.7.