### PR TITLE
Add bundler 2.6.2 and update bundler 2.5.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Ruby apps using bundler 2.6+ will now receive bundler 2.6.2 ()
+- Ruby apps using bundler 2.5.x will now receive bundler 2.5.23 ()
 
 ## [v287] - 2024-12-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Ruby apps using bundler 2.6+ will now receive bundler 2.6.2 ()
 
 ## [v287] - 2024-12-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 
-- Ruby apps using bundler 2.6+ will now receive bundler 2.6.2 ()
-- Ruby apps using bundler 2.5.x will now receive bundler 2.5.23 ()
+- Ruby apps using bundler 2.6+ will now receive bundler 2.6.2 (https://github.com/heroku/heroku-buildpack-ruby/pull/1535)
+- Ruby apps using bundler 2.5.x will now receive bundler 2.5.23 (https://github.com/heroku/heroku-buildpack-ruby/pull/1535)
 
 ## [v287] - 2024-12-25
 

--- a/changelogs/unreleased/bundler_2.5.23.md
+++ b/changelogs/unreleased/bundler_2.5.23.md
@@ -1,0 +1,15 @@
+## Bundler version 2.5.23 is now available for Ruby Applications
+
+The [Ruby Buildpack](https://devcenter.heroku.com/articles/ruby-support#libraries) installs a version of bundler based on the major and minor version listed in the `Gemfile.lock` under the `BUNDLED WITH` key:
+
+- `BUNDLED WITH` 2.5.x will receive bundler `2.5.23`
+
+It is strongly recommended that you have both a `RUBY VERSION` and `BUNDLED WITH` version listed in your `Gemfile.lock`. If you do not have those values, you can generate them and commit them to git:
+
+```
+$ bundle update --ruby
+$ git add Gemfile.lock
+$ git commit -m "Update Gemfile.lock"
+```
+
+Applications without these values specified in the `Gemfile.lock` may break unexpectedly when the defaults change.

--- a/changelogs/unreleased/bundler_2.6.x_support.md
+++ b/changelogs/unreleased/bundler_2.6.x_support.md
@@ -1,0 +1,15 @@
+## Bundler version 2.6.2 is now available for Ruby Applications
+
+The [Ruby Buildpack](https://devcenter.heroku.com/articles/ruby-support#libraries) installs a version of bundler based on the major and minor version listed in the `Gemfile.lock` under the `BUNDLED WITH` key:
+
+- `BUNDLED WITH` 2.6.x and above will receive bundler `2.6.2`
+
+It is strongly recommended that you have both a `RUBY VERSION` and `BUNDLED WITH` version listed in your `Gemfile.lock`. If you do not have those values, you can generate them and commit them to git:
+
+```
+$ bundle update --ruby
+$ git add Gemfile.lock
+$ git commit -m "Update Gemfile.lock"
+```
+
+Applications without these values specified in the `Gemfile.lock` may break unexpectedly when the defaults change.

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -41,12 +41,13 @@ class LanguagePack::Helpers::BundlerWrapper
   BLESSED_BUNDLER_VERSIONS["2.3"] = "2.3.25"
   BLESSED_BUNDLER_VERSIONS["2.4"] = "2.4.22"
   BLESSED_BUNDLER_VERSIONS["2.5"] = "2.5.6"
+  BLESSED_BUNDLER_VERSIONS["2.6"] = "2.6.2"
   BLESSED_BUNDLER_VERSIONS.default_proc = Proc.new do |hash, key|
     if Gem::Version.new(key).segments.first == 1
       hash["1"]
     elsif Gem::Version::new(key).segments.first == 2
-      if Gem::Version.new(key) > Gem::Version.new("2.5")
-        hash["2.5"]
+      if Gem::Version.new(key) > Gem::Version.new("2.6")
+        hash["2.6"]
       elsif Gem::Version.new(key) < Gem::Version.new("2.3")
         hash["2.3"]
       else

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -40,7 +40,7 @@ class LanguagePack::Helpers::BundlerWrapper
   # Heroku-20's oldest Ruby verison is 2.5.x which doesn't work with bundler 2.4
   BLESSED_BUNDLER_VERSIONS["2.3"] = "2.3.25"
   BLESSED_BUNDLER_VERSIONS["2.4"] = "2.4.22"
-  BLESSED_BUNDLER_VERSIONS["2.5"] = "2.5.6"
+  BLESSED_BUNDLER_VERSIONS["2.5"] = "2.5.23"
   BLESSED_BUNDLER_VERSIONS["2.6"] = "2.6.2"
   BLESSED_BUNDLER_VERSIONS.default_proc = Proc.new do |hash, key|
     if Gem::Version.new(key).segments.first == 1

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -39,6 +39,10 @@ describe "Bundler version detection" do
     expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("2.6")).to be_truthy
     expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["2.6"])
 
+    version = wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   2.999.7")
+    expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("2.6")).to be_truthy
+    expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["2.6"])
+
     expect {
       wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   3.6.7")
     }.to raise_error(wrapper_klass::UnsupportedBundlerVersion)

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -36,8 +36,8 @@ describe "Bundler version detection" do
     expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["2.5"])
 
     version = wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   2.6.7")
-    expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("2.5")).to be_truthy
-    expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["2.5"])
+    expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("2.6")).to be_truthy
+    expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["2.6"])
 
     expect {
       wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   3.6.7")


### PR DESCRIPTION
Adds support for Bundler 2.6 and updates the version of bundler 2.5.x to the latest. 

```
$ curl -sL "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/bundler/bundler-2.5.23.tgz" | tar --include="gems" -tzf - | head -n 5
./gems/
./gems/bundler-2.5.23/
./gems/bundler-2.5.23/CHANGELOG.md
./gems/bundler-2.5.23/LICENSE.md
./gems/bundler-2.5.23/README.md
$ curl -sL "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/bundler/bundler-2.6.2.tgz" | tar --include="gems" -tzf - | head -n 5
./gems/
./gems/bundler-2.6.2/
./gems/bundler-2.6.2/CHANGELOG.md
./gems/bundler-2.6.2/LICENSE.md
./gems/bundler-2.6.2/README.md
```