### PR TITLE
Add a mechanism for documenting Ruby versions via automation

### DIFF
--- a/.github/workflows/document_ruby_version.yml
+++ b/.github/workflows/document_ruby_version.yml
@@ -1,0 +1,43 @@
+name: Add Ruby version to changelog && prepare release
+run-name: "Add ${{ inputs.is_jruby && 'J' || ''}}Ruby ${{ inputs.ruby_version }} to the CHANGELOG.md and prepare a release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ruby_version:
+          description: "The Ruby version to announce"
+          type: string
+          required: true
+      is_jruby:
+          description: "JRuby version (as opposed to MRI)"
+          type: boolean
+          default: false
+          required: false
+
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
+jobs:
+  prepare-release:
+    uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-prepare-release.yml@latest
+    secrets: inherit
+    with:
+      custom_update_command: |
+        set -euo pipefail
+
+        sed --in-place '/## \[Unreleased\]/a\
+        \
+        - ${{ inputs.is_jruby && 'J' || ''}}Ruby ${{inputs.ruby_version}} is now available
+        ' CHANGELOG.md
+
+        sed --in-place --regexp-extended \
+          --expression "s/v${EXISTING_VERSION}/v${NEW_VERSION}/" \
+          lib/language_pack/version.rb
+
+        if compgen -G 'changelogs/unreleased/*.md' > /dev/null; then
+          # The unreleased changelogs directory contains a `.gitkeep` file, so we have to
+          # copy the markdown files individually instead of renaming the directory.
+          NEW_CHANGELOG_DIR="changelogs/v${NEW_VERSION}/"
+          mkdir -p "${NEW_CHANGELOG_DIR}"
+          mv changelogs/unreleased/*.md "${NEW_CHANGELOG_DIR}"
+        fi

--- a/.github/workflows/document_ruby_version.yml
+++ b/.github/workflows/document_ruby_version.yml
@@ -9,7 +9,7 @@ on:
           type: string
           required: true
       is_jruby:
-          description: "JRuby version (as opposed to MRI)"
+          description: "JRuby release? (as opposed to MRI)"
           type: boolean
           default: false
           required: false


### PR DESCRIPTION
Our current deploy process looks like this for releasing a Ruby version:

- Manually make a PR to the Ruby buildpack with the version in the changelog
- Get it approved by another engineer
- Pre-Release the buildpack via automation
- Merge the pre-release PR
- Pull changes locally and run deploy command `bundle exec rake buildpack:release`
- Then trigger S3 changes via running automations on https://github.com/heroku/docker-heroku-ruby-builder

In the future there's a desire to have the https://github.com/heroku/docker-heroku-ruby-builder generate an "inventory" file that tracks binary checksums and then the buildpack will require a PR to utilize new versions. However, that's a non-trivial amount of work and Ruby versions keep getting released on Fridays when I'm on vacation and no one else is around.

With this change the process can look like this:

- Trigger this new workflow which updates the CHANGELOG.md and runs the pre-release automation in one
- Merge that PR
- Pull changes locally and run deploy command `bundle exec rake buildpack:release`
- Then trigger S3 changes via running automations on https://github.com/heroku/docker-heroku-ruby-builder

Which is a substantial workflow savings. This task can be removed once we implement the full inventory workflow (sometime in the vague future), but this is a quality of life upgrade for the short term.