### PR TITLE
Add the ruby version to the current release

### DIFF
--- a/.github/workflows/document_ruby_version.yml
+++ b/.github/workflows/document_ruby_version.yml
@@ -28,8 +28,7 @@ jobs:
 
         sed --in-place "/## \[v${NEW_VERSION}\] - ${DATE_TODAY}/a\\
         \\
-        - ${{ inputs.is_jruby && 'J' || ''}}Ruby ${{inputs.ruby_version}} is now available
-        " CHANGELOG.md
+        - ${{ inputs.is_jruby && 'J' || ''}}Ruby ${{inputs.ruby_version}} is now available" CHANGELOG.md
 
         sed --in-place --regexp-extended \
           --expression "s/v${EXISTING_VERSION}/v${NEW_VERSION}/" \

--- a/.github/workflows/document_ruby_version.yml
+++ b/.github/workflows/document_ruby_version.yml
@@ -24,11 +24,12 @@ jobs:
     with:
       custom_update_command: |
         set -euo pipefail
+        DATE_TODAY="$(date --utc --iso-8601)"
 
-        sed --in-place '/## \[Unreleased\]/a\
-        \
+        sed --in-place "/## \[v${NEW_VERSION}\] - ${DATE_TODAY}/a\\
+        \\
         - ${{ inputs.is_jruby && 'J' || ''}}Ruby ${{inputs.ruby_version}} is now available
-        ' CHANGELOG.md
+        " CHANGELOG.md
 
         sed --in-place --regexp-extended \
           --expression "s/v${EXISTING_VERSION}/v${NEW_VERSION}/" \


### PR DESCRIPTION
This task runs after the new version is injected into the CHANGELOG. That means that if we add something under "unreleased" at this point, then it shows up in the wrong section. This commit fixes it.