### PR TITLE
Raise an explicit error message for Bundler 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
+- Explicit error message raised with upgrade instructions for applications specifying bundler `1.x` in the Gemfile.lock (https://github.com/heroku/heroku-buildpack-ruby/pull/1561)
 
 ## [v294] - 2025-03-19
 
 - Default Ruby version is now 3.3.7 (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
 - Default bundler version (when no version present in the `Gemfile.lock`) is now bundler `2.3.x` which is currently `2.3.25` (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
+- Bundler 1.x will no longer work with the Ruby buildpack (https://github.com/heroku/heroku-buildpack-ruby/pull/1534)
 
 ## [v293] - 2025-02-15
 

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -15,9 +15,9 @@ end
 describe "Bundler version detection" do
   it "supports minor versions" do
     wrapper_klass = LanguagePack::Helpers::BundlerWrapper
-    version = wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   1.17.3")
-    expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("1")).to be_truthy
-    expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["1"])
+    expect {
+      wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   1.17.3")
+    }.to raise_error(BuildpackError)
 
     version = wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   2.2.7")
     expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("2.3")).to be_truthy
@@ -57,16 +57,6 @@ describe "Multiple platform detection" do
 
       bundler = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: gemfile)
       expect(bundler.supports_multiple_platforms?).to be_truthy
-    end
-  end
-
-  it "reports false on bundler prior to 2.2" do
-    Dir.mktmpdir do |dir|
-      gemfile = Pathname(dir).join("Gemfile")
-      lockfile = Pathname(dir).join("Gemfile.lock").tap {|p| p.write("BUNDLED WITH\n   1.15.2") }
-
-      bundler = LanguagePack::Helpers::BundlerWrapper.new(gemfile_path: gemfile)
-      expect(bundler.supports_multiple_platforms?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
With the Ruby 3.3.7 default, bundler 1.x no longer works on Heroku with the Ruby buildpack. Here's the details of what's causing the error:

The Ruby buildpack uses Ruby code to inspect the application at build time to know what dependencies and versions to install. The version of Ruby that the buildpack uses is tied to the default Ruby version. Recently this version was changed to Ruby 3.3.7 https://devcenter.heroku.com/changelog-items/3167.

The Ruby buildpack runs `bundle platform --ruby` in order to determine what Ruby version the application needs. This invokes bundler using the current Ruby version (3.3.7). However, bundler is using a method that was deprecated and removed in Ruby 3.2 https://ruby-doc.org/stdlib-2.7.1/libdoc/pathname/rdoc/Pathname.html#method-i-untaint. Because this method does not exist in Ruby 3.3 the bundler code cannot execute and fails with an error message:

```
remote:  !     There was an error parsing your Gemfile, we cannot continue
remote:  !     /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:29:in `root': undefined method `untaint' for an instance of Pathname (NoMethodError)
remote:  !
remote:  !     Pathname.new(gemfile).untaint.expand_path.parent
remote:  !     ^^^^^^^^
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler.rb:234:in `root'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler.rb:246:in `app_config_path'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler.rb:273:in `settings'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler/feature_flag.rb:21:in `block in settings_method'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler/cli.rb:97:in `<class:CLI>'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler/cli.rb:7:in `<module:Bundler>'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler/cli.rb:6:in `<top (required)>'
remote:  !     from <internal:/tmp/tmp.CMaelujSAR/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
remote:  !     from <internal:/tmp/tmp.CMaelujSAR/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
remote:  !     from /tmp/tmp.CMaelujSAR/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/exe/bundle:21:in `block in <top (required)>'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
remote:  !     from /tmp/tmp.CMaelujSAR/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/exe/bundle:20:in `<top (required)>'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/bin/bundle:23:in `load'
remote:  !     from /tmp/d20250319-150-o0ictl/bundler-1.17.3/bin/bundle:23:in `<main>'
```

Bundler `1.17.3` was last released on December 27, 2018, and is no longer supported by bundler/rubygems core, so it has not been patched to remove this deprecated method. 

You can fix this issue by upgrading your application to bundler 2.3.x. I suggest `2.3.27`. Run:

```
$ gem install bundler -v 2.3.27
$ bundle update --bundler
```

Verify that the correct version is listed in the Gemfile.lock:

```
$ cat Gemfile.lock | grep "BUNDLED WITH" -A2
BUNDLED WITH
   2.3.27
```

And check the results into git:

```
$ git add Gemfile.lock
$ git commit -m "Update bundler version to 2.3.x"
```

Then deploy. Bundler 2.3.x supports Ruby >= 2.3.0 so it should work for your application. If you're using an older version of Rails that's locked to an older version of bundler, you can work around this with Rails LTS. That information and other upgrade suggestions are here https://www.reddit.com/r/Heroku/comments/1ij7b89/upgrading_ruby_versions_to_run_on_heroku24/.

## Additional concerns

Beyond `bundle platform --ruby` the buildpack also requires bundler internals to parse and load the Gemfile.lock. This strategy only works if the version of Ruby we're using for the buildpack is capable of running that version of bundler. Previously we only supported one version of bundler, but now that we support multiple, the Ruby version must be capable of running them all. We can move away from `bundle platform --ruby` by parsing the `Gemfile.lock` manually (this is what the CNB does) we can move away from requiring an arbitrary bundler version by listing out gems after they're installed via `gem list` or `bundle list`. However these are two relatively large behavior changes.

It's still possible to temporarily use bundler 1.17.3 on the platform by using an older buildpack version https://devcenter.heroku.com/articles/bundler-version#using-an-older-version-of-bundler. However this should only be considered a temporary fix and not a long term one.