### PR TITLE
Re-enable bundler 1.x, add a Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Bundler `1.x` usage error is downgraded to a warning. This warning will be moved to an error once `heroku-20` is Sunset (https://github.com/heroku/heroku-buildpack-ruby/pull/1565)
 
 ## [v295] - 2025-03-20
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.7"
+ruby "3.2.7"
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.7"
+ruby "3.1.6"
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.2.7p253
+   ruby 3.1.6p260
 
 BUNDLED WITH
    2.5.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.3.7p260
+   ruby 3.2.7p253
 
 BUNDLED WITH
    2.5.11

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "3.2.7"
+ruby_version = "3.1.6"
 
 [publish.Ignore]
 files = [

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "3.3.7"
+ruby_version = "3.2.7"
 
 [publish.Ignore]
 files = [

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,6 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   # Heroku-20's oldest Ruby verison is 2.5.x which doesn't work with bundler 2.4
+  BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
   BLESSED_BUNDLER_VERSIONS["2.3"] = "2.3.25"
   BLESSED_BUNDLER_VERSIONS["2.4"] = "2.4.22"
   BLESSED_BUNDLER_VERSIONS["2.5"] = "2.5.23"
@@ -47,22 +48,7 @@ class LanguagePack::Helpers::BundlerWrapper
   # Convert arbitrary `<Major>.<Minor>.x` versions
   BLESSED_BUNDLER_VERSIONS.default_proc = Proc.new do |hash, key|
     if Gem::Version.new(key).segments.first == 1
-      raise BuildpackError.new(<<~EOF)
-        Cannot install bundler 1.17.3
-
-        Your application requested bundler `#{key}` in the `Gemfile.lock`
-        which resolved to `1.17.3`. This version no longer works on
-        Heroku. Please upgrade to bundler `2.3.x` or higher:
-
-        ```
-        $ gem install bundler -v #{hash["2.3"]}
-        $ bundle update --bundler
-        $ git add Gemfile.lock
-        $ git commit -m "Updated bundler version"
-        ```
-
-        https://devcenter.heroku.com/changelog-items/3166
-      EOF
+      hash["1"]
     elsif Gem::Version::new(key).segments.first == 2
       if Gem::Version.new(key) > Gem::Version.new("2.6")
         hash["2.6"]
@@ -81,7 +67,8 @@ class LanguagePack::Helpers::BundlerWrapper
     if version_match
       major = version_match[:major]
       minor = version_match[:minor]
-      BLESSED_BUNDLER_VERSIONS["#{major}.#{minor}"]
+      version = BLESSED_BUNDLER_VERSIONS["#{major}.#{minor}"]
+      version
     else
       DEFAULT_VERSION
     end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -79,6 +79,7 @@ WARNING
     Dir.chdir(build_path)
     remove_vendor_bundle
     warn_bundler_upgrade
+    warn_bundler_1x
     warn_bad_binstubs
     install_ruby(slug_vendor_ruby)
     setup_language_pack_environment(
@@ -106,6 +107,30 @@ WARNING
   rescue => e
     warn_outdated_ruby
     raise e
+  end
+
+  def warn_bundler_1x
+    bundler_versions = LanguagePack::Helpers::BundlerWrapper::BLESSED_BUNDLER_VERSIONS
+    if bundler.version == bundler_versions["1"]
+      warn(<<~EOF, inline: true)
+        Deprecating bundler 1.17.3
+
+        Your application requested bundler `1.x` in the `Gemfile.lock`
+        which resolved to `1.17.3`. This version is no longer maintained
+        by bundler core and will no longer work soon.
+
+        Please upgrade to bundler `2.3.x` or higher:
+
+        ```
+        $ gem install bundler -v #{bundler_versions["2.3"]}
+        $ bundle update --bundler
+        $ git add Gemfile.lock
+        $ git commit -m "Updated bundler version"
+        ```
+
+        https://devcenter.heroku.com/changelog-items/3166
+      EOF
+    end
   end
 
   def cleanup

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,7 +12,7 @@ module LanguagePack
       end
     end
 
-    BOOTSTRAP_VERSION_NUMBER = "3.2.7".freeze
+    BOOTSTRAP_VERSION_NUMBER = "3.1.6".freeze
     DEFAULT_VERSION_NUMBER = "3.3.7".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,7 +12,7 @@ module LanguagePack
       end
     end
 
-    BOOTSTRAP_VERSION_NUMBER = "3.3.7".freeze
+    BOOTSTRAP_VERSION_NUMBER = "3.2.7".freeze
     DEFAULT_VERSION_NUMBER = "3.3.7".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     LEGACY_VERSION_NUMBER  = "1.9.2".freeze

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -9,4 +9,21 @@ describe "Bundler" do
       end
     end
   end
+
+  it "deploys with version 1.x" do
+    pending("Must enable HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
+
+    Hatchet::Runner.new("default_ruby").tap do |app|
+      app.before_deploy do
+        set_bundler_version(version: "1.17.3")
+      end
+      app.deploy do
+        expect(app.output).to match("Deprecating bundler 1.17.3")
+
+        app.run("which -a rake") do |which_rake|
+          expect(which_rake).to include("/app/vendor/bundle/bin/rake")
+        end
+      end
+    end
+  end
 end

--- a/spec/hatchet/bundler_spec.rb
+++ b/spec/hatchet/bundler_spec.rb
@@ -16,6 +16,11 @@ describe "Bundler" do
     Hatchet::Runner.new("default_ruby").tap do |app|
       app.before_deploy do
         set_bundler_version(version: "1.17.3")
+        Pathname("Gemfile.lock").write(<<~EOF, mode: "a")
+
+          RUBY VERSION
+            ruby 3.1.6
+        EOF
       end
       app.deploy do
         expect(app.output).to match("Deprecating bundler 1.17.3")

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -15,9 +15,9 @@ end
 describe "Bundler version detection" do
   it "supports minor versions" do
     wrapper_klass = LanguagePack::Helpers::BundlerWrapper
-    expect {
-      wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   1.17.3")
-    }.to raise_error(BuildpackError)
+    version = wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   1.17.3")
+    expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("1")).to be_truthy
+    expect(version).to eq(wrapper_klass::BLESSED_BUNDLER_VERSIONS["1"])
 
     version = wrapper_klass.detect_bundler_version(contents: "BUNDLED WITH\n   2.2.7")
     expect(wrapper_klass::BLESSED_BUNDLER_VERSIONS.key?("2.3")).to be_truthy

--- a/spec/helpers/config_spec.rb
+++ b/spec/helpers/config_spec.rb
@@ -9,9 +9,9 @@ describe "Boot Strap Config" do
 
     expect(`ruby -v`).to match(Regexp.escape(LanguagePack::RubyVersion::BOOTSTRAP_VERSION_NUMBER))
 
-    bootstrap_version = Gem::Version.new(LanguagePack::RubyVersion::BOOTSTRAP_VERSION_NUMBER)
-    default_version = Gem::Version.new(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
+    # bootstrap_version = Gem::Version.new(LanguagePack::RubyVersion::BOOTSTRAP_VERSION_NUMBER)
+    # default_version = Gem::Version.new(LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER)
 
-    expect(bootstrap_version).to be >= default_version
+    # expect(bootstrap_version).to be >= default_version
   end
 end

--- a/spec/helpers/shell_spec.rb
+++ b/spec/helpers/shell_spec.rb
@@ -87,7 +87,7 @@ describe "ShellHelpers" do
         def sh.mcount(*args); @error_caught = true; end
 
         bad_lines = File.read("spec/fixtures/invalid_encoding.log")
-        expect { sh.puts(bad_lines) }.to raise_error(Encoding::CompatibilityError)
+        expect { sh.puts(bad_lines) }.to raise_error(ArgumentError)
 
         error_caught = sh.instance_variable_get(:"@error_caught")
         expect(error_caught).to eq(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,8 @@ def set_bundler_version(version: )
     version = "BUNDLED WITH\n   #{version}"
   end
   gemfile_lock.gsub!(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.(?<minor>\d+)\.\d+/m, version)
+  gemfile_lock << "\n#{version}" unless gemfile_lock.match?(/^BUNDLED WITH/)
+
   Pathname("Gemfile.lock").write(gemfile_lock)
 end
 


### PR DESCRIPTION
## Context

PR #1534 changed the bootstrap version of the Ruby buildpack to 3.3.7. This caused errors with bundler 1.x as it has not been updated in ~6 years and is not compatible with Ruby 3.2 or 3.3.7. In #1561, the error mode was detected, and an explicit error was raised. This error affects relatively few customers, but almost all of them are on `heroku-20` and trying to upgrade. The deadline is April 30th, 2025: https://devcenter.heroku.com/changelog-items/2895. Those customers are already feeling pressured for time and this error adds another hurdle.

## This change

Decouples the default Ruby version from the bootstrap Ruby version so that the default can remain 3.3.7 for customers, but we can execute buildpack logic with 3.1.6. This re-enables the ability to deploy using bundler 1.x. It changes the error to a warning so customers who have not already upgraded to Bundler 2.3.x will have more time to upgrade. After the heroku-20 sunset deadline, customers will be more equipped to upgrade their bundler version.

While Ruby 3.1.x is EOL shortly, we can use it until heroku-20 is officially sunset. In the longer term, we will move towards the CNB model, where there is less coupling between the bundler version and internals, and the Ruby version has fewer side effects (restrictions) on the build process.