### PR TITLE
Ensure flat YAML build report

### DIFF
--- a/lib/heroku_build_report.rb
+++ b/lib/heroku_build_report.rb
@@ -27,12 +27,21 @@ module HerokuBuildReport
       @path.write("")
     end
 
+    def complex_object?(value)
+      value.to_yaml.match?(/!ruby\/object:/)
+    end
+
     def capture(metrics = {})
       metrics.each do |(key, value)|
         return if key.nil? || key.to_s.strip.empty?
 
         key = key&.strip
         raise "Key  cannot be empty (#{key.inspect} => #{value})" if key.nil? || key.empty?
+
+        # Don't serialize complex values by accident
+        if complex_object?(value)
+          value = value.to_s
+        end
 
         @data["#{key}"] = value
       end

--- a/spec/helpers/heroku_build_report_spec.rb
+++ b/spec/helpers/heroku_build_report_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 describe "Build report" do
+  it "handles complex object serialization by converting them to strings" do
+    Dir.mktmpdir do |dir|
+      path = Pathname(dir).join(".report.yml")
+      report = HerokuBuildReport::YamlReport.new(
+        path: path
+      )
+      value = Gem::Version.new("3.4.2")
+      expect(report.complex_object?(value)).to eq(true)
+      expect(value.to_yaml).to_not eq(value.to_s.to_yaml)
+      report.capture("key" => value)
+
+      expect(report.data).to eq({"key" => "3.4.2"})
+      expect(path.read).to eq(<<~EOF)
+        ---
+        key: 3.4.2
+      EOF
+    end
+  end
+
   it "writes valid yaml" do
     Dir.mktmpdir do |dir|
       path = Pathname(dir).join(".report.yml")


### PR DESCRIPTION
The `bin/report` structure is flat. All keys must map to values that are un-nested. Ruby's `to_yaml` will happily serialize ruby objects:

```
irb(main):004> puts Gem::Version.new("3.4.2").to_yaml
--- !ruby/object:Gem::Version
version: 3.4.2
```

This commit fixes this problem by inspecting if the value being serialized is an object or not. If it is, it is then converted into a string.