### PR TITLE
Add `.ruby-version` formats to observability metrics

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -112,8 +112,14 @@ class LanguagePack::Helpers::BundlerWrapper
 
     contents = @gemfile_lock_path.read(mode: "rt")
     bundled_with = contents.match(BUNDLED_WITH_REGEX)
+    dot_ruby_version_file = @gemfile_lock_path.join("..").join(".ruby-version")
     @report.capture(
-      "bundler.bundled_with" => bundled_with&.[]("version") || "empty"
+      "bundler.bundled_with" => bundled_with&.[]("version") || "empty",
+      # We use this bundler class to detect the Requested ruby version from the Gemfile.lock
+      # Rails 8 stopped generating `RUBY VERSION` in the Gemfile.lock and started generating
+      # a `.ruby-version` file. This will observe the formats to help guide implementation
+      # decisions
+      "ruby.dot_ruby_version" => dot_ruby_version_file.exist? ? dot_ruby_version_file.read&.strip : nil
     )
     @version = self.class.detect_bundler_version(
       contents: contents,

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -113,7 +113,7 @@ class LanguagePack::Helpers::BundlerWrapper
     contents = @gemfile_lock_path.read(mode: "rt")
     bundled_with = contents.match(BUNDLED_WITH_REGEX)
     @report.capture(
-      "bundled_with" => bundled_with&.[]("version") || "empty"
+      "bundler.bundled_with" => bundled_with&.[]("version") || "empty"
     )
     @version = self.class.detect_bundler_version(
       contents: contents,
@@ -121,10 +121,10 @@ class LanguagePack::Helpers::BundlerWrapper
     )
     parts = @version.split(".")
     @report.capture(
-      "bundler_version_installed" => @version,
-      "bundler_major" => parts&.shift,
-      "bundler_minor" => parts&.shift,
-      "bundler_patch" => parts&.shift
+      "bundler.version_installed" => @version,
+      "bundler.major" => parts&.shift,
+      "bundler.minor" => parts&.shift,
+      "bundler.patch" => parts&.shift
     )
     @dir_name = "bundler-#{@version}"
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -98,8 +98,8 @@ WARNING
       run_assets_precompile_rake_task
     end
     @report.capture(
-      "railties_version" => bundler.gem_version('railties'),
-      "rack_version" => bundler.gem_version('rack')
+      "gem.railties_version" => bundler.gem_version('railties'),
+      "gem.rack_version" => bundler.gem_version('rack')
     )
     config_detect
     best_practice_warnings

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -64,6 +64,7 @@ describe "Multiple platform detection" do
 
       expect(report.data).to eq(
         {
+          "ruby.dot_ruby_version" => nil,
           "bundler.bundled_with" => "2.5.7",
           "bundler.major" => "2",
           "bundler.minor" => "5",

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -64,11 +64,11 @@ describe "Multiple platform detection" do
 
       expect(report.data).to eq(
         {
-          "bundled_with" => "2.5.7",
-          "bundler_major" => "2",
-          "bundler_minor" => "5",
-          "bundler_patch" => "23",
-          "bundler_version_installed" => "2.5.23",
+          "bundler.bundled_with" => "2.5.7",
+          "bundler.major" => "2",
+          "bundler.minor" => "5",
+          "bundler.patch" => "23",
+          "bundler.version_installed" => "2.5.23",
         }
       )
     end


### PR DESCRIPTION
Rails 8 stopped generating `RUBY VERSION` in the Gemfile.lock and started generating a `.ruby-version` file. We will support this file in the future, but there is no spec for it.

This commit will observe the formats to help guide implementation decisions. It can also tell us how many people's `.ruby-version` files already align with their `Gemfile.lock` versions.

The logic is inside of the bundler wrapper class as this is the first class to read the ruby version from the Gemfile.lock via `$ bundle platform --ruby`.