### PR TITLE
Fix `cp` update none on Heroku 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
+- Fix `cp --update=none` on `heroku-20` (https://github.com/heroku/heroku-buildpack-ruby/pull/1586)
 
 ## [v303] - 2025-04-25
 
 - Ruby 3.5.0-preview1 is now available
-
 - Fix warning message about `cp -n` (https://github.com/heroku/heroku-buildpack-ruby/pull/1583)
 
 ## [v302] - 2025-04-16

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -58,7 +58,12 @@ class LanguagePack::Cache
     return unless @cache_base
 
     dest ||= path
-    copy (@cache_base + path), dest, '-a --update=none'
+
+    if ENV["STACK"] == "heroku-20"
+      copy (@cache_base + path), dest, "-a -n"
+    else
+      copy (@cache_base + path), dest, "-a --update=none"
+    end
   end
 
   # copy cache contents

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -74,7 +74,9 @@ class LanguagePack::Cache
 
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
-    system("cp #{options} #{from}/. #{to}")
+    command = "cp #{options} #{from}/. #{to}"
+    system(command)
+    raise "Command failed `#{command}`" unless $?
   end
 
   # copy contents between to places in the cache


### PR DESCRIPTION
In https://github.com/heroku/heroku-buildpack-ruby/pull/1583 a warning was bypassed by switching from `-n` to `--update none`. Unfortunately this triggers a problem with the version of `cp` on `heroku-20` (which is EOL in 2 days) due to not having that flag:

```
-----> Preparing app for Rails asset pipeline
remote: cp: option '--update' doesn't allow an argument
remote: Try 'cp --help' for more information.
```

Internal ticket link https://heroku.support/1570694.

GUS-W-18382830
