### PR TITLE
Update default Ruby version to 3.3.8

### DIFF
--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "3.1.6"
+          ruby-version: "3.3.8"
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Default Ruby version is now 3.3.8 (https://github.com/heroku/heroku-buildpack-ruby/pull/1595)
 
 ## [v308] - 2025-05-15
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.6"
+ruby "3.3.8"
 
 group :development, :test do
   gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 3.1.6p260
+   ruby 3.3.8p144
 
 BUNDLED WITH
-   2.5.11
+   2.5.22

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 name = "Ruby"
-ruby_version = "3.1.6"
+ruby_version = "3.3.8"
 
 [publish.Ignore]
 files = [

--- a/changelogs/unreleased/default_ruby.md
+++ b/changelogs/unreleased/default_ruby.md
@@ -1,0 +1,22 @@
+## Default Ruby version for new apps is now 3.3.8
+
+The [default Ruby version for new Ruby applications is 3.3.8](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.
+
+Heroku highly recommends specifying your desired Ruby version. You can specify a Ruby version in your `Gemfile:
+
+```term
+ruby "3.3.8"
+```
+
+Once you have a Ruby version specified in your `Gemfile`, update the `Gemfile.lock` by running the following command:
+
+```term
+$ bundle update --ruby
+```
+
+Make sure you commit the results to git before attempting to deploy again:
+
+```term
+$ git add Gemfile Gemfile.lock
+$ git commit -m "update ruby version"
+```

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -12,8 +12,8 @@ module LanguagePack
       end
     end
 
-    BOOTSTRAP_VERSION_NUMBER = "3.1.6".freeze
-    DEFAULT_VERSION_NUMBER = "3.3.7".freeze
+    BOOTSTRAP_VERSION_NUMBER = "3.3.8".freeze
+    DEFAULT_VERSION_NUMBER = "3.3.8".freeze
     DEFAULT_VERSION        = "ruby-#{DEFAULT_VERSION_NUMBER}".freeze
     RUBY_VERSION_REGEX     = %r{
         (?<ruby_version>\d+\.\d+\.\d+){0}

--- a/spec/helpers/shell_spec.rb
+++ b/spec/helpers/shell_spec.rb
@@ -74,7 +74,7 @@ describe "ShellHelpers" do
         end
 
         bad_lines = File.read("spec/fixtures/invalid_encoding.log")
-        expect { sh.puts(bad_lines) }.to raise_error(ArgumentError) do |error|
+        expect { sh.puts(bad_lines) }.to raise_error do |error|
           expect(error.message).to include("Invalid string:")
         end
       end


### PR DESCRIPTION
Also updates the "bootstrap" version of Ruby that the buildpack uses to run itself to match the default version. Previously, it was pinned to 3.1.x due to needing to support Bundler 1.x for the heroku-20.

GUS-W-18542568