### PR TITLE
Fix changelog message

### DIFF
--- a/changelogs/v309/default_ruby.md
+++ b/changelogs/v309/default_ruby.md
@@ -1,10 +1,10 @@
 ## Default Ruby version for new apps is now 3.3.8
 
-The [default Ruby version for new Ruby applications is 3.3.8](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a ruby version.
+The [default Ruby version for new Ruby applications is 3.3.8](https://devcenter.heroku.com/articles/ruby-support#default-ruby-version-for-new-apps). You’ll only get the default if the application does not specify a Ruby version.
 
-Heroku highly recommends specifying your desired Ruby version. You can specify a Ruby version in your `Gemfile:
+Heroku highly recommends specifying your desired Ruby version. You can specify a Ruby version in your `Gemfile`:
 
-```term
+```ruby
 ruby "3.3.8"
 ```
 


### PR DESCRIPTION
This was added in https://github.com/heroku/heroku-buildpack-ruby/pull/1595. Updating it so if a future developer copies/pastes for a future default change, it will be correct. 

Should match the source of https://devcenter.heroku.com/changelog-items/3244