### PR TITLE
Refactor RubyVersion class

### DIFF
--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -4,7 +4,7 @@
 #
 # Example:
 #
-#   ruby_version = LanguagePack::RubyVersion.new("ruby-2.2.5")
+#   ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.5")
 #   outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
 #     current_ruby_version: ruby_version,
 #     fetcher: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: "heroku-22")
@@ -175,7 +175,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
       next if !@fetcher.exists?("#{version}.tgz")
 
       check_eol_versions_minor(
-        base_version: LanguagePack::RubyVersion.new(version)
+        base_version: LanguagePack::RubyVersion.new(bundler_output: version)
       )
 
       version

--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -4,7 +4,7 @@
 #
 # Example:
 #
-#   ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.5")
+#   ruby_version = LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-2.2.5")
 #   outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
 #     current_ruby_version: ruby_version,
 #     fetcher: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, stack: "heroku-22")
@@ -175,7 +175,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
       next if !@fetcher.exists?("#{version}.tgz")
 
       check_eol_versions_minor(
-        base_version: LanguagePack::RubyVersion.new(bundler_output: version)
+        base_version: LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: version)
       )
 
       version

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -27,6 +27,7 @@ class LanguagePack::Installers::HerokuRubyInstaller
       "ruby.major" => ruby_version.major,
       "ruby.minor" => ruby_version.minor,
       "ruby.patch" => ruby_version.patch,
+      "ruby.default" => ruby_version.default?,
     )
     fetch_unpack(ruby_version, install_dir)
     setup_binstubs(install_dir)

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -472,7 +472,7 @@ EOF
     @metadata.write("buildpack_ruby_version", ruby_version.version_for_download)
 
     topic "Using Ruby version: #{ruby_version.version_for_download}"
-    if !ruby_version.set
+    if ruby_version.default?
       warn(<<~WARNING)
         You have not declared a Ruby version in your Gemfile.
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -183,9 +183,10 @@ WARNING
     last_version      = nil
     last_version      = @metadata.read(last_version_file).strip if @metadata.exists?(last_version_file)
 
-    @ruby_version = LanguagePack::RubyVersion.new(bundler.ruby_version,
-      is_new:       new_app?,
-      last_version: last_version)
+    @ruby_version = LanguagePack::RubyVersion.new(
+      bundler_output: bundler.ruby_version,
+      last_version: last_version
+    )
     return @ruby_version
   end
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -183,7 +183,7 @@ WARNING
     last_version      = nil
     last_version      = @metadata.read(last_version_file).strip if @metadata.exists?(last_version_file)
 
-    @ruby_version = LanguagePack::RubyVersion.new(
+    @ruby_version = LanguagePack::RubyVersion.bundle_platform_ruby(
       bundler_output: bundler.ruby_version,
       last_version: last_version
     )

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -172,7 +172,7 @@ WARNING
   # the relative path to the vendored ruby directory
   # @return [String] resulting path
   def slug_vendor_ruby
-    "vendor/#{ruby_version.version_without_patchlevel}"
+    "vendor/#{ruby_version.version_for_download}"
   end
 
   # fetch the ruby version from bundler

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -45,10 +45,11 @@ module LanguagePack
 
     include LanguagePack::ShellHelpers
 
-    def initialize(bundler_output, app = {})
+    def initialize(bundler_output:, last_version: nil)
       @set            = nil
       @bundler_output = bundler_output
-      @app            = app
+      @default_version = last_version || DEFAULT_VERSION
+
       set_version
       parse_version
 
@@ -126,7 +127,7 @@ module LanguagePack
     def set_version
       if @bundler_output.empty?
         @set     = false
-        @version = @app[:last_version] || DEFAULT_VERSION
+        @version = @default_version
       else
         @set     = :gemfile
         @version = @bundler_output

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -68,6 +68,7 @@ module LanguagePack
         @engine_version = engine_version
     end
 
+    # i.e. `ruby-3.4.2`
     def version_for_download
       if @engine == :jruby
         "ruby-#{ruby_version}-jruby-#{engine_version}"

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -25,11 +25,10 @@ module LanguagePack
       }x
 
 
-    # `version` is the bundler output like `ruby-3.4.2`
+    # The bundler output like `ruby-3.4.2` or `ruby-3.4.2-p100`
     attr_reader :version,
-      # `version_without_patchlevel` removes any `-p<number>` as they're not significant
-      # effectively this is `version_for_download`
-      :version_without_patchlevel,
+      # `The bundler output like `ruby-3.4.2` without patchlevel
+      :version_for_download,
       # `engine` is `:ruby` or `:jruby`
       :engine,
       # `ruby_version` is `<major>.<minor>.<patch>` extracted from `version`
@@ -48,19 +47,15 @@ module LanguagePack
         @default = false
         @version = bundler_output
       end
+      # Remove patchlevel (if one is present)
+      # https://github.com/bundler/bundler/issues/4621
+      @version_for_download = @version.sub(/-p-?\d+/, '')
 
       md = RUBY_VERSION_REGEX.match(version)
       raise BadVersionError.new("'#{version}' is not valid") unless md
       @ruby_version   = md[:ruby_version]
       @engine_version = md[:engine_version] || @ruby_version
       @engine         = (md[:engine]        || :ruby).to_sym
-
-      @version_without_patchlevel = @version.sub(/-p-?\d+/, '')
-    end
-
-    # https://github.com/bundler/bundler/issues/4621
-    def version_for_download
-      version_without_patchlevel
     end
 
     def file_name

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -46,16 +46,12 @@ module LanguagePack
     include LanguagePack::ShellHelpers
 
     def initialize(bundler_output:, last_version: nil)
-      @set            = nil
-      @bundler_output = bundler_output
-      @default_version = last_version || DEFAULT_VERSION
-
-      if @bundler_output.empty?
+      if bundler_output.empty?
         @set     = false
-        @version = @default_version
+        @version = last_version || DEFAULT_VERSION
       else
         @set     = :gemfile
-        @version = @bundler_output
+        @version = bundler_output
       end
 
       md = RUBY_VERSION_REGEX.match(version)

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -21,7 +21,7 @@ module LanguagePack
         (?<engine>\w+){0}
         (?<engine_version>.+){0}
 
-        ruby-\g<ruby_version>(-\g<patchlevel>)?(\.(?<pre>\S*\d+))?(-\g<engine>-\g<engine_version>)?
+        ruby-\g<ruby_version>(-\g<patchlevel>)?(\.(?<pre>\S*))?(-\g<engine>-\g<engine_version>)?
       }x
 
     # String formatted `<major>.<minor>.<patch>` for Ruby and JRuby

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -50,8 +50,20 @@ module LanguagePack
       @bundler_output = bundler_output
       @default_version = last_version || DEFAULT_VERSION
 
-      set_version
-      parse_version
+      if @bundler_output.empty?
+        @set     = false
+        @version = @default_version
+      else
+        @set     = :gemfile
+        @version = @bundler_output
+      end
+
+      md = RUBY_VERSION_REGEX.match(version)
+      raise BadVersionError.new("'#{version}' is not valid") unless md
+      @ruby_version   = md[:ruby_version]
+      @patchlevel     = md[:patchlevel]
+      @engine_version = md[:engine_version] || @ruby_version
+      @engine         = (md[:engine]        || :ruby).to_sym
 
       @version_without_patchlevel = @version.sub(/-p-?\d+/, '')
     end
@@ -121,26 +133,6 @@ module LanguagePack
       split_version[1] = 0
       split_version[2] = 0
       return "ruby-#{split_version.join(".")}"
-    end
-
-    private
-    def set_version
-      if @bundler_output.empty?
-        @set     = false
-        @version = @default_version
-      else
-        @set     = :gemfile
-        @version = @bundler_output
-      end
-    end
-
-    def parse_version
-      md = RUBY_VERSION_REGEX.match(version)
-      raise BadVersionError.new("'#{version}' is not valid") unless md
-      @ruby_version   = md[:ruby_version]
-      @patchlevel     = md[:patchlevel]
-      @engine_version = md[:engine_version] || @ruby_version
-      @engine         = (md[:engine]        || :ruby).to_sym
     end
   end
 end

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -33,8 +33,6 @@ module LanguagePack
       # `version_without_patchlevel` removes any `-p<number>` as they're not significant
       # effectively this is `version_for_download`
       :version_without_patchlevel,
-      # `patchlevel` is the `-p<number>` or is empty
-      :patchlevel,
       # `engine` is `:ruby` or `:jruby`
       :engine,
       # `ruby_version` is `<major>.<minor>.<patch>` extracted from `version`
@@ -57,7 +55,6 @@ module LanguagePack
       md = RUBY_VERSION_REGEX.match(version)
       raise BadVersionError.new("'#{version}' is not valid") unless md
       @ruby_version   = md[:ruby_version]
-      @patchlevel     = md[:patchlevel]
       @engine_version = md[:engine_version] || @ruby_version
       @engine         = (md[:engine]        || :ruby).to_sym
 

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -104,25 +104,15 @@ module LanguagePack
     # `ruby-2.3.1` then then `next_logical_version(1)`
     # will produce `ruby-2.3.2`.
     def next_logical_version(increment = 1)
-      split_version = @version_without_patchlevel.split(".")
-      teeny = split_version.pop
-      split_version << teeny.to_i + increment
-      split_version.join(".")
+      "ruby-#{major}.#{minor}.#{patch + increment}"
     end
 
     def next_minor_version(increment = 1)
-      split_version = @version_without_patchlevel.split(".")
-      split_version[1] = split_version[1].to_i + increment
-      split_version[2] = 0
-      split_version.join(".")
+      "ruby-#{major}.#{minor + increment}.0"
     end
 
     def next_major_version(increment = 1)
-      split_version = @version_without_patchlevel.split("-").last.split(".")
-      split_version[0] = Integer(split_version[0]) + increment
-      split_version[1] = 0
-      split_version[2] = 0
-      return "ruby-#{split_version.join(".")}"
+      "ruby-#{major + increment}.0.0"
     end
   end
 end

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -24,11 +24,8 @@ module LanguagePack
         ruby-\g<ruby_version>(-\g<patchlevel>)?(-\g<engine>-\g<engine_version>)?
       }x
 
-
-    # The bundler output like `ruby-3.4.2` or `ruby-3.4.2-p100`
-    attr_reader :version,
-      # `The bundler output like `ruby-3.4.2` without patchlevel
-      :version_for_download,
+    # `The bundler output like `ruby-3.4.2` without patchlevel
+    attr_reader :version_for_download,
       # `engine` is `:ruby` or `:jruby`
       :engine,
       # `ruby_version` is `<major>.<minor>.<patch>` extracted from `version`
@@ -42,17 +39,16 @@ module LanguagePack
     def initialize(bundler_output:, last_version: nil)
       if bundler_output.empty?
         @default = true
-        @version = last_version || DEFAULT_VERSION
+        bundler_output = last_version || DEFAULT_VERSION
       else
         @default = false
-        @version = bundler_output
       end
       # Remove patchlevel (if one is present)
       # https://github.com/bundler/bundler/issues/4621
-      @version_for_download = @version.sub(/-p-?\d+/, '')
+      @version_for_download = bundler_output.sub(/-p-?\d+/, '')
 
-      md = RUBY_VERSION_REGEX.match(version)
-      raise BadVersionError.new("'#{version}' is not valid") unless md
+      md = RUBY_VERSION_REGEX.match(bundler_output)
+      raise BadVersionError.new("'#{bundler_output}' is not valid") unless md
       @ruby_version   = md[:ruby_version]
       @engine_version = md[:engine_version] || @ruby_version
       @engine         = (md[:engine]        || :ruby).to_sym

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -1,4 +1,4 @@
-require "language_pack/shell_helpers"
+require "language_pack/shell_helpers" # Holds BuildpackError
 
 module LanguagePack
   class RubyVersion
@@ -31,8 +31,6 @@ module LanguagePack
       # `engine_version` is the Jruby version or for MRI it is the same as `ruby_version`
       # i.e. `<major>.<minor>.<patch>`
       :engine_version
-
-    include LanguagePack::ShellHelpers
 
     def self.bundle_platform_ruby(bundler_output:, last_version: nil)
       default = bundler_output.empty?

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -27,9 +27,6 @@ module LanguagePack
 
     # `version` is the bundler output like `ruby-3.4.2`
     attr_reader :version,
-      # `set` is either `:gemfile` when the app specified a version or `nil` when using
-      # the default version
-      :set,
       # `version_without_patchlevel` removes any `-p<number>` as they're not significant
       # effectively this is `version_for_download`
       :version_without_patchlevel,
@@ -45,10 +42,10 @@ module LanguagePack
 
     def initialize(bundler_output:, last_version: nil)
       if bundler_output.empty?
-        @set     = false
+        @default = true
         @version = last_version || DEFAULT_VERSION
       else
-        @set     = :gemfile
+        @default = false
         @version = bundler_output
       end
 
@@ -71,7 +68,7 @@ module LanguagePack
     end
 
     def default?
-      !set
+      @default
     end
 
     # determine if we're using jruby

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -35,25 +35,28 @@ module LanguagePack
     def self.bundle_platform_ruby(bundler_output:, last_version: nil)
       default = bundler_output.empty?
       if default
-        ruby_version = last_version&.split("-")&.last || DEFAULT_VERSION_NUMBER
-        pre = nil
-        engine = :ruby
-        engine_version = ruby_version
+        default(last_version: last_version)
       elsif md = RUBY_VERSION_REGEX.match(bundler_output)
-        pre = md[:pre]
-        engine = md[:engine]&.to_sym || :ruby
-        ruby_version = md[:ruby_version]
-        engine_version = md[:engine_version] || ruby_version
+        new(
+          pre: md[:pre],
+          engine: md[:engine]&.to_sym || :ruby,
+          default: default,
+          ruby_version: md[:ruby_version],
+          engine_version: md[:engine_version] || md[:ruby_version],
+        )
       else
         raise BadVersionError.new("'#{bundler_output}' is not valid") unless md
       end
+    end
 
+    def self.default(last_version: )
+      ruby_version = last_version&.split("-")&.last || DEFAULT_VERSION_NUMBER
       new(
-        pre: pre,
-        engine: engine,
-        default: default,
+        pre: nil,
+        engine: :ruby,
+        default: true,
         ruby_version: ruby_version,
-        engine_version: engine_version,
+        engine_version: ruby_version,
       )
     end
 

--- a/spec/helpers/heroku_ruby_installer_spec.rb
+++ b/spec/helpers/heroku_ruby_installer_spec.rb
@@ -11,7 +11,7 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
   end
 
   def ruby_version
-    LanguagePack::RubyVersion.new("ruby-3.1.7")
+    LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.7")
   end
 
   describe "#fetch_unpack" do
@@ -58,7 +58,7 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
             arch: "arm64",
             report: report
           ).install(
-            LanguagePack::RubyVersion.new("ruby-3.1.4-p0-jruby-9.4.9.0"),
+            LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.4-p0-jruby-9.4.9.0"),
             "#{dir}/vendor/ruby"
           )
 

--- a/spec/helpers/heroku_ruby_installer_spec.rb
+++ b/spec/helpers/heroku_ruby_installer_spec.rb
@@ -11,7 +11,7 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
   end
 
   def ruby_version
-    LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.7")
+    LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-3.1.7")
   end
 
   describe "#fetch_unpack" do
@@ -58,7 +58,7 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
             arch: "arm64",
             report: report
           ).install(
-            LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.4-p0-jruby-9.4.9.0"),
+            LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-3.1.4-p0-jruby-9.4.9.0"),
             "#{dir}/vendor/ruby"
           )
 

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -7,7 +7,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   }
 
   it "handles amd ↗️ architecture on heroku-24" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-3.1.0")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.0")
     fetcher = LanguagePack::Fetcher.new(
       LanguagePack::Base::VENDOR_URL,
       stack: "heroku-24",
@@ -23,7 +23,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "handles arm 💪 architecture on heroku-24" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-3.1.0")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.0")
     fetcher = LanguagePack::Fetcher.new(
       LanguagePack::Base::VENDOR_URL,
       stack: "heroku-24",
@@ -39,7 +39,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "finds the latest version on a stack" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-2.2.5")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.5")
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
       fetcher: fetcher
@@ -52,7 +52,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "detects returns original ruby version when using the latest" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-2.2.10")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.10")
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
       fetcher: fetcher
@@ -64,8 +64,8 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "recommends a non EOL version of Ruby" do
-    ruby_version_one = LanguagePack::RubyVersion.new("ruby-2.1.10")
-    ruby_version_two = LanguagePack::RubyVersion.new("ruby-2.2.10")
+    ruby_version_one = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.1.10")
+    ruby_version_two = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.10")
 
     outdated_one = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version_one,
@@ -94,7 +94,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "does not recommend EOL for recent ruby version" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-2.2.10")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.10")
 
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
@@ -104,7 +104,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     outdated.call
 
     good_version = outdated.suggest_ruby_eol_version.sub("x", "0")
-    ruby_version = LanguagePack::RubyVersion.new("ruby-#{good_version}")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-#{good_version}")
 
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
@@ -117,7 +117,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "can call eol? on the latest Ruby version" do
-    ruby_version = LanguagePack::RubyVersion.new("ruby-2.6.0")
+    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "bundler_output: ruby-2.6.0")
 
     new_fetcher = fetcher.dup
     def new_fetcher.exists?(value); false; end

--- a/spec/helpers/outdated_ruby_version_spec.rb
+++ b/spec/helpers/outdated_ruby_version_spec.rb
@@ -7,7 +7,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   }
 
   it "handles amd ↗️ architecture on heroku-24" do
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.0")
+    ruby_version = LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-3.1.0")
     fetcher = LanguagePack::Fetcher.new(
       LanguagePack::Base::VENDOR_URL,
       stack: "heroku-24",
@@ -23,7 +23,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "handles arm 💪 architecture on heroku-24" do
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-3.1.0")
+    ruby_version = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-3.1.0")
     fetcher = LanguagePack::Fetcher.new(
       LanguagePack::Base::VENDOR_URL,
       stack: "heroku-24",
@@ -39,7 +39,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "finds the latest version on a stack" do
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.5")
+    ruby_version = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-2.2.5")
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
       fetcher: fetcher
@@ -52,7 +52,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "detects returns original ruby version when using the latest" do
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.10")
+    ruby_version = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-2.2.10")
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
       fetcher: fetcher
@@ -64,8 +64,8 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "recommends a non EOL version of Ruby" do
-    ruby_version_one = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.1.10")
-    ruby_version_two = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.10")
+    ruby_version_one = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-2.1.10")
+    ruby_version_two = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-2.2.10")
 
     outdated_one = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version_one,
@@ -94,7 +94,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "does not recommend EOL for recent ruby version" do
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-2.2.10")
+    ruby_version = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-2.2.10")
 
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
@@ -104,7 +104,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
     outdated.call
 
     good_version = outdated.suggest_ruby_eol_version.sub("x", "0")
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "ruby-#{good_version}")
+    ruby_version = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "ruby-#{good_version}")
 
     outdated = LanguagePack::Helpers::OutdatedRubyVersion.new(
       current_ruby_version: ruby_version,
@@ -117,7 +117,7 @@ describe LanguagePack::Helpers::OutdatedRubyVersion do
   end
 
   it "can call eol? on the latest Ruby version" do
-    ruby_version = LanguagePack::RubyVersion.new(bundler_output: "bundler_output: ruby-2.6.0")
+    ruby_version = LanguagePack::RubyVersion::bundle_platform_ruby(bundler_output: "bundler_output: ruby-2.6.0")
 
     new_fetcher = fetcher.dup
     def new_fetcher.exists?(value); false; end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -21,7 +21,7 @@ describe "RubyVersion" do
     ruby_version   = LanguagePack::RubyVersion.new(bundler_output: "ruby-#{version_number}-p0")
     version        = "ruby-#{version_number}"
 
-    expect(ruby_version.version_without_patchlevel).to eq(version)
+    expect(ruby_version.version_for_download).to eq(version)
     expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
     expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
     expect(ruby_version.next_logical_version(2)).to eq("ruby-2.5.2")
@@ -43,7 +43,7 @@ describe "RubyVersion" do
         ruby_version   = LanguagePack::RubyVersion.new(bundler_output: @bundler.install.ruby_version)
         version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
         version        = LanguagePack::RubyVersion::DEFAULT_VERSION
-        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.version_for_download).to eq(version)
         expect(ruby_version.engine_version).to eq(version_number)
         expect(ruby_version.to_gemfile).to eq("ruby '#{version_number}'")
         expect(ruby_version.engine).to eq(:ruby)
@@ -87,7 +87,7 @@ describe "RubyVersion" do
         ruby_version   = LanguagePack::RubyVersion.new(bundler_output: @bundler.install.ruby_version)
         version_number = "3.2.3"
         version        = "ruby-#{version_number}"
-        expect(ruby_version.version_without_patchlevel).to eq(version)
+        expect(ruby_version.version_for_download).to eq(version)
         expect(ruby_version.engine_version).to eq(version_number)
         expect(ruby_version.engine).to eq(:ruby)
       end
@@ -126,7 +126,7 @@ describe "RubyVersion" do
         version_number = "2.6.8"
         engine_version = "9.3.6.0"
         engine = :jruby
-        expect(ruby_version.version_without_patchlevel).to eq("ruby-#{version_number}-#{engine}-#{engine_version}")
+        expect(ruby_version.version_for_download).to eq("ruby-#{version_number}-#{engine}-#{engine_version}")
         expect(ruby_version.engine_version).to eq(engine_version)
         expect(ruby_version.engine).to eq(engine)
       end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -18,7 +18,7 @@ describe "RubyVersion" do
 
   it "knows the next logical version" do
     version_number = "2.5.0"
-    ruby_version   = LanguagePack::RubyVersion.new(bundler_output: "ruby-#{version_number}-p0")
+    ruby_version   = LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-#{version_number}-p0")
     version        = "ruby-#{version_number}"
 
     expect(ruby_version.version_for_download).to eq(version)
@@ -40,7 +40,7 @@ describe "RubyVersion" do
     Hatchet::App.new("default_ruby").in_directory_fork do |dir|
       require 'bundler'
       Bundler.with_unbundled_env do
-        ruby_version   = LanguagePack::RubyVersion.new(bundler_output: @bundler.install.ruby_version)
+        ruby_version   = LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: @bundler.install.ruby_version)
         version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
         version        = LanguagePack::RubyVersion::DEFAULT_VERSION
         expect(ruby_version.version_for_download).to eq(version)
@@ -84,7 +84,7 @@ describe "RubyVersion" do
             2.4.19
         EOF
 
-        ruby_version   = LanguagePack::RubyVersion.new(bundler_output: @bundler.install.ruby_version)
+        ruby_version   = LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: @bundler.install.ruby_version)
         version_number = "3.2.3"
         version        = "ruby-#{version_number}"
         expect(ruby_version.version_for_download).to eq(version)
@@ -120,7 +120,7 @@ describe "RubyVersion" do
             2.3.25
         EOF
 
-        ruby_version   = LanguagePack::RubyVersion.new(
+        ruby_version   = LanguagePack::RubyVersion.bundle_platform_ruby(
           bundler_output: @bundler.install.ruby_version,
         )
         version_number = "2.6.8"

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -136,6 +136,43 @@ describe "RubyVersion" do
     end
   end
 
+  it "detects pre versions that do not end in numbers" do
+    Hatchet::App.new("default_ruby").in_directory_fork do |_|
+      require 'bundler'
+      dir = Pathname(Dir.pwd)
+      Bundler.with_unbundled_env do
+        dir.join("Gemfile").write(<<~EOF)
+          source "https://rubygems.org"
+          gem 'rake'
+          ruby '3.2.3'
+        EOF
+        dir.join("Gemfile.lock").write(<<~EOF)
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              rake (13.2.1)
+          PLATFORMS
+            arm64-darwin-22
+            ruby
+            x86_64-linux
+          DEPENDENCIES
+            rake
+          RUBY VERSION
+            ruby 3.2.3.lol
+          BUNDLED WITH
+            2.4.19
+        EOF
+
+        ruby_version   = LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: @bundler.install.ruby_version)
+        version_number = "3.2.3"
+        version        = "ruby-#{version_number}.lol"
+        expect(ruby_version.version_for_download).to eq(version)
+        expect(ruby_version.engine_version).to eq(version_number)
+        expect(ruby_version.engine).to eq(:ruby)
+      end
+    end
+  end
+
   it "detects non mri engines" do
     Hatchet::App.new("default_ruby").in_directory_fork do |_|
       require 'bundler'

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -18,7 +18,7 @@ describe "RubyVersion" do
 
   it "knows the next logical version" do
     version_number = "2.5.0"
-    ruby_version   = LanguagePack::RubyVersion.new("ruby-#{version_number}-p0", is_new: true)
+    ruby_version   = LanguagePack::RubyVersion.new(bundler_output: "ruby-#{version_number}-p0")
     version        = "ruby-#{version_number}"
 
     expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -40,7 +40,7 @@ describe "RubyVersion" do
     Hatchet::App.new("default_ruby").in_directory_fork do |dir|
       require 'bundler'
       Bundler.with_unbundled_env do
-        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+        ruby_version   = LanguagePack::RubyVersion.new(bundler_output: @bundler.install.ruby_version)
         version_number = LanguagePack::RubyVersion::DEFAULT_VERSION_NUMBER
         version        = LanguagePack::RubyVersion::DEFAULT_VERSION
         expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -84,7 +84,7 @@ describe "RubyVersion" do
             2.4.19
         EOF
 
-        ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+        ruby_version   = LanguagePack::RubyVersion.new(bundler_output: @bundler.install.ruby_version)
         version_number = "3.2.3"
         version        = "ruby-#{version_number}"
         expect(ruby_version.version_without_patchlevel).to eq(version)
@@ -121,8 +121,7 @@ describe "RubyVersion" do
         EOF
 
         ruby_version   = LanguagePack::RubyVersion.new(
-          @bundler.install.ruby_version,
-          is_new: true
+          bundler_output: @bundler.install.ruby_version,
         )
         version_number = "2.6.8"
         engine_version = "9.3.6.0"


### PR DESCRIPTION
The RubyVersion class is used to hold information about the application's Ruby version. It was previously tightly coupled to the parsing `bundle platform-- ruby` output. Now, its interface is standardized, but makes it into a simple store that can be populated by different information sources. This can be used to compare two different data sources for differences in the future.

Commits are small and ordered. There should be no net change to the end user behavior.

## Context of this work

Today, the order of operations for running the buildpack looks like this:

- Install bootstrap (buildpack) ruby version
- Detect and install a limited number of "blessed" bundler versions (from S3) 
- Use that version with the bootstrap Ruby to run `bundle platform --ruby` to detect the application Ruby version.

Moving into the future, an eventual goal is to be able to avoid running `bundle platform --ruby` with the bootstrap version of ruby (used by the buildpack). This execution exposes incompatibilities between the bootstrap ruby version and versions of bundler. Instead, the order will eventually be:

- Install bootstrap ruby version
- Read and parse the Gemfile.lock to determine Ruby version and install it
- Install the arbitrary bundler version found in Gemfile.lock (from `gem install bundler -v <version>`)

To support this, I want to populate RubyVersion from different sources at the same time so I can compare them, instrument them, and ensure consistent platform behavior. The work here is a stepping stone to this eventual goal.

Worth noting that the proposed future goal is the same order of execution as the CNB (without the need to install a bootstrap ruby as the CNB is written in Rust).