### PR TITLE
Fix fixture indentation

### DIFF
--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -138,7 +138,7 @@ describe "Ruby apps" do
               rake
 
             RUBY VERSION
-              ruby 3.3.1p0
+               ruby 3.3.1p0
           EOF
 
           Pathname("Rakefile").write(<<~'EOF')


### PR DESCRIPTION
It should be three spaces, but vscode formatting really wants it to be two.