### PR TITLE
Update tests

### DIFF
--- a/spec/hatchet/node_spec.rb
+++ b/spec/hatchet/node_spec.rb
@@ -34,11 +34,11 @@ describe "Node and Yarn" do
 
     Hatchet::Runner.new("minimal_webpacker", buildpacks: buildpacks, config: config).deploy do |app, heroku|
       expect(app.output).to include("yarn install")
-      expect(app.output).to include(".heroku/yarn/bin/yarn is the yarn directory")
+      expect(app.output).to include(".heroku/node/bin/yarn is the yarn directory ")
       expect(app.output).to include(".heroku/node/bin/node is the node directory")
 
       expect(app.run("which node")).to match("/app/.heroku/node/bin")
-      expect(app.run("which yarn")).to match("/app/.heroku/yarn/bin")
+      expect(app.run("which yarn")).to match("/app/.heroku/node/bin")
     end
   end
 end


### PR DESCRIPTION
The Ruby buildpack depends on PATH set by the node buildpack for some tests. It appears that the path on disk changed from `.heroku/yarn/bin/yarn` to `.heroku/node/bin/yarn`

This appears to be changed in https://github.com/heroku/heroku-buildpack-nodejs/compare/v295...v296.

Reported in https://github.com/heroku/heroku-buildpack-nodejs/issues/1428