### PR TITLE
Track origin of Ruby version

### DIFF
--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -27,11 +27,9 @@ class LanguagePack::Installers::HerokuRubyInstaller
       "ruby_version_engine" => ruby_version.engine,
       # i.e. 10.0.2.0 for Jruby, matches `ruby_version_spec` for MRI
       "ruby_version_engine_version" => ruby_version.engine_version,
-      # i.e. `3.4.2` for both MRI and JRuby
-      "ruby_version_spec" => ruby_version.ruby_version,
       # major/minor/patch pulled from the `ruby_version_spec` (will not include engine version information)
-      "ruby_version_major_minor" => "#{ruby_version.major}.#{ruby_version.minor}" ,
-      "ruby_version_major_minor_patch" => "#{ruby_version.major}.#{ruby_version.minor}.#{ruby_version.patch}",
+      "ruby_version_spec_major_minor" => "#{ruby_version.major}.#{ruby_version.minor}" ,
+      "ruby_version_spec_major_minor_patch" => "#{ruby_version.major}.#{ruby_version.minor}.#{ruby_version.patch}",
       "ruby_version_origin" => ruby_version.default? ? "default" : "Gemfile.lock"
     )
     fetch_unpack(ruby_version, install_dir)

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -29,10 +29,9 @@ class LanguagePack::Installers::HerokuRubyInstaller
       "ruby_version_engine_version" => ruby_version.engine_version,
       # i.e. `3.4.2` for both MRI and JRuby
       "ruby_version_spec" => ruby_version.ruby_version,
-      # major/minor/patch pulled from the spec
-      "ruby_version_major" => ruby_version.major,
-      "ruby_version_minor" => ruby_version.minor,
-      "ruby_version_patch" => ruby_version.patch,
+      # major/minor/patch pulled from the `ruby_version_spec` (will not include engine version information)
+      "ruby_version_major_minor" => "#{ruby_version.major}.#{ruby_version.minor}" ,
+      "ruby_version_major_minor_patch" => "#{ruby_version.major}.#{ruby_version.minor}.#{ruby_version.patch}",
       "ruby_version_origin" => ruby_version.default? ? "default" : "Gemfile.lock"
     )
     fetch_unpack(ruby_version, install_dir)

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -21,17 +21,36 @@ class LanguagePack::Installers::HerokuRubyInstaller
 
   def install(ruby_version, install_dir)
     @report.capture(
-      # i.e. `ruby-3.4.2-jruby-10.0.2.0` or `ruby-3.4.2` or `ruby-3.5.0.pre1`
-      "ruby_version_unique" => ruby_version.version_for_download,
       # i.e. `jruby` or `ruby`
       "ruby_version_engine" => ruby_version.engine,
-      # i.e. 10.0.2.0 for Jruby, matches `ruby_version_spec` for MRI
-      "ruby_version_engine_version" => ruby_version.engine_version,
-      # major/minor/patch pulled from the `ruby_version_spec` (will not include engine version information)
-      "ruby_version_spec_major_minor" => "#{ruby_version.major}.#{ruby_version.minor}" ,
-      "ruby_version_spec_major_minor_patch" => "#{ruby_version.major}.#{ruby_version.minor}.#{ruby_version.patch}",
-      "ruby_version_origin" => ruby_version.default? ? "default" : "Gemfile.lock"
+      # i.e. `ruby-3.4.2-jruby-10.0.2.0` or `ruby-3.4.2` or `ruby-3.5.0.pre1`
+      "ruby_version_unique" => ruby_version.version_for_download,
+      # i.e. `default` or `Gemfile.lock`
+      "ruby_version_origin" => ruby_version.default? ? "default" : "Gemfile.lock",
     )
+
+    case ruby_version.engine
+    when :ruby
+      @report.capture(
+        "ruby_version_major_minor" => "#{ruby_version.major}.#{ruby_version.minor}",
+        "ruby_version_full" => ruby_version.engine_version_full
+      )
+    when :jruby
+      @report.capture(
+        # i.e. `3.4.2` the target spec ruby version
+        "jruby_version_ruby_version" => ruby_version.ruby_version,
+        # i.e. `10.0.2.0` the version of jruby
+        "jruby_version_full" => ruby_version.engine_version_full,
+        # i.e. `9.4` or `10.0`
+        "jruby_version_major_minor" => [
+          ruby_version.engine_version.split(".")[0],
+          ruby_version.engine_version.split(".")[1]
+        ].join(".")
+      )
+    else
+      raise "Internal error: Unknown engine: #{ruby_version.engine}"
+    end
+
     fetch_unpack(ruby_version, install_dir)
     setup_binstubs(install_dir)
   end

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -21,8 +21,8 @@ class LanguagePack::Installers::HerokuRubyInstaller
 
   def install(ruby_version, install_dir)
     @report.capture(
-      # i.e. `ruby-3.4.2-jruby-10.0.2.0` or `ruby-3.4.2`
-      "ruby_version" => ruby_version.version_for_download,
+      # i.e. `ruby-3.4.2-jruby-10.0.2.0` or `ruby-3.4.2` or `ruby-3.5.0.pre1`
+      "ruby_version_unique" => ruby_version.version_for_download,
       # i.e. `jruby` or `ruby`
       "ruby_version_engine" => ruby_version.engine,
       # i.e. 10.0.2.0 for Jruby, matches `ruby_version_spec` for MRI

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -21,7 +21,8 @@ class LanguagePack::Installers::HerokuRubyInstaller
 
   def install(ruby_version, install_dir)
     @report.capture(
-      "ruby.version" => ruby_version.ruby_version,
+      "ruby.spec_version" => ruby_version.ruby_version,
+      "ruby.version_for_download" => ruby_version.version_for_download,
       "ruby.engine" => ruby_version.engine,
       "ruby.engine.version" => ruby_version.engine_version,
       "ruby.major" => ruby_version.major,

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -27,7 +27,7 @@ class LanguagePack::Installers::HerokuRubyInstaller
       "ruby.major" => ruby_version.major,
       "ruby.minor" => ruby_version.minor,
       "ruby.patch" => ruby_version.patch,
-      "ruby.default" => ruby_version.default?,
+      "ruby.origin" => ruby_version.default? ? "default" : "Gemfile.lock"
     )
     fetch_unpack(ruby_version, install_dir)
     setup_binstubs(install_dir)

--- a/lib/language_pack/installers/heroku_ruby_installer.rb
+++ b/lib/language_pack/installers/heroku_ruby_installer.rb
@@ -21,14 +21,19 @@ class LanguagePack::Installers::HerokuRubyInstaller
 
   def install(ruby_version, install_dir)
     @report.capture(
-      "ruby.spec_version" => ruby_version.ruby_version,
-      "ruby.version_for_download" => ruby_version.version_for_download,
-      "ruby.engine" => ruby_version.engine,
-      "ruby.engine.version" => ruby_version.engine_version,
-      "ruby.major" => ruby_version.major,
-      "ruby.minor" => ruby_version.minor,
-      "ruby.patch" => ruby_version.patch,
-      "ruby.origin" => ruby_version.default? ? "default" : "Gemfile.lock"
+      # i.e. `ruby-3.4.2-jruby-10.0.2.0` or `ruby-3.4.2`
+      "ruby_version" => ruby_version.version_for_download,
+      # i.e. `jruby` or `ruby`
+      "ruby_version_engine" => ruby_version.engine,
+      # i.e. 10.0.2.0 for Jruby, matches `ruby_version_spec` for MRI
+      "ruby_version_engine_version" => ruby_version.engine_version,
+      # i.e. `3.4.2` for both MRI and JRuby
+      "ruby_version_spec" => ruby_version.ruby_version,
+      # major/minor/patch pulled from the spec
+      "ruby_version_major" => ruby_version.major,
+      "ruby_version_minor" => ruby_version.minor,
+      "ruby_version_patch" => ruby_version.patch,
+      "ruby_version_origin" => ruby_version.default? ? "default" : "Gemfile.lock"
     )
     fetch_unpack(ruby_version, install_dir)
     setup_binstubs(install_dir)

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -88,6 +88,7 @@ module LanguagePack
         @engine_version = engine_version
     end
 
+    # Also used as for metrics to track unique installs
     # i.e. `ruby-3.4.2`
     def version_for_download
       if @engine == :jruby

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -93,10 +93,21 @@ module LanguagePack
     def version_for_download
       if @engine == :jruby
         "ruby-#{ruby_version}-jruby-#{engine_version}"
-      elsif @pre
-        "ruby-#{ruby_version}.#{@pre}"
       else
-        "ruby-#{ruby_version}"
+        "ruby-#{engine_version_full}"
+      end
+    end
+
+    # Full qualifier for the version including pre-release information
+    # i.e. `3.5.0.preview1` or `3.5.0` or `3.5.0.rc1` for ruby
+    # i.e. `9.4.9.0` for jruby
+    def engine_version_full
+      if @engine == :jruby
+        engine_version
+      elsif @pre
+        "#{engine_version}.#{@pre}"
+      else
+        "#{engine_version}"
       end
     end
 

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -189,7 +189,7 @@ describe "Ruby apps" do
             expect(report_match).to be_truthy
             yaml = report_match[:yaml].gsub(/remote: /, "")
             report = YAML.load(yaml)
-            expect(report.fetch("ruby_version_engine_version")).to eq(expected)
+            expect(report.fetch("ruby_version_full")).to eq(expected)
           rescue Exception => e
             puts app.output
             puts yaml if yaml

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -189,7 +189,7 @@ describe "Ruby apps" do
             expect(report_match).to be_truthy
             yaml = report_match[:yaml].gsub(/remote: /, "")
             report = YAML.load(yaml)
-            expect(report.fetch("ruby.version")).to eq(expected)
+            expect(report.fetch("ruby_version_engine_version")).to eq(expected)
           rescue Exception => e
             puts app.output
             puts yaml if yaml

--- a/spec/helpers/heroku_ruby_installer_spec.rb
+++ b/spec/helpers/heroku_ruby_installer_spec.rb
@@ -30,7 +30,7 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
     end
   end
 
-  describe "#install" do
+  describe "ruby installation" do
     it "should install ruby and setup binstubs" do
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
@@ -43,11 +43,36 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
 
           expected = {
             "ruby_version_engine" => :ruby,
-            "ruby_version_engine_version" => "3.1.7",
-            "ruby_version_spec_major_minor" => "3.1",
+            "ruby_version_full" => "3.1.7",
+            "ruby_version_major_minor" => "3.1",
             "ruby_version_origin" => "Gemfile.lock",
-            "ruby_version_spec_major_minor_patch" => "3.1.7",
             "ruby_version_unique" => "ruby-3.1.7"
+          }
+
+          expect(sort_hash(report.data)).to eq(sort_hash(expected))
+        end
+      end
+    end
+
+    it "should work with pre-release versions" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          report = HerokuBuildReport.dev_null
+          installer(report: report).install(
+            LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-3.5.0.preview1"),
+            "#{dir}/vendor/ruby"
+          )
+
+          expect(File.symlink?("#{dir}/bin/ruby")).to be true
+          expect(File.symlink?("#{dir}/bin/ruby.exe")).to be true
+          expect(File).to exist("#{dir}/vendor/ruby/bin/ruby")
+
+          expected = {
+            "ruby_version_engine" => :ruby,
+            "ruby_version_major_minor" => "3.5",
+            "ruby_version_full" => "3.5.0.preview1",
+            "ruby_version_origin" => "Gemfile.lock",
+            "ruby_version_unique" => "ruby-3.5.0.preview1"
           }
 
           expect(sort_hash(report.data)).to eq(sort_hash(expected))
@@ -72,10 +97,10 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
 
           expected = {
             "ruby_version_engine" => :jruby,
-            "ruby_version_engine_version" => "9.4.9.0",
-            "ruby_version_spec_major_minor" => "3.1",
+            "jruby_version_full" => "9.4.9.0",
+            "jruby_version_major_minor" => "9.4",
+            "jruby_version_ruby_version" => "3.1.4",
             "ruby_version_origin" => "Gemfile.lock",
-            "ruby_version_spec_major_minor_patch" => "3.1.4",
             "ruby_version_unique" => "ruby-3.1.4-jruby-9.4.9.0"
           }
 

--- a/spec/helpers/heroku_ruby_installer_spec.rb
+++ b/spec/helpers/heroku_ruby_installer_spec.rb
@@ -37,12 +37,12 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
           expect(File.symlink?("#{dir}/bin/ruby.exe")).to be true
           expect(File).to exist("#{dir}/vendor/ruby/bin/ruby")
 
-          expect(report.data["ruby.version"]).to eq("3.1.7")
-          expect(report.data["ruby.engine"]).to eq(:ruby)
-          expect(report.data["ruby.engine.version"]).to eq(report.data["ruby.version"])
-          expect(report.data["ruby.major"]).to eq(3)
-          expect(report.data["ruby.minor"]).to eq(1)
-          expect(report.data["ruby.patch"]).to eq(7)
+          expect(report.data["ruby_version"]).to eq("ruby-3.1.7")
+          expect(report.data["ruby_version_engine"]).to eq(:ruby)
+          expect(report.data["ruby_version_engine_version"]).to eq(report.data["ruby_version"].split("-").last)
+          expect(report.data["ruby_version_major"]).to eq(3)
+          expect(report.data["ruby_version_minor"]).to eq(1)
+          expect(report.data["ruby_version_patch"]).to eq(7)
         end
       end
     end
@@ -62,12 +62,12 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
             "#{dir}/vendor/ruby"
           )
 
-          expect(report.data["ruby.version"]).to eq("3.1.4")
-          expect(report.data["ruby.engine"]).to eq(:jruby)
-          expect(report.data["ruby.engine.version"]).to eq("9.4.9.0")
-          expect(report.data["ruby.major"]).to eq(3)
-          expect(report.data["ruby.minor"]).to eq(1)
-          expect(report.data["ruby.patch"]).to eq(4)
+          expect(report.data["ruby_version"]).to eq("ruby-3.1.4-jruby-9.4.9.0")
+          expect(report.data["ruby_version_engine"]).to eq(:jruby)
+          expect(report.data["ruby_version_engine_version"]).to eq("9.4.9.0")
+          expect(report.data["ruby_version_major"]).to eq(3)
+          expect(report.data["ruby_version_minor"]).to eq(1)
+          expect(report.data["ruby_version_patch"]).to eq(4)
         end
       end
     end

--- a/spec/helpers/heroku_ruby_installer_spec.rb
+++ b/spec/helpers/heroku_ruby_installer_spec.rb
@@ -37,12 +37,11 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
           expect(File.symlink?("#{dir}/bin/ruby.exe")).to be true
           expect(File).to exist("#{dir}/vendor/ruby/bin/ruby")
 
-          expect(report.data["ruby_version"]).to eq("ruby-3.1.7")
+          expect(report.data["ruby_version_unique"]).to eq("ruby-3.1.7")
           expect(report.data["ruby_version_engine"]).to eq(:ruby)
-          expect(report.data["ruby_version_engine_version"]).to eq(report.data["ruby_version"].split("-").last)
-          expect(report.data["ruby_version_major"]).to eq(3)
-          expect(report.data["ruby_version_minor"]).to eq(1)
-          expect(report.data["ruby_version_patch"]).to eq(7)
+          expect(report.data["ruby_version_engine_version"]).to eq("3.1.7")
+          expect(report.data["ruby_version_major_minor"]).to eq("3.1")
+          expect(report.data["ruby_version_major_minor_patch"]).to eq("3.1.7")
         end
       end
     end
@@ -62,12 +61,11 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
             "#{dir}/vendor/ruby"
           )
 
-          expect(report.data["ruby_version"]).to eq("ruby-3.1.4-jruby-9.4.9.0")
+          expect(report.data["ruby_version_unique"]).to eq("ruby-3.1.4-jruby-9.4.9.0")
           expect(report.data["ruby_version_engine"]).to eq(:jruby)
           expect(report.data["ruby_version_engine_version"]).to eq("9.4.9.0")
-          expect(report.data["ruby_version_major"]).to eq(3)
-          expect(report.data["ruby_version_minor"]).to eq(1)
-          expect(report.data["ruby_version_patch"]).to eq(4)
+          expect(report.data["ruby_version_major_minor"]).to eq("3.1")
+          expect(report.data["ruby_version_major_minor_patch"]).to eq("3.1.4")
         end
       end
     end

--- a/spec/helpers/heroku_ruby_installer_spec.rb
+++ b/spec/helpers/heroku_ruby_installer_spec.rb
@@ -10,6 +10,10 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
     )
   end
 
+  def sort_hash(hash)
+    hash.sort_by { |k, _| k.to_s }.to_h
+  end
+
   def ruby_version
     LanguagePack::RubyVersion.bundle_platform_ruby(bundler_output: "ruby-3.1.7")
   end
@@ -37,11 +41,16 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
           expect(File.symlink?("#{dir}/bin/ruby.exe")).to be true
           expect(File).to exist("#{dir}/vendor/ruby/bin/ruby")
 
-          expect(report.data["ruby_version_unique"]).to eq("ruby-3.1.7")
-          expect(report.data["ruby_version_engine"]).to eq(:ruby)
-          expect(report.data["ruby_version_engine_version"]).to eq("3.1.7")
-          expect(report.data["ruby_version_major_minor"]).to eq("3.1")
-          expect(report.data["ruby_version_major_minor_patch"]).to eq("3.1.7")
+          expected = {
+            "ruby_version_engine" => :ruby,
+            "ruby_version_engine_version" => "3.1.7",
+            "ruby_version_spec_major_minor" => "3.1",
+            "ruby_version_origin" => "Gemfile.lock",
+            "ruby_version_spec_major_minor_patch" => "3.1.7",
+            "ruby_version_unique" => "ruby-3.1.7"
+          }
+
+          expect(sort_hash(report.data)).to eq(sort_hash(expected))
         end
       end
     end
@@ -61,11 +70,16 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
             "#{dir}/vendor/ruby"
           )
 
-          expect(report.data["ruby_version_unique"]).to eq("ruby-3.1.4-jruby-9.4.9.0")
-          expect(report.data["ruby_version_engine"]).to eq(:jruby)
-          expect(report.data["ruby_version_engine_version"]).to eq("9.4.9.0")
-          expect(report.data["ruby_version_major_minor"]).to eq("3.1")
-          expect(report.data["ruby_version_major_minor_patch"]).to eq("3.1.4")
+          expected = {
+            "ruby_version_engine" => :jruby,
+            "ruby_version_engine_version" => "9.4.9.0",
+            "ruby_version_spec_major_minor" => "3.1",
+            "ruby_version_origin" => "Gemfile.lock",
+            "ruby_version_spec_major_minor_patch" => "3.1.4",
+            "ruby_version_unique" => "ruby-3.1.4-jruby-9.4.9.0"
+          }
+
+          expect(sort_hash(report.data)).to eq(sort_hash(expected))
         end
       end
     end


### PR DESCRIPTION
Previously "default" was a boolean. In the future we will add other locations such as the `.ruby-version` file.

GUS-W-19310637

Track unique version number

Both JRuby and MRI share the same `ruby.version` value. i.e. `3.4.2` to distinguish we are switching to the `version-for-download` which includes the information about the engine, this will make queries more clear whether they include jruby or not.

The prior value is moved to the "spec" version as engines such as JRuby will implement a spec such as `3.4.2`.

GUS-W-19310643