### PR TITLE
Default PUMA_PERSISTENT_TIMEOUT to match router 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Set `export PUMA_PERSISTENT_TIMEOUT=95` to match recommended router 2.0 settings (https://github.com/heroku/heroku-buildpack-ruby/pull/1641)
 
 ## [v319] - 2025-08-27
 

--- a/changelogs/puma_persistent_timeout.md
+++ b/changelogs/puma_persistent_timeout.md
@@ -1,0 +1,16 @@
+## Ruby apps now have `PUMA_PERSISTENT_TIMEOUT=95` set by default
+
+All Ruby applications now have `PUMA_PERSISTENT_TIMEOUT` environment variable set to a default value of `95`.
+
+Puma [7.0](https://github.com/puma/puma/pull/3378) introduced the ability to configure the `persistent_timeout` value via an environment variable. Router 2.0 uses an idle timeout value of 90s https://devcenter.heroku.com/articles/http-routing#keepalives. To avoid a situation where a request is sent right before Puma closes the connection, the value needs to be slightly higher than the Router's value.
+
+Applications that are not on Puma 7+ can use it manually in their `config/puma.rb` file:
+
+```ruby
+# config/puma.rb
+
+# Only required for Puma 6 and below
+persistent_timeout(ENV.fetch("PUMA_PERSISTENT_TIMEOUT") || 95)
+```
+
+Other web server users can use this as a stable interface to retrieve a suggested idle timeout setting.

--- a/lib/language_pack/rack.rb
+++ b/lib/language_pack/rack.rb
@@ -15,9 +15,10 @@ class LanguagePack::Rack < LanguagePack::Ruby
   end
 
   def default_config_vars
-    super.merge({
-      "RACK_ENV" => env("RACK_ENV") || "production"
-    })
+    out = super
+    out["RACK_ENV"] = env("RACK_ENV") || "production"
+    out["PUMA_PERSISTENT_TIMEOUT"] = env("PUMA_PERSISTENT_TIMEOUT") || "95"
+    out
   end
 
   def default_process_types

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -305,11 +305,12 @@ end
 
 describe "Rack" do
   it "should not overwrite already set environment variables" do
-    custom_env = "FFFUUUUUUU"
+    custom_env = SecureRandom.hex(16)
     app = Hatchet::Runner.new("default_ruby", config: {"RACK_ENV" => custom_env})
 
     app.deploy do |app|
-      expect(app.run("env")).to match(custom_env)
+      environment_variables = app.run("env")
+      expect(environment_variables).to match(custom_env)
     end
   end
 end

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -311,6 +311,7 @@ describe "Rack" do
     app.deploy do |app|
       environment_variables = app.run("env")
       expect(environment_variables).to match(custom_env)
+      expect(environment_variables).to match("PUMA_PERSISTENT_TIMEOUT")
     end
   end
 end


### PR DESCRIPTION
Router 2.0 introduced keepalive support. It will close connections idle after 90 seconds https://devcenter.heroku.com/articles/http-routing#keepalives. We want to avoid a situation where they send a request right before puma closes the connection. We can do that by setting it to the same timeout the router uses + some value (such as 5 seconds). 

Puma 7.0 was just released, and I helped make that value configurable via env var https://github.com/puma/puma/pull/3378. This sets the value for any puma user to do this manually, in their `config/puma.rb`, and for Puma 7+ users they will get that value by default.