### PR TITLE
Warn when app has bin/bundle binstub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Warn when app has a `bin/bundle` binstub that can cause bundler version issues ([#1728](https://github.com/heroku/heroku-buildpack-ruby/pull/1728))
 
 ## [v361] - 2026-06-11
 

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -52,6 +52,7 @@ module LanguagePack
     Ruby.remove_vendor_bundle(app_path: app_path)
     Ruby.warn_bundler_upgrade(metadata: metadata, bundler_version: bundler_version)
     Ruby.warn_bad_binstubs(app_path: app_path, warn_object: warn_io)
+    Ruby.warn_bundle_binstub(app_path: app_path, warn_object: warn_io)
     Ruby.install_ruby(
       app_path: app_path,
       ruby_version: ruby_version,

--- a/lib/language_pack/helpers/bundle_binstub_check.rb
+++ b/lib/language_pack/helpers/bundle_binstub_check.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Checks for the presence of a `bin/bundle` binstub in the app.
+#
+# When `bin/bundle` exists, bundler may remove itself during `bundle clean`
+# and then fall back to the default bundler version shipped with Ruby at
+# runtime, which can be a different major version than what the app expects.
+#
+# The fix is to remove the `bin/bundle` binstub from the app.
+#
+# See: https://github.com/heroku/heroku-buildpack-ruby/issues/1690
+# See: https://github.com/ruby/rubygems/issues/9218
+#
+# Example:
+#
+#   check = LanguagePack::Helpers::BundleBinstubCheck.new(
+#     app_root_dir: Dir.pwd,
+#     warn_object: self
+#   )
+#   check.call
+#
+class LanguagePack::Helpers::BundleBinstubCheck
+  def initialize(app_root_dir:, warn_object:)
+    @bin_bundle = Pathname.new(app_root_dir).join("bin", "bundle")
+    @warn_object = warn_object
+  end
+
+  def call
+    return false unless @bin_bundle.exist?
+
+    @warn_object.warn(warning_message, inline: true)
+    true
+  end
+
+  private
+
+  def warning_message
+    <<~WARNING
+      Your app has a `bin/bundle` binstub that may cause bundler to
+      malfunction. We recommend you remove it.
+
+      When `bin/bundle` is present, `bundle clean` may remove the
+      installed version of bundler and then your app falls back to
+      the default bundler version that ships with Ruby, which can be
+      a different major version than expected.
+
+      To fix this issue, run:
+
+      ```
+      $ rm bin/bundle
+      $ git add .
+      $ git commit -m "Remove bin/bundle binstub"
+      ```
+
+      For more information see:
+        https://github.com/heroku/heroku-buildpack-ruby/issues/1690
+    WARNING
+  end
+end

--- a/lib/language_pack/helpers/bundle_binstub_check.rb
+++ b/lib/language_pack/helpers/bundle_binstub_check.rb
@@ -26,15 +26,12 @@ class LanguagePack::Helpers::BundleBinstubCheck
   end
 
   def call
-    return false unless @bin_bundle.exist?
-
-    @warn_object.warn(warning_message, inline: true)
-    true
+    if @bin_bundle.exist?
+      @warn_object.warn(warning_message, inline: true)
+    end
   end
 
-  private
-
-  def warning_message
+  private def warning_message
     <<~WARNING
       Your app has a `bin/bundle` binstub that may cause bundler to
       malfunction. We recommend you remove it.

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -9,6 +9,7 @@ require "language_pack/helpers/nodebin"
 require "language_pack/helpers/node_installer"
 require "language_pack/helpers/yarn_installer"
 require "language_pack/helpers/binstub_check"
+require "language_pack/helpers/bundle_binstub_check"
 require "language_pack/version"
 
 # base Ruby Language Pack. This is for any base ruby app.
@@ -152,6 +153,14 @@ class LanguagePack::Ruby < LanguagePack::Base
   #
   def self.warn_bad_binstubs(app_path:, warn_object:)
     check = LanguagePack::Helpers::BinstubCheck.new(
+      warn_object: warn_object,
+      app_root_dir: app_path
+    )
+    check.call
+  end
+
+  def self.warn_bundle_binstub(app_path:, warn_object:)
+    check = LanguagePack::Helpers::BundleBinstubCheck.new(
       warn_object: warn_object,
       app_root_dir: app_path
     )

--- a/spec/helpers/bundle_binstub_check_spec.rb
+++ b/spec/helpers/bundle_binstub_check_spec.rb
@@ -1,0 +1,64 @@
+require_relative "../spec_helper"
+
+describe LanguagePack::Helpers::BundleBinstubCheck do
+  def make_warn_obj
+    warn_obj = Object.new
+    def warn_obj.warn(*args, **kwargs)
+      @msg = args.first
+    end
+
+    def warn_obj.msg
+      @msg
+    end
+
+    warn_obj
+  end
+
+  it "warns when bin/bundle exists" do
+    Dir.mktmpdir do |dir|
+      bin_dir = Pathname.new(dir).join("bin")
+      bin_dir.mkpath
+      bin_dir.join("bundle").write("#!/usr/bin/env ruby\n")
+
+      warn_obj = make_warn_obj
+      check = LanguagePack::Helpers::BundleBinstubCheck.new(
+        app_root_dir: dir,
+        warn_object: warn_obj
+      )
+
+      expect(check.call).to eq(true)
+      expect(warn_obj.msg).to include("bin/bundle")
+      expect(warn_obj.msg).to include("rm bin/bundle")
+    end
+  end
+
+  it "does not warn when bin/bundle does not exist" do
+    Dir.mktmpdir do |dir|
+      bin_dir = Pathname.new(dir).join("bin")
+      bin_dir.mkpath
+      bin_dir.join("rails").write("#!/usr/bin/env ruby\n")
+
+      warn_obj = make_warn_obj
+      check = LanguagePack::Helpers::BundleBinstubCheck.new(
+        app_root_dir: dir,
+        warn_object: warn_obj
+      )
+
+      expect(check.call).to eq(false)
+      expect(warn_obj.msg).to be_nil
+    end
+  end
+
+  it "does not warn when bin directory does not exist" do
+    Dir.mktmpdir do |dir|
+      warn_obj = make_warn_obj
+      check = LanguagePack::Helpers::BundleBinstubCheck.new(
+        app_root_dir: dir,
+        warn_object: warn_obj
+      )
+
+      expect(check.call).to eq(false)
+      expect(warn_obj.msg).to be_nil
+    end
+  end
+end

--- a/spec/helpers/bundle_binstub_check_spec.rb
+++ b/spec/helpers/bundle_binstub_check_spec.rb
@@ -25,8 +25,8 @@ describe LanguagePack::Helpers::BundleBinstubCheck do
         app_root_dir: dir,
         warn_object: warn_obj
       )
+      check.call
 
-      expect(check.call).to eq(true)
       expect(warn_obj.msg).to include("bin/bundle")
       expect(warn_obj.msg).to include("rm bin/bundle")
     end
@@ -43,8 +43,8 @@ describe LanguagePack::Helpers::BundleBinstubCheck do
         app_root_dir: dir,
         warn_object: warn_obj
       )
+      check.call
 
-      expect(check.call).to eq(false)
       expect(warn_obj.msg).to be_nil
     end
   end
@@ -56,8 +56,8 @@ describe LanguagePack::Helpers::BundleBinstubCheck do
         app_root_dir: dir,
         warn_object: warn_obj
       )
+      check.call
 
-      expect(check.call).to eq(false)
       expect(warn_obj.msg).to be_nil
     end
   end


### PR DESCRIPTION
When a `bin/bundle` binstub exists it can cause `bundle clean` to remove the installed bundler and fall back to the wrong version at runtime. This PR adds a warning suggesting people remove the file. The issue is fixed in newer rubygems versions https://github.com/ruby/rubygems/issues/9218, however, it's best to remove the file.

Rails stopped generating `bin/bundle` in March 2025 https://github.com/rails/rails/pull/54687

Closes #1690

GUS-W-21079573