### PR TITLE
Fix BUNDLE_CONFIG path

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -641,7 +641,7 @@ class LanguagePack::Ruby < LanguagePack::Base
     env_vars = {}
 
     env_vars["BUNDLE_GEMFILE"] = app_path.join("Gemfile").to_s
-    env_vars["BUNDLE_CONFIG"] = app_path.join("/.bundle/config").to_s
+    env_vars["BUNDLE_CONFIG"] = app_path.join(".bundle/config").to_s
     env_vars["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
     env_vars["BUNDLE_DISABLE_VERSION_CHECK"] = "true"
 


### PR DESCRIPTION
`Pathname#join` can have somewhat surpising behavior when passed an absolute path:

```ruby
>> Pathname.new("/home").join("/.bundle/config").to_s
=> "/.bundle/config"
>> File.join("/home", "/.bundle/config")
=> "/home/.bundle/config"
```