### PR TITLE
Replace curl silent flags with --no-progress-meter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed curl calls from `--silent` to `--no-progress-meter`. Using `curl -s` without `--show-error` silently swallows error messages when downloads fail, making failures hard to debug. Replace with `--no-progress-meter` which hides only the progress bar while still showing error messages and retry backoff status.
 
 ## [v357] - 2026-04-21
 

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -86,7 +86,7 @@ compile_buildpack_v2()
 
     if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then
       mkdir -p "$dir"
-      if curl_retry_on_18 -s --fail --show-error --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" "$url" | tar xz -C "$dir"; then
+      if curl_retry_on_18 --no-progress-meter --fail --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" "$url" | tar xz -C "$dir"; then
         :
       else
         echo "Failed to download $url"

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -51,7 +51,7 @@ fi
 
 mkdir -p "$RUBY_BOOTSTRAP_DIR"
 
-if curl_retry_on_18 --fail --show-error --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" --silent --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url"; then
+if curl_retry_on_18 --fail --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" --no-progress-meter --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url"; then
   :
 else
 cat<<EOF

--- a/bin/support/download_ruby
+++ b/bin/support/download_ruby
@@ -51,7 +51,7 @@ fi
 
 mkdir -p "$RUBY_BOOTSTRAP_DIR"
 
-if curl_retry_on_18 --fail --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" --no-progress-meter --location -o "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url"; then
+if curl_retry_on_18 --fail --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" --no-progress-meter --location --output "$RUBY_BOOTSTRAP_DIR/ruby.tgz" "$heroku_buildpack_ruby_url"; then
   :
 else
 cat<<EOF

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -27,7 +27,7 @@ module LanguagePack
     end
 
     def fetch_untar(path, files_to_extract = nil, strip_components: 0)
-      curl = curl_command("#{@host_url.join(path)} -s -o")
+      curl = curl_command("#{@host_url.join(path)} --no-progress-meter -o")
       tar_cmd = ["tar", "--strip-components=#{strip_components}", "-xzf", "- #{files_to_extract}"]
       run! "#{curl} - | #{tar_cmd.join(" ")}",
         error_class: FetchError,
@@ -35,7 +35,7 @@ module LanguagePack
     end
 
     def fetch_bunzip2(path, files_to_extract = nil)
-      curl = curl_command("#{@host_url.join(path)} -s -o")
+      curl = curl_command("#{@host_url.join(path)} --no-progress-meter -o")
       run!("#{curl} - | tar jxf - #{files_to_extract}", error_class: FetchError)
     end
 

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -15,19 +15,19 @@ module LanguagePack
     end
 
     def exists?(path, max_attempts = 1)
-      curl = curl_command("-I #{@host_url.join(path)}")
+      curl = curl_command("--head #{@host_url.join(path)}")
       run!(curl, error_class: FetchError, max_attempts: max_attempts, silent: true)
     rescue FetchError
       false
     end
 
     def fetch(path)
-      curl = curl_command("-O #{@host_url.join(path)}")
+      curl = curl_command("--remote-name #{@host_url.join(path)}")
       run!(curl, error_class: FetchError)
     end
 
     def fetch_untar(path, files_to_extract = nil, strip_components: 0)
-      curl = curl_command("#{@host_url.join(path)} --no-progress-meter -o")
+      curl = curl_command("#{@host_url.join(path)} --no-progress-meter --output")
       tar_cmd = ["tar", "--strip-components=#{strip_components}", "-xzf", "- #{files_to_extract}"]
       run! "#{curl} - | #{tar_cmd.join(" ")}",
         error_class: FetchError,
@@ -35,14 +35,14 @@ module LanguagePack
     end
 
     def fetch_bunzip2(path, files_to_extract = nil)
-      curl = curl_command("#{@host_url.join(path)} --no-progress-meter -o")
+      curl = curl_command("#{@host_url.join(path)} --no-progress-meter --output")
       run!("#{curl} - | tar jxf - #{files_to_extract}", error_class: FetchError)
     end
 
     private
 
     def curl_command(command)
-      "set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
+      "set -o pipefail; curl --location --fail --retry 5 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
     end
 
     def curl_timeout_in_seconds

--- a/lib/language_pack/helpers/plugin_installer.rb
+++ b/lib/language_pack/helpers/plugin_installer.rb
@@ -30,7 +30,7 @@ module LanguagePack
         return true if directory.exist?
         directory.mkpath
         Dir.chdir(directory) do |dir|
-          run("curl #{vendor_url}/#{name}.tgz --no-progress-meter --fail --retry 3 --retry-connrefused --connect-timeout #{curl_connect_timeout_in_seconds} -o - | tar xzf -")
+          run("curl #{vendor_url}/#{name}.tgz --no-progress-meter --fail --retry 3 --retry-connrefused --connect-timeout #{curl_connect_timeout_in_seconds} --output - | tar xzf -")
         end
       end
 

--- a/lib/language_pack/helpers/plugin_installer.rb
+++ b/lib/language_pack/helpers/plugin_installer.rb
@@ -30,7 +30,7 @@ module LanguagePack
         return true if directory.exist?
         directory.mkpath
         Dir.chdir(directory) do |dir|
-          run("curl #{vendor_url}/#{name}.tgz -s --fail --retry 3 --retry-connrefused --connect-timeout #{curl_connect_timeout_in_seconds} -o - | tar xzf -")
+          run("curl #{vendor_url}/#{name}.tgz --no-progress-meter --fail --retry 3 --retry-connrefused --connect-timeout #{curl_connect_timeout_in_seconds} -o - | tar xzf -")
         end
       end
 


### PR DESCRIPTION
Using `curl -s` without `--show-error` silently swallows error messages when downloads fail, making failures hard to debug. Replace with `--no-progress-meter` which hides only the progress bar while still showing error messages and retry backoff status.

GUS-W-22509988