### PR TITLE
Capture `.ruby-version` differences with `Gemfile.lock` 

### DIFF
--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -35,10 +35,18 @@ module LanguagePack
     metadata = LanguagePack::Metadata.new(cache_path: cache_path)
     new_app = metadata.empty?
 
+    dot_ruby_version_path = app_path.join(".ruby-version")
+    dot_ruby_version_result = if dot_ruby_version_path.exist?
+      LanguagePack::Helpers::DotRubyVersionFile.new(
+        contents: dot_ruby_version_path.read
+      ).call
+    end
+
     ruby_version = Ruby.get_ruby_version(
       report: HerokuBuildReport::GLOBAL,
       metadata: metadata,
-      gemfile_lock: gemfile_lock
+      gemfile_lock: gemfile_lock,
+      dot_ruby_version_result: dot_ruby_version_result
     )
 
     Ruby.remove_vendor_bundle(app_path: app_path)

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -45,7 +45,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
     dot_ruby_version_file = @gemfile_lock_path.join("..").join(".ruby-version")
     @report.capture(
-      "ruby.dot_ruby_version" => dot_ruby_version_file.exist? ? dot_ruby_version_file.read&.strip : nil
+      "dot_ruby_version.contents" => dot_ruby_version_file.exist? ? dot_ruby_version_file.read&.strip : nil
     )
     @version = bundler_version
     parts = @version.split(".")

--- a/lib/language_pack/helpers/dot_ruby_version_file.rb
+++ b/lib/language_pack/helpers/dot_ruby_version_file.rb
@@ -92,7 +92,7 @@ module LanguagePack
           warnings << <<~EOF
             Cannot parse Ruby version from `.ruby-version` file.
 
-            Only full version specifiers with major, minor, and patch are supported
+            Only full Ruby versions with major, minor, and patch are supported
             such as `3.4.8` or `ruby-3.4.8`. Got:
 
             ```

--- a/lib/language_pack/helpers/dot_ruby_version_file.rb
+++ b/lib/language_pack/helpers/dot_ruby_version_file.rb
@@ -15,7 +15,7 @@ module LanguagePack
     class DotRubyVersionFile
       VERSION_PATTERN = /\A(?<version>\d+\.\d+\.\d+)(?:[.-](?<pre>\S+))?\z/
       JRUBY_PATTERN = /\Ajruby-/i
-      SPECIFIER_PATTERN = />=|<=|~>|>|</
+      SPECIFIER_PATTERN = /(>=|<=|~>|>|<)/
 
       Result = Data.define(:ruby_version, :warnings)
 
@@ -62,9 +62,10 @@ module LanguagePack
           EOF
         end
 
-        if version_string.match?(SPECIFIER_PATTERN)
+        if (match = version_string.match(SPECIFIER_PATTERN))
+          specifier = match[1]
           warnings << <<~EOF
-            Cannot parse version specifiers in `.ruby-version` file.
+            Cannot parse `.ruby-version` file, version specifiers (`#{specifier}`) are not supported.
 
             Only exact versions are supported such as `3.4.8` or `ruby-3.4.8`.
             Got:

--- a/lib/language_pack/helpers/dot_ruby_version_file.rb
+++ b/lib/language_pack/helpers/dot_ruby_version_file.rb
@@ -15,7 +15,7 @@ module LanguagePack
     class DotRubyVersionFile
       VERSION_PATTERN = /\A(?<version>\d+\.\d+\.\d+)(?:[.-](?<pre>\S+))?\z/
       JRUBY_PATTERN = /\Ajruby-/i
-      SPECIFIER_PATTERN = /(>=|<=|~>|>|<)/
+      SPECIFIER_PATTERN = /((>|<|~|=)+)/
 
       Result = Data.define(:ruby_version, :warnings)
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -216,11 +216,11 @@ class LanguagePack::Ruby < LanguagePack::Base
     )
 
     if dot_ruby_version_result&.ruby_version
-      report.capture("ruby.dot_ruby_version.version" => dot_ruby_version_result.ruby_version.ruby_version)
+      report.capture("dot_ruby_version.version" => dot_ruby_version_result.ruby_version.ruby_version)
 
       if !lockfile_ruby_version.default?
         report.capture(
-          "ruby.dot_ruby_version.vs_gemfile_lock" =>
+          "dot_ruby_version.vs_gemfile_lock" =>
             case Gem::Version.new(dot_ruby_version_result.ruby_version.ruby_version) <=> Gem::Version.new(lockfile_ruby_version.ruby_version)
             when 0 then "match"
             when 1 then "dot_ruby_version_higher"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -200,7 +200,7 @@ class LanguagePack::Ruby < LanguagePack::Base
     @ruby_version or raise "Internal error: @ruby_version is not set. Call `get_ruby_version` and set @ruby_version"
   end
 
-  def self.get_ruby_version(metadata:, gemfile_lock:, report: HerokuBuildReport::GLOBAL)
+  def self.get_ruby_version(metadata:, gemfile_lock:, dot_ruby_version_result: nil, report: HerokuBuildReport::GLOBAL)
     lockfile_ruby_version = LanguagePack::RubyVersion.from_gemfile_lock(
       ruby: gemfile_lock.ruby,
       last_version: metadata.try_read("buildpack_ruby_version")
@@ -214,6 +214,23 @@ class LanguagePack::Ruby < LanguagePack::Base
       "gemfile_lock.ruby_version.patch" => lockfile_ruby_version.patch,
       "gemfile_lock.ruby_version.default" => lockfile_ruby_version.default?
     )
+
+    if dot_ruby_version_result&.ruby_version
+      report.capture("ruby.dot_ruby_version.version" => dot_ruby_version_result.ruby_version.ruby_version)
+
+      unless lockfile_ruby_version.default?
+        dot_v = Gem::Version.new(dot_ruby_version_result.ruby_version.ruby_version)
+        lock_v = Gem::Version.new(lockfile_ruby_version.ruby_version)
+        comparison = if dot_v == lock_v
+          "match"
+        elsif dot_v > lock_v
+          "dot_ruby_version_higher"
+        else
+          "gemfile_lock_higher"
+        end
+        report.capture("ruby.dot_ruby_version.vs_gemfile_lock" => comparison)
+      end
+    end
 
     lockfile_ruby_version
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -218,17 +218,15 @@ class LanguagePack::Ruby < LanguagePack::Base
     if dot_ruby_version_result&.ruby_version
       report.capture("ruby.dot_ruby_version.version" => dot_ruby_version_result.ruby_version.ruby_version)
 
-      unless lockfile_ruby_version.default?
-        dot_v = Gem::Version.new(dot_ruby_version_result.ruby_version.ruby_version)
-        lock_v = Gem::Version.new(lockfile_ruby_version.ruby_version)
-        comparison = if dot_v == lock_v
-          "match"
-        elsif dot_v > lock_v
-          "dot_ruby_version_higher"
-        else
-          "gemfile_lock_higher"
-        end
-        report.capture("ruby.dot_ruby_version.vs_gemfile_lock" => comparison)
+      if !lockfile_ruby_version.default?
+        report.capture(
+          "ruby.dot_ruby_version.vs_gemfile_lock" =>
+            case Gem::Version.new(dot_ruby_version_result.ruby_version.ruby_version) <=> Gem::Version.new(lockfile_ruby_version.ruby_version)
+            when 0 then "match"
+            when 1 then "dot_ruby_version_higher"
+            when -1 then "gemfile_lock_higher"
+            end
+        )
       end
     end
 

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -157,6 +157,8 @@ describe "Ruby apps" do
             end
           EOF
 
+          Pathname(".ruby-version").write("3.3.1")
+
           dir = Pathname("client")
           dir.mkpath
           FileUtils.touch(dir.join(".gitkeep"))
@@ -200,6 +202,8 @@ describe "Ruby apps" do
             yaml = report_match[:yaml].gsub("remote: ", "")
             report = YAML.load(yaml)
             expect(report.fetch("ruby_version_full")).to eq(expected)
+            expect(report.fetch("ruby.dot_ruby_version.version")).to eq(expected)
+            expect(report.fetch("ruby.dot_ruby_version.vs_gemfile_lock")).to eq("match")
           rescue Exception => e # standard:disable Lint/RescueException
             puts app.output
             puts yaml if yaml

--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -202,8 +202,8 @@ describe "Ruby apps" do
             yaml = report_match[:yaml].gsub("remote: ", "")
             report = YAML.load(yaml)
             expect(report.fetch("ruby_version_full")).to eq(expected)
-            expect(report.fetch("ruby.dot_ruby_version.version")).to eq(expected)
-            expect(report.fetch("ruby.dot_ruby_version.vs_gemfile_lock")).to eq("match")
+            expect(report.fetch("dot_ruby_version.version")).to eq(expected)
+            expect(report.fetch("dot_ruby_version.vs_gemfile_lock")).to eq("match")
           rescue Exception => e # standard:disable Lint/RescueException
             puts app.output
             puts yaml if yaml

--- a/spec/helpers/bundler_wrapper_spec.rb
+++ b/spec/helpers/bundler_wrapper_spec.rb
@@ -14,7 +14,7 @@ describe "Multiple platform detection" do
       )
       expect(report.data).to eq(
         {
-          "ruby.dot_ruby_version" => nil,
+          "dot_ruby_version.contents" => nil,
           "bundler.major" => "2",
           "bundler.minor" => "5",
           "bundler.patch" => "7",

--- a/spec/helpers/dot_ruby_version_file_spec.rb
+++ b/spec/helpers/dot_ruby_version_file_spec.rb
@@ -155,6 +155,27 @@ describe "DotRubyVersionFile" do
     expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`>=`) are not supported.")
   end
 
+  it "warns for > specifier" do
+    result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "> 3.1.6").call
+    expect(result.ruby_version).to be_nil
+    expect(result.warnings.length).to eq(1)
+    expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`>`) are not supported.")
+  end
+
+  it "warns for < specifier" do
+    result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "< 3.1.6").call
+    expect(result.ruby_version).to be_nil
+    expect(result.warnings.length).to eq(1)
+    expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`<`) are not supported.")
+  end
+
+  it "warns for = specifier" do
+    result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "=3.1.6").call
+    expect(result.ruby_version).to be_nil
+    expect(result.warnings.length).to eq(1)
+    expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`=`) are not supported.")
+  end
+
   it "warns for garbage input" do
     result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "not-a-version").call
     expect(result.ruby_version).to be_nil

--- a/spec/helpers/dot_ruby_version_file_spec.rb
+++ b/spec/helpers/dot_ruby_version_file_spec.rb
@@ -138,21 +138,21 @@ describe "DotRubyVersionFile" do
     result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "ruby >= 3.1.6, < 3.3").call
     expect(result.ruby_version).to be_nil
     expect(result.warnings.length).to eq(1)
-    expect(result.warnings.first).to include("Only exact versions are supported")
+    expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`>=`) are not supported.")
   end
 
   it "warns for ~> specifier" do
     result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "~> 3.1").call
     expect(result.ruby_version).to be_nil
     expect(result.warnings.length).to eq(1)
-    expect(result.warnings.first).to include("Only exact versions are supported")
+    expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`~>`) are not supported.")
   end
 
   it "warns for >= specifier" do
     result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: ">= 3.1.6").call
     expect(result.ruby_version).to be_nil
     expect(result.warnings.length).to eq(1)
-    expect(result.warnings.first).to include("Only exact versions are supported")
+    expect(result.warnings.first).to include("Cannot parse `.ruby-version` file, version specifiers (`>=`) are not supported.")
   end
 
   it "warns for garbage input" do

--- a/spec/helpers/dot_ruby_version_file_spec.rb
+++ b/spec/helpers/dot_ruby_version_file_spec.rb
@@ -166,7 +166,7 @@ describe "DotRubyVersionFile" do
     result = LanguagePack::Helpers::DotRubyVersionFile.new(contents: "3.4").call
     expect(result.ruby_version).to be_nil
     expect(result.warnings.length).to eq(1)
-    expect(result.warnings.first).to include("Only full version specifiers with major, minor, and patch are supported")
+    expect(result.warnings.first).to include("Only full Ruby versions with major, minor, and patch are supported")
   end
 
   it "does not crash on bare ruby- prefix" do

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -237,8 +237,8 @@ describe "get_ruby_version .ruby-version comparison" do
   it "sets no comparison keys when .ruby-version is absent" do
     report = get_ruby_version(gemfile_lock: gemfile_lock_with_ruby("3.4.2"))
 
-    expect(report.data).not_to have_key("ruby.dot_ruby_version.version")
-    expect(report.data).not_to have_key("ruby.dot_ruby_version.vs_gemfile_lock")
+    expect(report.data).not_to have_key("dot_ruby_version.version")
+    expect(report.data).not_to have_key("dot_ruby_version.vs_gemfile_lock")
   end
 
   it "sets no comparison keys when .ruby-version is unparseable" do
@@ -249,8 +249,8 @@ describe "get_ruby_version .ruby-version comparison" do
     )
 
     expect(result.ruby_version).to be_nil
-    expect(report.data).not_to have_key("ruby.dot_ruby_version.version")
-    expect(report.data).not_to have_key("ruby.dot_ruby_version.vs_gemfile_lock")
+    expect(report.data).not_to have_key("dot_ruby_version.version")
+    expect(report.data).not_to have_key("dot_ruby_version.vs_gemfile_lock")
   end
 
   it "reports match when versions are equal" do
@@ -259,8 +259,8 @@ describe "get_ruby_version .ruby-version comparison" do
       dot_ruby_version_result: dot_ruby_version_result("3.4.2")
     )
 
-    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.4.2")
-    expect(report.data["ruby.dot_ruby_version.vs_gemfile_lock"]).to eq("match")
+    expect(report.data["dot_ruby_version.version"]).to eq("3.4.2")
+    expect(report.data["dot_ruby_version.vs_gemfile_lock"]).to eq("match")
   end
 
   it "reports dot_ruby_version_higher when .ruby-version is newer" do
@@ -269,8 +269,8 @@ describe "get_ruby_version .ruby-version comparison" do
       dot_ruby_version_result: dot_ruby_version_result("3.5.0")
     )
 
-    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.5.0")
-    expect(report.data["ruby.dot_ruby_version.vs_gemfile_lock"]).to eq("dot_ruby_version_higher")
+    expect(report.data["dot_ruby_version.version"]).to eq("3.5.0")
+    expect(report.data["dot_ruby_version.vs_gemfile_lock"]).to eq("dot_ruby_version_higher")
   end
 
   it "reports gemfile_lock_higher when Gemfile.lock is newer" do
@@ -279,8 +279,8 @@ describe "get_ruby_version .ruby-version comparison" do
       dot_ruby_version_result: dot_ruby_version_result("3.3.0")
     )
 
-    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.3.0")
-    expect(report.data["ruby.dot_ruby_version.vs_gemfile_lock"]).to eq("gemfile_lock_higher")
+    expect(report.data["dot_ruby_version.version"]).to eq("3.3.0")
+    expect(report.data["dot_ruby_version.vs_gemfile_lock"]).to eq("gemfile_lock_higher")
   end
 
   it "sets version but skips comparison when Gemfile.lock has no ruby version" do
@@ -289,7 +289,7 @@ describe "get_ruby_version .ruby-version comparison" do
       dot_ruby_version_result: dot_ruby_version_result("3.4.2")
     )
 
-    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.4.2")
-    expect(report.data).not_to have_key("ruby.dot_ruby_version.vs_gemfile_lock")
+    expect(report.data["dot_ruby_version.version"]).to eq("3.4.2")
+    expect(report.data).not_to have_key("dot_ruby_version.vs_gemfile_lock")
   end
 end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -192,3 +192,104 @@ describe "RubyVersion" do
     end
   end
 end
+
+describe "get_ruby_version .ruby-version comparison" do
+  def gemfile_lock_with_ruby(version)
+    LanguagePack::Helpers::GemfileLock.new(
+      report: HerokuBuildReport.dev_null,
+      contents: <<~EOF
+        RUBY VERSION
+           ruby #{version}
+        BUNDLED WITH
+           2.5.23
+      EOF
+    )
+  end
+
+  def gemfile_lock_default
+    LanguagePack::Helpers::GemfileLock.new(
+      report: HerokuBuildReport.dev_null,
+      contents: <<~EOF
+        BUNDLED WITH
+           2.5.23
+      EOF
+    )
+  end
+
+  def dot_ruby_version_result(version)
+    LanguagePack::Helpers::DotRubyVersionFile.new(contents: version).call
+  end
+
+  def get_ruby_version(gemfile_lock:, dot_ruby_version_result: nil)
+    report = HerokuBuildReport.dev_null
+    Dir.mktmpdir do |dir|
+      metadata = LanguagePack::Metadata.new(cache_path: dir)
+      LanguagePack::Ruby.get_ruby_version(
+        metadata: metadata,
+        gemfile_lock: gemfile_lock,
+        dot_ruby_version_result: dot_ruby_version_result,
+        report: report
+      )
+    end
+    report
+  end
+
+  it "sets no comparison keys when .ruby-version is absent" do
+    report = get_ruby_version(gemfile_lock: gemfile_lock_with_ruby("3.4.2"))
+
+    expect(report.data).not_to have_key("ruby.dot_ruby_version.version")
+    expect(report.data).not_to have_key("ruby.dot_ruby_version.vs_gemfile_lock")
+  end
+
+  it "sets no comparison keys when .ruby-version is unparseable" do
+    result = dot_ruby_version_result("not-a-version")
+    report = get_ruby_version(
+      gemfile_lock: gemfile_lock_with_ruby("3.4.2"),
+      dot_ruby_version_result: result
+    )
+
+    expect(result.ruby_version).to be_nil
+    expect(report.data).not_to have_key("ruby.dot_ruby_version.version")
+    expect(report.data).not_to have_key("ruby.dot_ruby_version.vs_gemfile_lock")
+  end
+
+  it "reports match when versions are equal" do
+    report = get_ruby_version(
+      gemfile_lock: gemfile_lock_with_ruby("3.4.2"),
+      dot_ruby_version_result: dot_ruby_version_result("3.4.2")
+    )
+
+    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.4.2")
+    expect(report.data["ruby.dot_ruby_version.vs_gemfile_lock"]).to eq("match")
+  end
+
+  it "reports dot_ruby_version_higher when .ruby-version is newer" do
+    report = get_ruby_version(
+      gemfile_lock: gemfile_lock_with_ruby("3.4.2"),
+      dot_ruby_version_result: dot_ruby_version_result("3.5.0")
+    )
+
+    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.5.0")
+    expect(report.data["ruby.dot_ruby_version.vs_gemfile_lock"]).to eq("dot_ruby_version_higher")
+  end
+
+  it "reports gemfile_lock_higher when Gemfile.lock is newer" do
+    report = get_ruby_version(
+      gemfile_lock: gemfile_lock_with_ruby("3.4.2"),
+      dot_ruby_version_result: dot_ruby_version_result("3.3.0")
+    )
+
+    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.3.0")
+    expect(report.data["ruby.dot_ruby_version.vs_gemfile_lock"]).to eq("gemfile_lock_higher")
+  end
+
+  it "sets version but skips comparison when Gemfile.lock has no ruby version" do
+    report = get_ruby_version(
+      gemfile_lock: gemfile_lock_default,
+      dot_ruby_version_result: dot_ruby_version_result("3.4.2")
+    )
+
+    expect(report.data["ruby.dot_ruby_version.version"]).to eq("3.4.2")
+    expect(report.data).not_to have_key("ruby.dot_ruby_version.vs_gemfile_lock")
+  end
+end


### PR DESCRIPTION
To roll out support for `.ruby-version` files, I need to determine what to do when there's a conflict (i.e. both `Gemfile.lock` and `.ruby-version` have valid contents, but they disagree). To inform that decision, we can parse the and compare the two files and send the values to honeycomb to query.

The primary questions (and corresponding queries) look like this:

- **How many apps have .ruby-version but no version in Gemfile.lock?** `WHERE dot_ruby_version.version EXISTS AND gemfile_lock.ruby_version.default = true`
- **How many apps have .ruby-version that matches Gemfile.lock?** `WHERE dot_ruby_version.vs_gemfile_lock = "match"`
- **How many differ?** `WHERE dot_ruby_version.vs_gemfile_lock != "match" AND dot_ruby_version.vs_gemfile_lock EXISTS`
- **When they disagree, which file has the higher version?** `GROUP BY dot_ruby_version.vs_gemfile_lock, COUNT` filtered to `WHERE dot_ruby_version.vs_gemfile_lock != "match"`

GUS-W-22244654