### PR TITLE
Fix test assertion

### DIFF
--- a/spec/hatchet/ruby_spec.rb
+++ b/spec/hatchet/ruby_spec.rb
@@ -59,7 +59,11 @@ describe "Ruby apps" do
         end
         app.deploy do
           expect(app.output).to match("custom rake binstub called")
-          expect(app.run("rake")).to match("custom rake binstub called")
+          # Using `bash -c rake` here to bypass heroku process type detection because
+          # rake = "bundle exec rake" is a process type. This test was previously
+          # relying on a bug in the CLI that was fixed in https://github.com/heroku/cli/pull/3804.
+          # The goal is to test PATH resolution at build/runtime.
+          expect(app.run("bash -c rake")).to match("custom rake binstub called")
         end
       end
     end


### PR DESCRIPTION
This test was added to assert the order of PATH, and the `rake` executable. An implementation detail is that it uses `heroku run` in the background as well as the `--exit-code` flag.

The Heroku CLI changed in 11.8.1 for users of `--exit-code`:

```
$ npm_config_min_release_age=0 npx -y heroku@11.8.0 run --app "$APP" --exit-code -- console
Running console on ⬢ fast-plains-61981... up, run.3560
/bin/bash: line 1: console: command not found

 ›   Error: Process exited with code 127

$ npm_config_min_release_age=0 npx -y heroku@11.8.1 run --app "$APP" --exit-code -- console
Running console on ⬢ fast-plains-61981... up, run.1524
irb(main):001>
```

This resolves the behavior to match what a user would expect when they're NOT using `--exit-code`. The behavior you're seeing above is:

There's a shortcut so when `heroku run console` is used, it checks to see if a `console` process type exists and runs that if it does. https://github.com/heroku/cli/pull/3804 changed fixed the behavior to mirror `heroku run` (without `--exit-code`). Which broke the test.

Since `heroku run` is an implementation detail, we can bypass it using `bash -c`.