### PR TITLE
Download Yarn from npm registry instead of heroku-nodebin S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Yarn is now downloaded from the npm registry instead of the `heroku-nodebin` S3 bucket ([#1761](https://github.com/heroku/heroku-buildpack-ruby/pull/1761))
 - Warn when app has a `bin/bundle` binstub that can cause bundler version issues ([#1728](https://github.com/heroku/heroku-buildpack-ruby/pull/1728))
 
 ## [v361] - 2026-06-11

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -15,7 +15,7 @@ class LanguagePack::Helpers::Nodebin
   def self.hardcoded_yarn
     {
       "number" => YARN_VERSION,
-      "url" => "https://heroku-nodebin.s3.dualstack.us-east-1.amazonaws.com/yarn/release/yarn-v#{YARN_VERSION}.tar.gz"
+      "url" => "https://registry.npmjs.org/yarn/-/yarn-#{YARN_VERSION}.tgz"
     }
   end
 

--- a/spec/helpers/nodebin_spec.rb
+++ b/spec/helpers/nodebin_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe LanguagePack::Helpers::Nodebin do
+  describe ".yarn" do
+    it "downloads Yarn from the npm registry (not the heroku-nodebin S3 bucket)" do
+      url = LanguagePack::Helpers::Nodebin.yarn["url"]
+
+      expect(url).to include("registry.npmjs.org")
+      expect(url).to_not include("heroku-nodebin")
+      expect(url).to eq("https://registry.npmjs.org/yarn/-/yarn-#{LanguagePack::Helpers::Nodebin::YARN_VERSION}.tgz")
+    end
+  end
+end


### PR DESCRIPTION
The `heroku-nodebin` S3 bucket is being sunset, so point the Yarn download at the public npm registry tarball instead (`https://registry.npmjs.org/yarn/-/yarn-<version>.tgz`).

The npm tarball is structurally identical to the S3 one (both extract to `package/` with the same `bin/yarn` and `bin/yarnpkg`), so the existing `Fetcher#fetch_untar` + `strip_components: 1` install path and the resulting on-disk layout are unchanged. Only the URL string changes; note npm's filename convention has no `v` prefix and uses `.tgz`.

Add a unit spec guarding that `Nodebin.yarn` points at `registry.npmjs.org` so it can't silently regress back to the S3 bucket.

W-21368290
