### PR TITLE
Enable Dependabot updates for transitive dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     open-pull-requests-limit: 1 # Limit concurrent CI runs from executing, do not remove
     schedule:
       interval: "monthly"
+    allow:
+      # Update transitive dependencies too.
+      - dependency-type: "all"
     labels:
       - "dependencies"
       - "ruby"


### PR DESCRIPTION
Configure Dependabot's `allow` key with `dependency-type: all` so it also updates transitive dependencies (those only in the lockfile), not just direct dependencies. This removes the need to manually refresh lockfiles.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#allow--

GUS-W-24099599.