### PR TITLE
Fix typos in comments, docs, and user-facing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed typos in code comments, YARD docs, and user-facing warning and error messages (no behavior change)
 
 ## [v362] - 2026-08-25
 

--- a/lib/language_pack/helpers/outdated_ruby_version.rb
+++ b/lib/language_pack/helpers/outdated_ruby_version.rb
@@ -53,7 +53,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
   def join
     return unless can_check?
     return true if @already_joined
-    raise "Must initalize threads with `call()` before joining" if @minor_version_threads.empty?
+    raise "Must initialize threads with `call()` before joining" if @minor_version_threads.empty?
 
     @eol_versions = @eol_version_threads.map(&:value).compact
     @minor_versions = @minor_version_threads.map(&:value).compact
@@ -103,14 +103,14 @@ class LanguagePack::Helpers::OutdatedRubyVersion
 
   # Checks for a range of "tiny" versions in parallel
   #
-  # For example if 2.5.0 is given it will check for the existance of
+  # For example if 2.5.0 is given it will check for the existence of
   # - 2.5.1
   # - 2.5.2
   # - 2.5.3
   # - 2.5.4
   # - 2.5.5
   #
-  # If the last elment in the series exists, it will continue to
+  # If the last element in the series exists, it will continue to
   # search by enqueuing additional numbers until the final
   # value in the series is found
   private def check_minor_versions(range: DEFAULT_RANGE, base_version: current_ruby_version, &block)
@@ -133,7 +133,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
 
   # Checks to see if 3 minor versions exist above current version
   #
-  # for example 2.4.0 would check for existance of:
+  # for example 2.4.0 would check for existence of:
   #   - 2.5.0
   #   - 2.6.0
   #   - 2.7.0
@@ -160,7 +160,7 @@ class LanguagePack::Helpers::OutdatedRubyVersion
   # Checks to see if one major version exists above current version
   # if it does, then it will check for minor versions of that version
   #
-  # For checking 2.5. it would check for the existance of 3.0.0
+  # For checking 2.5. it would check for the existence of 3.0.0
   #
   # If 3.0.0 exists then it will check for:
   #   - 3.1.0

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -77,7 +77,7 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
         You set your `config.assets.compile = true` in production.
         This can negatively impact the performance of your application.
 
-        For more information can be found in this article:
+        More information can be found in this article:
           https://devcenter.heroku.com/articles/rails-asset-pipeline#compile-set-to-true-in-production
 
       WARNING

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -6,7 +6,7 @@ module LanguagePack
       def initialize(output = "")
         msg = ""
         msg << output
-        msg << "Can not parse Ruby Version:\n"
+        msg << "Cannot parse Ruby Version:\n"
         msg << "Valid versions listed on: https://devcenter.heroku.com/articles/ruby-support\n"
         super(msg)
       end

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -65,7 +65,7 @@ module LanguagePack
     # run a shell command (deferring to #run), and raise an error if it fails
     # @param [String] command to be run
     # @return [String] result of #run
-    # @option options [Error] :error_class Class of error to raise, defaults to Standard Error
+    # @option options [Error] :error_class Class of error to raise, defaults to StandardError
     # @option options [Integer] :max_attempts Number of times to attempt command before raising
     def run!(command, options = {})
       max_attempts = options[:max_attempts] || 1

--- a/lib/rake/deploy_check.rb
+++ b/lib/rake/deploy_check.rb
@@ -42,7 +42,7 @@ class DeployCheck
     EOM
   end
 
-  # Returns tuthy value if the remote contains the next version already
+  # Returns truthy value if the remote contains the next version already
   def tag_exists_on_remote?
     remote_tag_array.include?(next_version)
   end
@@ -78,7 +78,7 @@ class DeployCheck
 
     raise <<~EOM
       Must be in-sync with #{@github}. Local commit: #{local_sha.inspect} #{@github}: #{remote_sha.inspect}
-      "Make sure that you've pulled: `git pull --rebase #{@github_url} main`
+      Make sure that you've pulled: `git pull --rebase #{@github_url} main`
     EOM
   end
 


### PR DESCRIPTION
## Summary

Fix 10 typos across 5 files. Mostly comments and YARD docs; four are in strings that reach a user.

### Comments and YARD docs (no runtime effect)

- **lib/language_pack/helpers/outdated_ruby_version.rb**: `existance of` -> `existence of` (3 occurrences, lines 106, 136, 163)
- **lib/language_pack/helpers/outdated_ruby_version.rb**: `the last elment in the series` -> `element`
- **lib/rake/deploy_check.rb**: `# Returns tuthy value` -> `truthy` (the sibling method's comment four lines below already reads "Returns a truthy value")
- **lib/language_pack/shell_helpers.rb**: `@option options [Error] :error_class ... defaults to Standard Error` -> `StandardError` (the code on the next line literally does `options[:error_class] || StandardError`)

### Message strings (text-only; please sanity-check these four)

- **lib/language_pack/rails3.rb**: build warning read `For more information can be found in this article:`, which conflates "For more information, see" with "More information can be found". Now `More information can be found in this article:`.
- **lib/language_pack/ruby_version.rb**: `BadVersionError` message `Can not parse Ruby Version:` -> `Cannot parse Ruby Version:`.
- **lib/language_pack/helpers/outdated_ruby_version.rb**: internal `raise` message `Must initalize threads with \`call()\` before joining` -> `initialize`.
- **lib/rake/deploy_check.rb**: `check_sync!` raises a `<<~EOM` heredoc whose second line begins with a stray, unmatched `"`, left over from when this was a double-quoted string. Inside a heredoc it is just a literal character, so the released error message renders as `"Make sure that you've pulled: ...`. Removed the stray quote.

I grepped `lib/`, `bin/` and `spec/` for every string touched here: none of them appear in any test assertion, so no spec changes were needed. `ruby -c` passes on all five files.

A CHANGELOG.md entry is included under `## [Unreleased]` so the `check-changelog` job passes; happy to drop it and take the `skip changelog` label instead if you would rather not spend a changelog line on this.

No identifiers renamed, no behavior changes.